### PR TITLE
Rename Control tab to Buzz and add Nectar graphs

### DIFF
--- a/ui/assets/buzz.svg
+++ b/ui/assets/buzz.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <circle cx="12" cy="12" r="5" fill="#FFC107"/>
+  <ellipse cx="8" cy="8" rx="4" ry="2" fill="#FFF" opacity="0.7"/>
+  <ellipse cx="16" cy="8" rx="4" ry="2" fill="#FFF" opacity="0.7"/>
+  <rect x="7" y="11" width="10" height="2" fill="#111"/>
+</svg>

--- a/ui/assets/js/app.js
+++ b/ui/assets/js/app.js
@@ -44,7 +44,7 @@
   const sysLines = [];
   const topicLines = [];
   // Logging toggles
-  const LOG_BUZZ_RAW = true; // show raw buzz payloads in Event Log
+  const LOG_EVENTS_RAW = true; // show raw payloads in Events Log
   const LOG_STOMP_DEBUG = true; // STOMP frame debug to System Logs
   // Hive view elements
   const tabBuzz = document.getElementById('tab-buzz');
@@ -91,39 +91,38 @@
 
   // Tabs handling
   (function(){
-    if(!tabBuzz || !tabHive || !tabNectar || !viewBuzz || !viewHive || !viewNectar) return;
     const activate = (which)=>{
-      viewBuzz.style.display = (which==='buzz') ? 'block' : 'none';
-      viewHive.style.display = (which==='hive') ? 'block' : 'none';
-      viewNectar.style.display = (which==='nectar') ? 'block' : 'none';
-      tabBuzz.classList.toggle('tab-active', which==='buzz');
-      tabHive.classList.toggle('tab-active', which==='hive');
-      tabNectar.classList.toggle('tab-active', which==='nectar');
+      if(viewBuzz) viewBuzz.style.display = (which==='buzz') ? 'block' : 'none';
+      if(viewHive) viewHive.style.display = (which==='hive') ? 'block' : 'none';
+      if(viewNectar) viewNectar.style.display = (which==='nectar') ? 'block' : 'none';
+      if(tabBuzz) tabBuzz.classList.toggle('tab-active', which==='buzz');
+      if(tabHive) tabHive.classList.toggle('tab-active', which==='hive');
+      if(tabNectar) tabNectar.classList.toggle('tab-active', which==='nectar');
       if(which==='hive' && hiveSvg) redrawHive();
     };
-    tabBuzz.addEventListener('click', ()=> activate('buzz'));
-    tabHive.addEventListener('click', ()=> activate('hive'));
-    tabNectar.addEventListener('click', ()=> activate('nectar'));
+    if(tabBuzz) tabBuzz.addEventListener('click', ()=> activate('buzz'));
+    if(tabHive) tabHive.addEventListener('click', ()=> activate('hive'));
+    if(tabNectar) tabNectar.addEventListener('click', ()=> activate('nectar'));
     activate('buzz');
   })();
 
-  // Log tabs handling (Buzz vs Topic)
+  // Log tabs handling (Events vs Topic)
   (function(){
-    const tBuzz = document.getElementById('log-tab-buzz');
+    const tEvents = document.getElementById('log-tab-events');
     const tTop = document.getElementById('log-tab-topic');
-    const vBuzz = document.getElementById('log-buzz');
+    const vEvents = document.getElementById('log-events');
     const vTop = document.getElementById('log-topic');
-    if(!tBuzz || !tTop || !vBuzz || !vTop) return;
+    if(!tEvents || !tTop || !vEvents || !vTop) return;
     const set = (which)=>{
-      if(which==='buzz'){
-        vBuzz.style.display='block'; vTop.style.display='none'; tBuzz.classList.add('tab-active'); tTop.classList.remove('tab-active');
+      if(which==='events'){
+        vEvents.style.display='block'; vTop.style.display='none'; tEvents.classList.add('tab-active'); tTop.classList.remove('tab-active');
       } else {
-        vBuzz.style.display='none'; vTop.style.display='block'; tBuzz.classList.remove('tab-active'); tTop.classList.add('tab-active');
+        vEvents.style.display='none'; vTop.style.display='block'; tEvents.classList.remove('tab-active'); tTop.classList.add('tab-active');
       }
     };
-    tBuzz.addEventListener('click', ()=> set('buzz'));
+    tEvents.addEventListener('click', ()=> set('events'));
     tTop.addEventListener('click', ()=> set('topic'));
-    set('buzz');
+    set('events');
   })();
 
   // Topic sniffer (subscribe to any RK on buzz exchange)
@@ -503,9 +502,9 @@
                   if(svc === 'processor') addPoint('processor', tpsVal);
                 }
               }
