### PR TITLE
Add Prometheus and Grafana monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ See also: Control Bindings page (Menu → Control Bindings) and `ui/spec/asyncap
 
 - `rabbitmq` (with Web-STOMP): 5672 (AMQP), 15672 (Mgmt UI), 15674 (Web-STOMP, internal only)
 - `ui` (nginx static site): 8088 → serves UI, proxies WebSocket at `/ws` to RabbitMQ
-- `generator`, `moderator`, `processor`: Spring Boot services using AMQP
+- `generator`, `moderator`, `processor`, `postprocessor`: Spring Boot services using AMQP
+- `prometheus` (metrics store): 9090
+- `grafana` (dashboard): 3000 (admin / admin)
 
 ## Quick Start
 
@@ -72,6 +74,12 @@ docker compose up -d --build
 
 - http://localhost:15672 (guest / guest)
 - Web-STOMP plugin is enabled in the RabbitMQ image.
+
+4) Metrics and Dashboards (optional)
+
+- Prometheus: http://localhost:9090
+- Grafana: http://localhost:3000 (admin / admin)
+- Prometheus scrapes metrics from `postprocessor` at `/actuator/prometheus`.
 
 ## WebSocket Proxy (UI ←→ RabbitMQ)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,3 +83,25 @@ services:
       timeout: 5s
       retries: 6
       start_period: 5s
+
+  prometheus:
+    image: prom/prometheus
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"
+    depends_on:
+      - postprocessor
+
+  grafana:
+    image: grafana/grafana
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus

--- a/grafana/dashboards/pockethive.json
+++ b/grafana/dashboards/pockethive.json
@@ -1,0 +1,22 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Postprocessor Heap Memory",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "jvm_memory_used_bytes{area=\"heap\",job=\"postprocessor\"}"
+        }
+      ],
+      "lines": true,
+      "id": 1
+    }
+  ],
+  "schemaVersion": 27,
+  "title": "PocketHive",
+  "version": 1
+}

--- a/grafana/provisioning/dashboards/dashboard.yml
+++ b/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+providers:
+  - name: 'PocketHive'
+    orgId: 1
+    folder: ''
+    type: file
+    options:
+      path: /var/lib/grafana/dashboards

--- a/grafana/provisioning/datasources/datasource.yml
+++ b/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+  - job_name: 'postprocessor'
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['postprocessor:8080']


### PR DESCRIPTION
## Summary
- add Prometheus service and configuration to scrape the postprocessor's `/actuator/prometheus` endpoint
- add Grafana service with pre-provisioned Prometheus datasource and basic dashboard
- document metrics endpoints and default credentials in the README

## Testing
- `mvn -q -pl postprocessor-service test` *(fails: Non-resolvable import POM due to network restrictions)*
- `docker compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2eface7488328b32edd937ba34d30