### PR TITLE
Include all modules in service Docker builds

### DIFF
--- a/generator-service/Dockerfile
+++ b/generator-service/Dockerfile
@@ -6,9 +6,13 @@ COPY pom.xml ./
 COPY generator-service/pom.xml generator-service/pom.xml
 COPY moderator-service/pom.xml moderator-service/pom.xml
 COPY processor-service/pom.xml processor-service/pom.xml
+COPY observability/pom.xml observability/pom.xml
+COPY postprocessor-service/pom.xml postprocessor-service/pom.xml
 COPY generator-service/src generator-service/src
 COPY moderator-service/src moderator-service/src
 COPY processor-service/src processor-service/src
+COPY observability/src observability/src
+COPY postprocessor-service/src postprocessor-service/src
 # build only this module (+ its dependencies) to get a fat jar with Boot repackage
 RUN mvn -q -B -DskipTests -pl generator-service -am package
 

--- a/moderator-service/Dockerfile
+++ b/moderator-service/Dockerfile
@@ -6,9 +6,13 @@ COPY pom.xml ./
 COPY generator-service/pom.xml generator-service/pom.xml
 COPY moderator-service/pom.xml moderator-service/pom.xml
 COPY processor-service/pom.xml processor-service/pom.xml
+COPY observability/pom.xml observability/pom.xml
+COPY postprocessor-service/pom.xml postprocessor-service/pom.xml
 COPY generator-service/src generator-service/src
 COPY moderator-service/src moderator-service/src
 COPY processor-service/src processor-service/src
+COPY observability/src observability/src
+COPY postprocessor-service/src postprocessor-service/src
 # build only this module (+ its dependencies) to get a fat jar with Boot repackage
 RUN mvn -q -B -DskipTests -pl moderator-service -am package
 

--- a/postprocessor-service/Dockerfile
+++ b/postprocessor-service/Dockerfile
@@ -4,8 +4,14 @@ WORKDIR /app
 COPY pom.xml ./
 COPY observability/pom.xml observability/pom.xml
 COPY postprocessor-service/pom.xml postprocessor-service/pom.xml
+COPY generator-service/pom.xml generator-service/pom.xml
+COPY moderator-service/pom.xml moderator-service/pom.xml
+COPY processor-service/pom.xml processor-service/pom.xml
 COPY observability/src observability/src
 COPY postprocessor-service/src postprocessor-service/src
+COPY generator-service/src generator-service/src
+COPY moderator-service/src moderator-service/src
+COPY processor-service/src processor-service/src
 RUN mvn -q -B -DskipTests -pl postprocessor-service -am package
 
 # ---- Runtime ----

--- a/processor-service/Dockerfile
+++ b/processor-service/Dockerfile
@@ -6,9 +6,13 @@ COPY pom.xml ./
 COPY generator-service/pom.xml generator-service/pom.xml
 COPY moderator-service/pom.xml moderator-service/pom.xml
 COPY processor-service/pom.xml processor-service/pom.xml
+COPY observability/pom.xml observability/pom.xml
+COPY postprocessor-service/pom.xml postprocessor-service/pom.xml
 COPY generator-service/src generator-service/src
 COPY moderator-service/src moderator-service/src
 COPY processor-service/src processor-service/src
+COPY observability/src observability/src
+COPY postprocessor-service/src postprocessor-service/src
 # build only this module (+ its dependencies) to get a fat jar with Boot repackage
 RUN mvn -q -B -DskipTests -pl processor-service -am package
 


### PR DESCRIPTION
## Summary
- Ensure Docker builds include all Maven modules across services
- Allow multi-module Maven builds to resolve without missing child modules

## Testing
- `docker build -f generator-service/Dockerfile -t generator-service-test .` *(fails: command not found)*
- `mvn -q -B -DskipTests -pl generator-service -am package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b3215472188328aa4450c74cabbb1f