-              if(LOG_BUZZ_RAW) appendLog(`BUZZ RAW ${dest} ${body}`);
+              if(LOG_EVENTS_RAW) appendLog(`EVENT RAW ${dest} ${body}`);
             } catch(e){
-              if(LOG_BUZZ_RAW) appendLog(`BUZZ RAW ${dest} ${body}`);
+              if(LOG_EVENTS_RAW) appendLog(`EVENT RAW ${dest} ${body}`);
             }
           }, { ack:'auto' });
           appendSys(`[BUZZ] SUB ${d}`);

--- a/ui/assets/js/app.js
+++ b/ui/assets/js/app.js
@@ -15,10 +15,10 @@
   const genEl = qs('gen');
   const modEl = qs('mod');
   const procEl = qs('proc');
+  const postEl = qs('post');
   const uiStatus = qs('status-ui');
   const wsStatus = qs('status-ws');
   const chartsEl = qs('charts');
-  const toggleChartsBtn = qs('toggle-charts');
   const metricBtn = qs('metric-btn');
   const metricDropdown = qs('metric-dropdown');
   let currentMetric = 'tps';
@@ -31,6 +31,7 @@
     generator: /** @type {HTMLCanvasElement|null} */(document.getElementById('chart-gen')),
     moderator: /** @type {HTMLCanvasElement|null} */(document.getElementById('chart-mod')),
     processor: /** @type {HTMLCanvasElement|null} */(document.getElementById('chart-proc')),
+    postprocessor: /** @type {HTMLCanvasElement|null} */(document.getElementById('chart-post')),
     latency: /** @type {HTMLCanvasElement|null} */(document.getElementById('chart-latency')),
     hops: /** @type {HTMLCanvasElement|null} */(document.getElementById('chart-hops'))
   };
@@ -57,9 +58,9 @@
   const hiveHoldInput = /** @type {HTMLInputElement|null} */(document.getElementById('hive-hold'));
   const hiveClearBtn = document.getElementById('hive-clear');
   const hiveStats = document.getElementById('hive-stats');
-  const series = { generator: [], moderator: [], processor: [], latency: [], hops: [] }; // {t:number,v:number}
+  const series = { generator: [], moderator: [], processor: [], postprocessor: [], latency: [], hops: [] }; // {t:number,v:number}
   const WINDOW_MS = 60_000; // 60s window
