### PR TITLE
Rename sim headers and properties

### DIFF
--- a/generator-service/src/main/java/com/example/generator/Generator.java
+++ b/generator-service/src/main/java/com/example/generator/Generator.java
@@ -34,7 +34,7 @@ public class Generator {
     try{ sendStatusFull(0); } catch(Exception ignore){}
   }
 
-  @Value("${sim.gen.ratePerSec:5}")
+  @Value("${ph.gen.ratePerSec:5}")
   private int ratePerSec;
 
   @Scheduled(fixedRate = 1000)
@@ -57,7 +57,7 @@ public class Generator {
           .setContentType(MessageProperties.CONTENT_TYPE_JSON) // application/json
           .setContentEncoding(StandardCharsets.UTF_8.name())
           .setMessageId(id)
-          .setHeader("x-sim-service", "generator")
+          .setHeader("x-ph-service", "generator")
           .build();
 
       rabbit.convertAndSend(Topology.EXCHANGE, Topology.GEN_QUEUE, msg);

--- a/moderator-service/src/main/java/com/example/moderator/Moderator.java
+++ b/moderator-service/src/main/java/com/example/moderator/Moderator.java
@@ -30,7 +30,8 @@ public class Moderator {
 
   // Consume RAW AMQP message to avoid converter issues
   @RabbitListener(queues = "${ph.genQueue:gen.queue}")
-  public void onGenerated(Message message) {
+  public void onGenerated(Message message,
+                          @Header(value = "x-ph-service", required = false) String service) {
     // forward the same message to the moderated queue (preserve body + props)
     rabbit.send(Topology.EXCHANGE, Topology.MOD_QUEUE, message);
     counter.incrementAndGet();

--- a/processor-service/src/main/java/com/example/processor/Processor.java
+++ b/processor-service/src/main/java/com/example/processor/Processor.java
@@ -25,7 +25,8 @@ public class Processor {
   public Processor(RabbitTemplate rabbit){ this.rabbit = rabbit; try{ sendStatusFull(0); } catch(Exception ignore){} }
 
   @RabbitListener(queues = "${ph.modQueue:moderated.queue}")
-  public void onModerated(byte[] payload){
+  public void onModerated(byte[] payload,
+                          @Header(value = "x-ph-service", required = false) String service){
     // MVP: pretend to process
     counter.incrementAndGet();
   }


### PR DESCRIPTION
## Summary
- rename `sim.gen.ratePerSec` property to `ph.gen.ratePerSec`
- switch message header `x-sim-service` to `x-ph-service`
- update moderator and processor listeners to accept the new header

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e5b9992c8328ad77789222ffc91a