### PR TITLE
feat(ui): adopt CSS-based HAL and Monolith icons

### DIFF
--- a/ui/assets/css/app.css
+++ b/ui/assets/css/app.css
@@ -22,66 +22,6 @@ p{ color:#9aa0a6; }
   backdrop-filter: blur(6px);
 }
 
-/* HAL status eyes */
-.hal{ display:flex; align-items:center; gap:10px; }
-.hal-eye{
-  --hal: #9aa0a6; /* base tint */
-  position: relative; width: 28px; height: 28px; border-radius: 50%;
-  background:
-    radial-gradient(100% 100% at 50% 50%, #000 0%, #111 40%, #0a0d12 100%);
-  box-shadow: 0 0 10px rgba(0,0,0,.35) inset, 0 0 10px color-mix(in srgb, var(--hal) 18%, transparent);
-  outline: 1px solid rgba(255,255,255,0.14);
-}
-.hal-eye#status-ws{ cursor: pointer; }
-/* Inner core that pulses (center only) */
-.hal-eye::after{
-  content:""; position:absolute; inset: 12%; border-radius:50%;
-  background:
-    radial-gradient(48% 48% at 50% 44%, #fff9 0%, #fff0 62%),
-    radial-gradient(70% 72% at 50% 56%, color-mix(in srgb, var(--hal) 95%, #000) 0%, transparent 72%);
-  filter: drop-shadow(0 0 8px color-mix(in srgb, var(--hal) 55%, transparent));
-  transform: scale(0.98);
-  opacity: .95;
-}
-@keyframes hal-core-slow{ 0%{ transform:scale(0.94); opacity:.70 } 50%{ transform:scale(1.06); opacity:.95 } 100%{ transform:scale(0.94); opacity:.70 } }
-@keyframes hal-core-fast{ 0%{ transform:scale(0.88); opacity:.60 } 50%{ transform:scale(1.12); opacity:1.0 } 100%{ transform:scale(0.88); opacity:.60 } }
-@keyframes hal-core-modem{ 0%,70%,100%{ transform:scale(0.95); opacity:.55 } 78%{ transform:scale(1.10); opacity:1 } 82%{ transform:scale(0.98); opacity:.70 } }
-/* UI states (HAL eyes policy) — center pulsing */
-#status-ui[data-state="healthy"], #status-ws[data-state="connected"]{ --hal:#00ff66; }
-#status-ui[data-state="healthy"]::after, #status-ws[data-state="connected"]::after{ animation: hal-core-slow 2.4s ease-in-out infinite; }
-#status-ui[data-state="unhealthy"], #status-ws[data-state="error"],
-#status-ui[data-state="down"], #status-ws[data-state="closed"], #status-ws[data-state="idle"]{ --hal:#ff0033; }
-#status-ui[data-state="unhealthy"]::after, #status-ws[data-state="error"]::after,
-#status-ui[data-state="down"]::after, #status-ws[data-state="closed"]::after, #status-ws[data-state="idle"]::after{ animation: hal-core-fast 0.7s ease-in-out infinite; }
-#status-ui[data-state="connecting"], #status-ws[data-state="connecting"]{ --hal:#00ccff; }
-#status-ui[data-state="connecting"]::after, #status-ws[data-state="connecting"]::after{ animation: hal-core-modem 1.1s linear infinite; }
-
-/* Stronger outer glow per state to increase contrast */
-#status-ui[data-state="healthy"], #status-ws[data-state="connected"]{
-  box-shadow: 0 0 10px rgba(0,0,0,.35) inset,
-              0 0 18px color-mix(in srgb, var(--hal) 30%, transparent),
-              0 0 34px color-mix(in srgb, var(--hal) 18%, transparent);
-}
-#status-ui[data-state*="unhealthy"], #status-ws[data-state="error"],
-#status-ui[data-state="down"], #status-ws[data-state="closed"], #status-ws[data-state="idle"]{
-  box-shadow: 0 0 10px rgba(0,0,0,.35) inset,
-              0 0 18px color-mix(in srgb, var(--hal) 36%, transparent),
-              0 0 36px color-mix(in srgb, var(--hal) 22%, transparent);
-}
-#status-ui[data-state="connecting"], #status-ws[data-state="connecting"]{
-  box-shadow: 0 0 10px rgba(0,0,0,.35) inset,
-              0 0 16px color-mix(in srgb, var(--hal) 26%, transparent),
-              0 0 28px color-mix(in srgb, var(--hal) 16%, transparent);
-}
-
-/* Hover feedback for connection icon */
-#status-ws{ transition: box-shadow .15s, transform .15s; }
-#status-ws:hover{
-  transform: scale(1.08);
-  box-shadow: 0 0 10px rgba(0,0,0,.35) inset,
-              0 0 24px color-mix(in srgb, var(--hal) 40%, transparent),
-              0 0 44px color-mix(in srgb, var(--hal) 28%, transparent);
-}
 /* Shared dropdown menu styling */
 .dropdown-panel{
   background: rgba(12,16,22,0.95);
@@ -107,29 +47,3 @@ p{ color:#9aa0a6; }
 .dropdown-item:last-child{ border-bottom:none; }
 .dropdown-item:hover{ background:rgba(255,255,255,0.08); }
 
-/* Monolith status button */
-#broadcast-status{
-  appearance:none;
-  background:none;
-  border:none;
-  cursor:pointer;
-  width:40px;
-  height:40px;
-  padding:0;
-}
-#broadcast-status .monolith{
-  width:100%;
-  height:100%;
-  animation: monolith-glow 2s ease-in-out infinite alternate;
-  transition: transform .2s ease;
-}
-#broadcast-status:hover .monolith{
-  transform: translateY(-2px);
-  animation: none;
-  filter: drop-shadow(0 0 8px #33E1FF);
-}
-
-@keyframes monolith-glow{
-  from{filter:drop-shadow(0 0 2px #33E1FF);}
-  to{filter:drop-shadow(0 0 6px #33E1FF);}
-}

--- a/ui/assets/css/icons.css
+++ b/ui/assets/css/icons.css
@@ -1,0 +1,72 @@
+:root{
+  --ok:#42d392;
+  --warn:#ffd166;
+  --err:#ff4d4f;
+
+  /* HAL defaults */
+  --hal-color:#ff3b30;
+  --hal-glow:#ff8a80;
+  --hal-core:#8b0f0a;
+  --hal-pulse-dur: 2.4s;
+
+  /* Monolith */
+  --monolith:#1b2430;
+}
+
+/* ===== HAL (Health Check Eye) ===== */
+.hal{ --size: 110px; width:var(--size); height:var(--size); border-radius:50%; position:relative; display:grid; place-items:center; }
+.hal .disc{ position:absolute; inset:0; border-radius:50%;
+  background: radial-gradient(circle at 50% 52%, var(--hal-color) 0 28%, var(--hal-glow) 29% 36%, var(--hal-core) 37% 58%, #000 59% 100%);
+}
+.hal::before{ content:""; position:absolute; inset:-6px; border-radius:50%;
+  background: radial-gradient(closest-side, rgba(255,255,255,.10), rgba(255,255,255,0));
+  border:1px solid rgba(255,255,255,.10); box-shadow: inset 0 0 0 1px rgba(0,0,0,.85), 0 0 0 1px rgba(0,0,0,.6);
+}
+.hal::after{ content:""; position:absolute; top:14%; left:26%; width:28%; height:28%; border-radius:50%; opacity:0;
+  background: radial-gradient(circle at 40% 40%, #fff, rgba(255,255,255,.65) 40%, rgba(255,255,255,0) 72%); }
+.hal .outer-halo{ position:absolute; inset:-18%; border-radius:50%; pointer-events:none; opacity:0; transform: scale(.96);
+  background: radial-gradient(circle, color-mix(in oklab, var(--hal-color) 40%, transparent) 0%, color-mix(in oklab, var(--hal-color) 20%, transparent) 35%, transparent 60%); }
+
+@keyframes hal-pulse { from{ transform:scale(1);} to{ transform:scale(1.08);} }
+@keyframes hal-blink { 0%{opacity:0;} 18%{opacity:.85;} 100%{opacity:0;} }
+@keyframes halo-pulse { from{ opacity:0; transform:scale(.9);} to{ opacity:.9; transform:scale(1.05);} }
+@keyframes modem-scan { 0%, 6%{opacity:0} 7%, 10%{opacity:1} 11%, 18%{opacity:0} 19%, 22%{opacity:1} 23%, 36%{opacity:0} 37%, 40%{opacity:1} 41%, 100%{opacity:0} }
+
+.hal.is-animating   .disc{ will-change: transform; animation: hal-pulse var(--hal-pulse-dur) ease-in-out infinite alternate; }
+.hal.is-animating::after{ animation: hal-blink calc(var(--hal-pulse-dur) * 1.1) ease-in-out infinite; }
+.hal.is-animating .outer-halo{ will-change: transform, opacity; animation: halo-pulse var(--hal-pulse-dur) ease-in-out infinite alternate; }
+.hal.scan .outer-halo{ animation: modem-scan 1.6s steps(30) infinite; opacity:1; transform:none; }
+.hal.scan .disc{ animation: none; }
+
+/* States */
+.hal.ok    { --hal-color:#22c55e; --hal-glow:#9cffb8; --hal-core:#0d3b22; --hal-pulse-dur: 2.8s; }
+.hal.warn  { --hal-color:#ffd166; --hal-glow:#ffe6a9; --hal-core:#5b3d00; --hal-pulse-dur: 1.8s; }
+.hal.err   { --hal-color:#ff4040; --hal-glow:#ff9b93; --hal-core:#3f0000; --hal-pulse-dur: 1.1s; }
+
+.badge{ position:absolute; right:-6px; bottom:-6px; width:16px; height:16px; border-radius:50%; background:#222; display:grid; place-items:center; }
+.dot{ width:8px; height:8px; border-radius:50%; background:#666 }
+.ok   .dot{ background: var(--ok) }
+.warn .dot{ background: var(--warn) }
+.err  .dot{ background: var(--err) }
+
+/* ===== Monolith (Perspective Block) ===== */
+.monolith{ --w: 74px; --h: 128px; width:var(--w); height:var(--h); border-radius:12px; position:relative; overflow:hidden;
+  background: var(--monolith);
+  outline:1px solid rgba(255,255,255,.18); box-shadow: 0 10px 24px rgba(0,0,0,.55), inset 0 0 0 1px rgba(0,0,0,.85);
+  transform: perspective(800px) rotateY(-18deg) rotateX(2deg);
+}
+.monolith .face{ position:absolute; inset:0; background:
+    linear-gradient(180deg, rgba(255,255,255,.10) 0%, rgba(0,0,0,.35) 85%),
+    linear-gradient(160deg, rgba(255,255,255,.08) 0%, rgba(255,255,255,0) 55%);
+  pointer-events:none; }
+.monolith .rim{ position:absolute; inset:0; pointer-events:none; }
+.monolith .rim.near{ width:14%; left:0; background: linear-gradient(90deg, rgba(255,255,255,.24), rgba(255,255,255,0)); }
+.monolith .rim.far { width:10%; right:0; background: linear-gradient(270deg, rgba(0,0,0,.45), rgba(0,0,0,0)); }
+.monolith .diag{ position:absolute; inset:-20% -30% -20% -30%; opacity:.22; transform: rotate(-15deg);
+  background: linear-gradient(180deg, rgba(255,255,255,0) 0%, rgba(255,255,255,.28) 50%, rgba(255,255,255,0) 100%); }
+.monolith .sheen{ position:absolute; top:0; bottom:0; width:42%; left:-50%; opacity:.75;
+  background: linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(255,255,255,.32) 50%, rgba(255,255,255,0) 100%);
+  transform: translateX(0);
+}
+@keyframes sheen-sweep{ from{ transform:translateX(0);} to{ transform:translateX(240%);} }
+.monolith.is-animating .sheen{ will-change: transform; animation: sheen-sweep 2.6s linear infinite; }

--- a/ui/assets/js/app.js
+++ b/ui/assets/js/app.js
@@ -331,13 +331,43 @@
 
   function setUiStatus(state){
     if(!uiStatus) return;
-    uiStatus.dataset.state = state || 'connecting';
+    state = state || 'connecting';
+    const badge = uiStatus.querySelector('.badge');
+    uiStatus.classList.remove('ok','warn','err','scan');
+    if(badge) badge.classList.remove('ok','warn','err');
+    const cls = state==='healthy'
+      ? 'ok'
+      : state==='unhealthy'
+        ? 'warn'
+        : (state==='down')
+          ? 'err'
+          : (state==='connecting'
+            ? 'scan'
+            : '');
+    if(cls){
+      uiStatus.classList.add(cls);
+      if(badge && cls!=='scan') badge.classList.add(cls);
+    }
     uiStatus.setAttribute('aria-label', `UI ${state||''}`.trim());
     uiStatus.title = `UI: ${state}`;
   }
   function setWsStatus(state){
     if(!wsStatus) return;
-    wsStatus.dataset.state = state || 'idle';
+    state = state || 'idle';
+    const badge = wsStatus.querySelector('.badge');
+    wsStatus.classList.remove('ok','warn','err','scan');
+    if(badge) badge.classList.remove('ok','warn','err');
+    const cls = state==='connected'
+      ? 'ok'
+      : state==='error' || state==='closed' || state==='idle'
+        ? 'err'
+        : state==='connecting'
+          ? 'scan'
+          : '';
+    if(cls){
+      wsStatus.classList.add(cls);
+      if(badge && cls!=='scan') badge.classList.add(cls);
+    }
     wsStatus.setAttribute('aria-label', `WS ${state||''}`.trim());
     wsStatus.title = `WebSocket: ${state}`;
   }

--- a/ui/changelog.html
+++ b/ui/changelog.html
@@ -13,6 +13,7 @@
   <link rel="manifest" href="./assets/favicon/site.webmanifest">
   <meta name="theme-color" content="#0f1116">
   <link rel="stylesheet" href="./assets/css/app.css">
+  <link rel="stylesheet" href="./assets/css/icons.css">
   <style>
     body{margin:0; font-family: ui-sans-serif,system-ui,Segoe UI,Roboto,Helvetica,Arial; color:#e6eef8; background:#0b0f14}
     header{display:flex;align-items:center;gap:12px;padding:16px 20px;border-bottom:1px solid rgba(255,255,255,.1);background:#0c1118;position:sticky;top:0}

--- a/ui/docs.html
+++ b/ui/docs.html
@@ -13,6 +13,7 @@
   <link rel="manifest" href="./assets/favicon/site.webmanifest">
   <meta name="theme-color" content="#0f1116">
   <link rel="stylesheet" href="./assets/css/app.css">
+  <link rel="stylesheet" href="./assets/css/icons.css">
   <style>
     body{margin:0; font-family: ui-sans-serif,system-ui,Segoe UI,Roboto,Helvetica,Arial; color:#e6eef8; background:#0b0f14}
     header{display:flex;align-items:center;gap:12px;padding:16px 20px;border-bottom:1px solid rgba(255,255,255,.1);background:#0c1118;position:sticky;top:0}

--- a/ui/index.html
+++ b/ui/index.html
@@ -13,6 +13,7 @@
   <link rel="manifest" href="./assets/favicon/site.webmanifest">
   <meta name="theme-color" content="#0f1116">
   <link rel="stylesheet" href="./assets/css/app.css">
+  <link rel="stylesheet" href="./assets/css/icons.css">
   <style>
       header {
         display: flex; align-items: center; gap: 16px;
@@ -85,19 +86,27 @@
               </div>
           </div>
           <div class="bg-toggle" style="gap:10px; align-items:center">
-            <div class="hal">
-              <span id="status-ui" class="hal-eye" data-state="connecting" title="UI Health"></span>
-              <span id="status-ws" class="hal-eye" data-state="idle" title="WebSocket to RabbitMQ — click to open connection" role="button" tabindex="0"></span>
-              <div class="menu" id="conn-menu" style="position:relative; display:inline-flex;">
-                <div id="conn-dropdown" style="display:none; position:absolute; right:0; top:36px; background: rgba(12,16,22,0.95); border:1px solid rgba(255,255,255,0.15); border-radius:10px; min-width: 340px; box-shadow:0 6px 22px rgba(0,0,0,0.4); padding:10px"></div>
-              </div>
+            <div id="status-ui" class="hal scan is-animating" style="--size:28px" title="UI Health">
+              <span class="disc"></span>
+              <span class="outer-halo" aria-hidden="true"></span>
+              <span class="badge"><span class="dot"></span></span>
             </div>
-            <button id="broadcast-status" title="Broadcast status.request to all services" aria-label="Broadcast status">
-              <svg class="monolith" width="32" height="32" viewBox="0 0 32 32" aria-hidden="true">
-                <polygon points="10,8 18,8 18,26 10,26" fill="#111"/>
-                <polygon points="18,8 20,6 20,24 18,26" fill="#1a1a1a"/>
-                <polygon points="10,8 18,8 20,6 12,6" fill="#222"/>
-              </svg>
+            <div id="status-ws" class="hal err is-animating" style="--size:28px" title="WebSocket to RabbitMQ — click to open connection" role="button" tabindex="0">
+              <span class="disc"></span>
+              <span class="outer-halo" aria-hidden="true"></span>
+              <span class="badge err"><span class="dot"></span></span>
+            </div>
+            <div class="menu" id="conn-menu" style="position:relative; display:inline-flex;">
+              <div id="conn-dropdown" style="display:none; position:absolute; right:0; top:36px; background: rgba(12,16,22,0.95); border:1px solid rgba(255,255,255,0.15); border-radius:10px; min-width: 340px; box-shadow:0 6px 22px rgba(0,0,0,0.4); padding:10px"></div>
+            </div>
+            <button id="broadcast-status" title="Broadcast status.request to all services" aria-label="Broadcast status" style="width:40px;height:40px;padding:0;background:none;border:none;cursor:pointer;">
+              <div class="monolith is-animating" style="--w:32px; --h:32px;">
+                <i class="face"></i>
+                <i class="rim near"></i>
+                <i class="rim far"></i>
+                <i class="diag"></i>
+                <i class="sheen" aria-hidden="true"></i>
+              </div>
             </button>
             <span id="ph-version" title="Current Version">v…</span>
           </div>


### PR DESCRIPTION
## Summary
- add new icons.css with CSS-only HAL eye and Monolith styles
- replace index header icons with HAL/Monolith markup
- update health status logic to toggle HAL states via classes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b42017cb808328ad607d4567d85663