-  let rafPending = { generator:false, moderator:false, processor:false, latency:false, hops:false };
+  let rafPending = { generator:false, moderator:false, processor:false, postprocessor:false, latency:false, hops:false };
   const HAS_CONN = !!(elUrl && btn);
   const logLimitInput = qs('log-limit');
   if(logLimitInput){
@@ -391,7 +392,7 @@
     ctx.fillText(String(Math.round(ymax)), 6, 12);
     ctx.fillText('0', 28, h-24);
     // line
-    const colors = { generator:'#4CAF50', moderator:'#FFC107', processor:'#03A9F4', latency:'#E91E63', hops:'#9C27B0' };
+    const colors = { generator:'#4CAF50', moderator:'#FFC107', processor:'#03A9F4', postprocessor:'#FF5722', latency:'#E91E63', hops:'#9C27B0' };
     ctx.strokeStyle = colors[svc] || '#FFFFFF';
     ctx.lineWidth = 2;
     ctx.beginPath();
@@ -497,9 +498,11 @@
                   if(svc === 'generator' && genEl) genEl.textContent = String(tpsVal);
                   if(svc === 'moderator' && modEl) modEl.textContent = String(tpsVal);
                   if(svc === 'processor' && procEl) procEl.textContent = String(tpsVal);
+                  if(svc === 'postprocessor' && postEl) postEl.textContent = String(tpsVal);
                   if(svc === 'generator') addPoint('generator', tpsVal);
                   if(svc === 'moderator') addPoint('moderator', tpsVal);
                   if(svc === 'processor') addPoint('processor', tpsVal);
+                  if(svc === 'postprocessor') addPoint('postprocessor', tpsVal);
                 }
               }
               if(LOG_EVENTS_RAW) appendLog(`EVENT RAW ${dest} ${body}`);
@@ -626,7 +629,7 @@
     setInterval(ping, 15000);
   })();
 
-  // Hook broadcast button (located near charts toggle)
+  // Hook broadcast button (next to metric selector)
   (function(){
     const btn = document.getElementById('broadcast-status');
     if(!btn) return;
@@ -650,7 +653,7 @@
   })();
   function refreshCharts(){
     const metric = currentMetric;
-    if(metric==='tps'){ ['generator','moderator','processor'].forEach(s=> drawChart(s)); }
+    if(metric==='tps'){ ['generator','moderator','processor','postprocessor'].forEach(s=> drawChart(s)); }
     if(metric==='latency') drawChart('latency');
     if(metric==='hops') drawChart('hops');
   }
@@ -690,15 +693,6 @@
     });
     updateMetricView();
   })();
-
-  // Toggle charts visibility
-  if(toggleChartsBtn && chartsEl){
-    toggleChartsBtn.addEventListener('click', ()=>{
-      const show = chartsEl.style.display === 'none';
-      chartsEl.style.display = show ? 'block' : 'none';
-      if(show) refreshCharts();
-    });
-  }
 
   // (removed duplicate legacy broadcast handler)
 })();

--- a/ui/assets/nectar.svg
+++ b/ui/assets/nectar.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path d="M12 2C9 2 5 7 5 10c0 5 7 12 7 12s7-7 7-12c0-3-4-8-7-8z" fill="#FF8A00"/>
+</svg>

--- a/ui/bindings.html
+++ b/ui/bindings.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>PocketHive – Control Bindings</title>
+  <title>PocketHive – Buzz Bindings</title>
   <link rel="icon" type="image/svg+xml" href="./assets/favicon/favicon.svg">
   <link rel="icon" type="image/png" sizes="48x48" href="./assets/favicon/favicon-48.png">
   <link rel="icon" type="image/png" sizes="32x32" href="./assets/favicon/favicon-32.png">
@@ -67,7 +67,7 @@
 </head>
 <body>
   <header>
-    <div class="muted">PocketHive / Control Bindings</div>
+    <div class="muted">PocketHive / Buzz Bindings</div>
   </header>
   <main>
     <p class="muted">This page renders <code>rules/control-plane-rules.md</code> from the repository.</p>

--- a/ui/index.html
+++ b/ui/index.html
@@ -70,15 +70,16 @@
   <header>
         <img class="logo" src="./assets/logo.svg" alt="PocketHive Logo" />
         <nav class="nav-tabs">
