### PR TITLE
Add configurable log limits and dropdown styling

### DIFF
--- a/ui/generator/index.html
+++ b/ui/generator/index.html
@@ -183,6 +183,7 @@
       <div class="row">
         <h3 style="margin:0">Results & Log</h3>
         <label class="small"><input type="checkbox" id="showJson" checked /> Show JSON</label>
+        <label class="small">Lines <input id="logLimit" type="number" value="500" min="100" style="width:80px"/></label>
       </div>
       <div id="log" aria-live="polite"></div>
       <p class="small">

--- a/ui/index.html
+++ b/ui/index.html
@@ -44,7 +44,7 @@
     #menu-btn:active{ transform: translateY(1px); filter: brightness(1.1); }
     main { max-width: 1100px; margin: 24px auto; padding: 0 20px 40px; }
     .controls { display:flex; gap:10px; flex-wrap:wrap; margin-bottom:16px; }
-    .controls input {
+    .controls input, .controls select {
       padding: 8px 10px; border-radius: 8px;
       border: 1px solid rgba(255,255,255,0.15);
       background: rgba(12,16,22,0.7); color:#fff;
@@ -129,6 +129,10 @@
         <option value="latency">End-to-End Latency</option>
         <option value="hops">Per-Hop Count</option>
       </select>
+      <label style="font-size:12px; display:flex; align-items:center; gap:6px; color:#fff;">
+        Points
+        <input id="event-limit" type="number" value="600" min="60" max="10000" style="width:72px"/>
+      </label>
     </div>
     <div id="charts" class="card" style="display:none; padding:16px">
       <div class="kpi-title" id="charts-title" style="margin-bottom:10px">RabbitMQ Control Stream — TPS (last 60s)</div>
@@ -161,6 +165,10 @@
           <button id="log-tab-control" class="tab-btn tab-active" type="button">Control Log</button>
           <button id="log-tab-topic" class="tab-btn" type="button">Topic Sniffer</button>
         </div>
+        <label style="font-size:12px; display:flex; align-items:center; gap:6px; color:#fff;">
+          Lines
+          <input id="log-limit" type="number" value="500" min="100" max="5000" style="width:72px"/>
+        </label>
       </div>
       <div id="log-control" aria-live="polite">
         <div id="log"></div>


### PR DESCRIPTION
## Summary
- allow configuring log and chart point retention in the dashboard
- cap in-memory log data across control, topic and system logs
- style graph metric selector to match other controls

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check ui/assets/js/app.js`
- `node --check ui/generator/app.js`


------
https://chatgpt.com/codex/tasks/task_e_68b326aecfac8328aaa32f416d8bb608