-          <button id="tab-control" class="tab-btn tab-active" type="button">Control</button>
-          <button id="tab-hive" class="tab-btn" type="button"><img src="./assets/hive.svg" alt="" class="tab-icon">Hive</button>
+          <button id="tab-hive" class="tab-btn tab-active" type="button"><img src="./assets/hive.svg" alt="" class="tab-icon">Hive</button>
+          <button id="tab-buzz" class="tab-btn" type="button"><img src="./assets/buzz.svg" alt="" class="tab-icon">Buzz</button>
+          <button id="tab-nectar" class="tab-btn" type="button"><img src="./assets/nectar.svg" alt="" class="tab-icon">Nectar</button>
         </nav>
         <div class="header-right">
           <div class="menu" style="position:relative">
             <button id="menu-btn" class="bg-toggle" style="cursor:pointer">☰ Menu</button>
             <div id="menu-dropdown" class="dropdown-panel" style="display:none; position:absolute; right:0; top:36px; min-width: 240px;">
               <a href="readme.html" class="dropdown-item">README</a>
-              <a href="bindings.html" class="dropdown-item">Control Bindings</a>
+              <a href="bindings.html" class="dropdown-item">Buzz Bindings</a>
               <a href="changelog.html" class="dropdown-item">Changelog</a>
                 <a href="docs.html" class="dropdown-item">API Docs</a>
               </div>
@@ -103,7 +104,7 @@
         </div>
       </header>
 
-  <main id="view-control">
+  <main id="view-buzz">
     <div class="controls" style="display:none">
       <input id="wsurl" size="40" value="ws://localhost:15674/ws"/>
       <input id="login" value="guest"/>
@@ -116,50 +117,10 @@
       <div class="card"><div class="kpi-title">Moderator TPS</div><div id="mod" class="kpi-value">0</div></div>
       <div class="card"><div class="kpi-title">Processor TPS</div><div id="proc" class="kpi-value">0</div></div>
     </div>
-    <div class="controls" style="margin-top:10px">
-      <button id="toggle-charts">Toggle Charts</button>
-      <div class="menu" style="position:relative">
-        <button id="metric-btn" class="tab-btn" style="cursor:pointer">TPS</button>
-        <div id="metric-dropdown" class="dropdown-panel" style="display:none; position:absolute; left:0; top:36px; min-width:220px; z-index:10;">
-          <button data-metric="tps" type="button" class="dropdown-item">TPS</button>
-          <button data-metric="latency" type="button" class="dropdown-item">End-to-End Latency</button>
-          <button data-metric="hops" type="button" class="dropdown-item">Per-Hop Count</button>
-        </div>
-      </div>
-        <label style="font-size:12px; display:flex; align-items:center; gap:6px; color:#fff;">
-          Points
-          <input id="event-limit" class="themed-input" type="number" value="600" min="60" max="10000" style="width:72px"/>
-        </label>
-      </div>
-    <div id="charts" class="card" style="display:none; padding:16px">
-      <div class="kpi-title" id="charts-title" style="margin-bottom:10px">RabbitMQ Control Stream — TPS (last 60s)</div>
-      <div id="charts-tps" style="display:grid; grid-template-columns: 1fr; gap:16px">
-        <div>
-          <div class="kpi-title" style="margin-bottom:6px">Generator</div>
-          <canvas id="chart-gen" width="1000" height="180" style="width:100%; height:180px; background: rgba(0,0,0,0.25); border:1px solid rgba(255,255,255,0.1); border-radius:8px"></canvas>
-        </div>
-        <div>
-          <div class="kpi-title" style="margin-bottom:6px">Moderator</div>
-          <canvas id="chart-mod" width="1000" height="180" style="width:100%; height:180px; background: rgba(0,0,0,0.25); border:1px solid rgba(255,255,255,0.1); border-radius:8px"></canvas>
-        </div>
-        <div>
-          <div class="kpi-title" style="margin-bottom:6px">Processor</div>
-          <canvas id="chart-proc" width="1000" height="180" style="width:100%; height:180px; background: rgba(0,0,0,0.25); border:1px solid rgba(255,255,255,0.1); border-radius:8px"></canvas>
-        </div>
-      </div>
-      <div id="charts-latency" style="display:none">
-        <div class="kpi-title" style="margin-bottom:6px">End-to-End Latency</div>
-        <canvas id="chart-latency" width="1000" height="180" style="width:100%; height:180px; background: rgba(0,0,0,0.25); border:1px solid rgba(255,255,255,0.1); border-radius:8px"></canvas>
-      </div>
-      <div id="charts-hops" style="display:none">
-        <div class="kpi-title" style="margin-bottom:6px">Per-Hop Count</div>
-        <canvas id="chart-hops" width="1000" height="180" style="width:100%; height:180px; background: rgba(0,0,0,0.25); border:1px solid rgba(255,255,255,0.1); border-radius:8px"></canvas>
-      </div>
-    </div>
     <section class="card" style="margin-top:16px; padding:12px">
       <div class="row" style="display:flex; justify-content:space-between; align-items:center">
         <div style="display:flex; gap:8px; align-items:center">
-          <button id="log-tab-control" class="tab-btn tab-active" type="button">Control Log</button>
+          <button id="log-tab-buzz" class="tab-btn tab-active" type="button">Buzz Log</button>
           <button id="log-tab-topic" class="tab-btn" type="button">Topic Sniffer</button>
         </div>
         <label style="font-size:12px; display:flex; align-items:center; gap:6px; color:#fff;">
@@ -167,7 +128,7 @@
           <input id="log-limit" class="themed-input" type="number" value="100" min="10" max="500" style="width:72px"/>
         </label>
       </div>
-      <div id="log-control" aria-live="polite">
+        <div id="log-buzz" aria-live="polite">
         <div id="log"></div>
       </div>
       <div id="log-topic" style="display:none">
@@ -203,7 +164,8 @@
     }
     .tab-btn:hover{ box-shadow: 0 0 26px rgba(51,225,255,0.22) inset, 0 0 20px rgba(51,225,255,0.28); background: radial-gradient(120% 120% at 10% 10%, rgba(51,225,255,0.35), rgba(51,225,255,0.1) 50%, rgba(255,255,255,0.07) 75%, rgba(0,0,0,0.0) 100%); }
     .tab-active{ background:#33E1FF !important; color:#111 !important; font-weight:800 !important; border-color:transparent !important; }
-    #view-hive{ display:none; max-width:1200px; margin: 24px auto; padding: 0 20px 40px; color:#fff; font-family: Inter, Segoe UI, Arial, sans-serif; }
+      #view-hive{ display:none; max-width:1200px; margin: 24px auto; padding: 0 20px 40px; color:#fff; font-family: Inter, Segoe UI, Arial, sans-serif; }
+      #view-nectar{ display:none; max-width:1100px; margin: 24px auto; padding: 0 20px 40px; }
     #hive-toolbar{ display:flex; gap:10px; align-items:center; margin-bottom:10px }
     #hive-canvas{ width:100%; height:480px; border:1px solid rgba(255,255,255,.12); border-radius:12px; background: rgba(0,0,0,.25); }
     .controls > button, #topic-sub, #topic-unsub, #hive-clear, #toggle-charts{
@@ -217,15 +179,57 @@
     .controls > button:active, #topic-sub:active, #topic-unsub:active, #hive-clear:active, #toggle-charts:active{ transform: translateY(1px); filter: brightness(1.1); }
     .tab-icon{ width:16px; height:16px; margin-right:6px; vertical-align:middle; }
   </style>
-  <div id="view-hive">
-    <div id="hive-toolbar">
-      <label>Hold time (s) <input id="hive-hold" type="number" min="1" max="120" step="1" value="15" style="width:64px"></label>
-      <button id="hive-clear" class="tab-btn" style="cursor:pointer">Clear & Restart</button>
-      <span class="small" id="hive-stats" style="color:#9aa0a6"></span>
+    <div id="view-hive">
+      <div id="hive-toolbar">
+        <label>Hold time (s) <input id="hive-hold" type="number" min="1" max="120" step="1" value="15" style="width:64px"></label>
+        <button id="hive-clear" class="tab-btn" style="cursor:pointer">Clear & Restart</button>
+        <span class="small" id="hive-stats" style="color:#9aa0a6"></span>
+      </div>
+      <svg id="hive-canvas" viewBox="0 0 1200 480" preserveAspectRatio="xMidYMid meet" aria-label="Hive view"></svg>
     </div>
-    <svg id="hive-canvas" viewBox="0 0 1200 480" preserveAspectRatio="xMidYMid meet" aria-label="Hive view"></svg>
-  </div>
-  <script src="https://unpkg.com/@stomp/stompjs@7.0.0/bundles/stomp.umd.js"></script>
-  <script src="./assets/js/app.js"></script>
+    <div id="view-nectar">
+      <div class="controls" style="margin-top:10px">
+        <button id="toggle-charts">Toggle Charts</button>
+        <div class="menu" style="position:relative">
+          <button id="metric-btn" class="tab-btn" style="cursor:pointer">TPS</button>
+          <div id="metric-dropdown" class="dropdown-panel" style="display:none; position:absolute; left:0; top:36px; min-width:220px; z-index:10;">
+            <button data-metric="tps" type="button" class="dropdown-item">TPS</button>
+            <button data-metric="latency" type="button" class="dropdown-item">End-to-End Latency</button>
+            <button data-metric="hops" type="button" class="dropdown-item">Per-Hop Count</button>
+          </div>
+        </div>
+        <label style="font-size:12px; display:flex; align-items:center; gap:6px; color:#fff;">
+          Points
+          <input id="event-limit" class="themed-input" type="number" value="600" min="60" max="10000" style="width:72px"/>
+        </label>
+      </div>
+      <div id="charts" class="card" style="display:none; padding:16px">
+        <div class="kpi-title" id="charts-title" style="margin-bottom:10px">RabbitMQ Buzz Stream — TPS (last 60s)</div>
+        <div id="charts-tps" style="display:grid; grid-template-columns: 1fr; gap:16px">
+          <div>
+            <div class="kpi-title" style="margin-bottom:6px">Generator</div>
+            <canvas id="chart-gen" width="1000" height="180" style="width:100%; height:180px; background: rgba(0,0,0,0.25); border:1px solid rgba(255,255,255,0.1); border-radius:8px"></canvas>
+          </div>
+          <div>
+            <div class="kpi-title" style="margin-bottom:6px">Moderator</div>
+            <canvas id="chart-mod" width="1000" height="180" style="width:100%; height:180px; background: rgba(0,0,0,0.25); border:1px solid rgba(255,255,255,0.1); border-radius:8px"></canvas>
+          </div>
+          <div>
+            <div class="kpi-title" style="margin-bottom:6px">Processor</div>
+            <canvas id="chart-proc" width="1000" height="180" style="width:100%; height:180px; background: rgba(0,0,0,0.25); border:1px solid rgba(255,255,255,0.1); border-radius:8px"></canvas>
+          </div>
+        </div>
+        <div id="charts-latency" style="display:none">
+          <div class="kpi-title" style="margin-bottom:6px">End-to-End Latency</div>
+          <canvas id="chart-latency" width="1000" height="180" style="width:100%; height:180px; background: rgba(0,0,0,0.25); border:1px solid rgba(255,255,255,0.1); border-radius:8px"></canvas>
+        </div>
+        <div id="charts-hops" style="display:none">
+          <div class="kpi-title" style="margin-bottom:6px">Per-Hop Count</div>
+          <canvas id="chart-hops" width="1000" height="180" style="width:100%; height:180px; background: rgba(0,0,0,0.25); border:1px solid rgba(255,255,255,0.1); border-radius:8px"></canvas>
+        </div>
+      </div>
+    </div>
+    <script src="https://unpkg.com/@stomp/stompjs@7.0.0/bundles/stomp.umd.js"></script>
+    <script src="./assets/js/app.js"></script>
 </body>
 </html>

--- a/ui/index.html
+++ b/ui/index.html
@@ -48,7 +48,7 @@
       color:#fff;
     }
     .controls button { cursor: pointer; }
-    .kpi-grid { display:grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+    .kpi-grid { display:grid; grid-template-columns: repeat(4, 1fr); gap: 14px; }
     .card {
       border: 1px solid rgba(255,255,255,0.12);
       background: rgba(12,16,22,0.66);
@@ -112,11 +112,6 @@
       <button id="connect">Connect</button>
       <span id="state"></span>
     </div>
-    <div class="kpi-grid">
-      <div class="card"><div class="kpi-title">Generator TPS</div><div id="gen" class="kpi-value">0</div></div>
-      <div class="card"><div class="kpi-title">Moderator TPS</div><div id="mod" class="kpi-value">0</div></div>
-      <div class="card"><div class="kpi-title">Processor TPS</div><div id="proc" class="kpi-value">0</div></div>
-    </div>
     <section class="card" style="margin-top:16px; padding:12px">
       <div class="row" style="display:flex; justify-content:space-between; align-items:center">
         <div style="display:flex; gap:8px; align-items:center">
@@ -168,15 +163,15 @@
       #view-nectar{ display:none; max-width:1100px; margin: 24px auto; padding: 0 20px 40px; }
     #hive-toolbar{ display:flex; gap:10px; align-items:center; margin-bottom:10px }
     #hive-canvas{ width:100%; height:480px; border:1px solid rgba(255,255,255,.12); border-radius:12px; background: rgba(0,0,0,.25); }
-    .controls > button, #topic-sub, #topic-unsub, #hive-clear, #toggle-charts{
+    .controls > button, #topic-sub, #topic-unsub, #hive-clear{
       appearance:none; border:none; cursor:pointer; color:#0ff; font-weight:700;
       padding:8px 12px; border-radius:12px; text-transform:uppercase; letter-spacing:0.04em;
       background: radial-gradient(120% 120% at 10% 10%, rgba(51,225,255,0.25), rgba(51,225,255,0.06) 40%, rgba(255,255,255,0.05) 70%, rgba(0,0,0,0.0) 100%);
       border:1px solid rgba(51,225,255,0.35);
       box-shadow: 0 0 20px rgba(51,225,255,0.15) inset, 0 0 16px rgba(51,225,255,0.18);
     }
-    .controls > button:hover, #topic-sub:hover, #topic-unsub:hover, #hive-clear:hover, #toggle-charts:hover{ box-shadow: 0 0 26px rgba(51,225,255,0.22) inset, 0 0 20px rgba(51,225,255,0.28); background: radial-gradient(120% 120% at 10% 10%, rgba(51,225,255,0.35), rgba(51,225,255,0.1) 50%, rgba(255,255,255,0.07) 75%, rgba(0,0,0,0.0) 100%); }
-    .controls > button:active, #topic-sub:active, #topic-unsub:active, #hive-clear:active, #toggle-charts:active{ transform: translateY(1px); filter: brightness(1.1); }
+    .controls > button:hover, #topic-sub:hover, #topic-unsub:hover, #hive-clear:hover{ box-shadow: 0 0 26px rgba(51,225,255,0.22) inset, 0 0 20px rgba(51,225,255,0.28); background: radial-gradient(120% 120% at 10% 10%, rgba(51,225,255,0.35), rgba(51,225,255,0.1) 50%, rgba(255,255,255,0.07) 75%, rgba(0,0,0,0.0) 100%); }
+    .controls > button:active, #topic-sub:active, #topic-unsub:active, #hive-clear:active{ transform: translateY(1px); filter: brightness(1.1); }
     .tab-icon{ width:16px; height:16px; margin-right:6px; vertical-align:middle; }
   </style>
     <div id="view-hive">
@@ -188,8 +183,13 @@
       <svg id="hive-canvas" viewBox="0 0 1200 480" preserveAspectRatio="xMidYMid meet" aria-label="Hive view"></svg>
     </div>
     <div id="view-nectar">
+      <div class="kpi-grid">
+        <div class="card"><div class="kpi-title">Generator TPS</div><div id="gen" class="kpi-value">0</div></div>
+        <div class="card"><div class="kpi-title">Moderator TPS</div><div id="mod" class="kpi-value">0</div></div>
+        <div class="card"><div class="kpi-title">Processor TPS</div><div id="proc" class="kpi-value">0</div></div>
+        <div class="card"><div class="kpi-title">Postprocessor TPS</div><div id="post" class="kpi-value">0</div></div>
+      </div>
       <div class="controls" style="margin-top:10px">
-        <button id="toggle-charts">Toggle Charts</button>
         <div class="menu" style="position:relative">
           <button id="metric-btn" class="tab-btn" style="cursor:pointer">TPS</button>
           <div id="metric-dropdown" class="dropdown-panel" style="display:none; position:absolute; left:0; top:36px; min-width:220px; z-index:10;">
@@ -203,7 +203,7 @@
           <input id="event-limit" class="themed-input" type="number" value="600" min="60" max="10000" style="width:72px"/>
         </label>
       </div>
-      <div id="charts" class="card" style="display:none; padding:16px">
+      <div id="charts" class="card" style="padding:16px">
         <div class="kpi-title" id="charts-title" style="margin-bottom:10px">RabbitMQ Buzz Stream — TPS (last 60s)</div>
         <div id="charts-tps" style="display:grid; grid-template-columns: 1fr; gap:16px">
           <div>
@@ -217,6 +217,10 @@
           <div>
             <div class="kpi-title" style="margin-bottom:6px">Processor</div>
             <canvas id="chart-proc" width="1000" height="180" style="width:100%; height:180px; background: rgba(0,0,0,0.25); border:1px solid rgba(255,255,255,0.1); border-radius:8px"></canvas>
+          </div>
+          <div>
+            <div class="kpi-title" style="margin-bottom:6px">Postprocessor</div>
+            <canvas id="chart-post" width="1000" height="180" style="width:100%; height:180px; background: rgba(0,0,0,0.25); border:1px solid rgba(255,255,255,0.1); border-radius:8px"></canvas>
           </div>
         </div>
         <div id="charts-latency" style="display:none">

--- a/ui/index.html
+++ b/ui/index.html
@@ -120,7 +120,7 @@
     <section class="card" style="margin-top:16px; padding:12px">
       <div class="row" style="display:flex; justify-content:space-between; align-items:center">
         <div style="display:flex; gap:8px; align-items:center">
-          <button id="log-tab-buzz" class="tab-btn tab-active" type="button">Buzz Log</button>
+          <button id="log-tab-events" class="tab-btn tab-active" type="button">Events Log</button>
           <button id="log-tab-topic" class="tab-btn" type="button">Topic Sniffer</button>
         </div>
         <label style="font-size:12px; display:flex; align-items:center; gap:6px; color:#fff;">
@@ -128,7 +128,7 @@
           <input id="log-limit" class="themed-input" type="number" value="100" min="10" max="500" style="width:72px"/>
         </label>
       </div>
-        <div id="log-buzz" aria-live="polite">
+        <div id="log-events" aria-live="polite">
         <div id="log"></div>
       </div>
       <div id="log-topic" style="display:none">


### PR DESCRIPTION
## Summary
- Rename the Control tab to **Buzz**, reorder navigation after Hive, and add a bee-themed icon
- Introduce a new **Nectar** tab with a honey icon and relocate all metric charts there
- Update bindings page and logs to use Buzz terminology

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b413aa581c8328bd8a807e0cd1f5a5