### PR TITLE
refactor: centralize status envelope building

### DIFF
--- a/observability/src/main/java/io/pockethive/observability/StatusEnvelopeBuilder.java
+++ b/observability/src/main/java/io/pockethive/observability/StatusEnvelopeBuilder.java
@@ -1,0 +1,89 @@
+package io.pockethive.observability;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.time.Instant;
+import java.util.*;
+
+/**
+ * Helper for building JSON status envelopes shared across services.
+ * <p>
+ * The builder exposes fluent setters for common fields that appear in the
+ * status events emitted by the individual services (role, instance, queues,
+ * tps, etc.).  The {@link #toJson()} method materialises the payload as a
+ * JSON string using Jackson's {@link ObjectMapper}.
+ */
+public class StatusEnvelopeBuilder {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final Map<String, Object> root = new LinkedHashMap<>();
+    private final Map<String, Object> data = new LinkedHashMap<>();
+    private final Map<String, List<String>> queues = new LinkedHashMap<>();
+
+    public StatusEnvelopeBuilder() {
+        root.put("event", "status");
+        root.put("version", "1.0");
+        root.put("messageId", UUID.randomUUID().toString());
+        root.put("timestamp", Instant.now().toString());
+        String location = System.getenv().getOrDefault("PH_LOCATION",
+                System.getenv().getOrDefault("HOSTNAME", "local"));
+        root.put("location", location);
+    }
+
+    public StatusEnvelopeBuilder kind(String kind) {
+        root.put("kind", kind);
+        return this;
+    }
+
+    public StatusEnvelopeBuilder role(String role) {
+        root.put("role", role);
+        return this;
+    }
+
+    public StatusEnvelopeBuilder instance(String instance) {
+        root.put("instance", instance);
+        return this;
+    }
+
+    public StatusEnvelopeBuilder traffic(String traffic) {
+        root.put("traffic", traffic);
+        return this;
+    }
+
+    public StatusEnvelopeBuilder inQueues(String... queues) {
+        if (queues != null && queues.length > 0) {
+            this.queues.put("in", Arrays.asList(queues));
+        }
+        return this;
+    }
+
+    public StatusEnvelopeBuilder outQueues(String... queues) {
+        if (queues != null && queues.length > 0) {
+            this.queues.put("out", Arrays.asList(queues));
+        }
+        return this;
+    }
+
+    public StatusEnvelopeBuilder tps(long tps) {
+        data.put("tps", tps);
+        return this;
+    }
+
+    /**
+     * Serialise the collected fields into a JSON document.
+     */
+    public String toJson() {
+        if (!queues.isEmpty()) {
+            root.put("queues", queues);
+        }
+        root.put("data", data.isEmpty() ? Collections.emptyMap() : data);
+        try {
+            return MAPPER.writeValueAsString(root);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Failed to serialise status envelope", e);
+        }
+    }
+}
+

--- a/processor-service/src/main/java/io/pockethive/processor/Processor.java
+++ b/processor-service/src/main/java/io/pockethive/processor/Processor.java
@@ -11,10 +11,10 @@ import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.amqp.support.AmqpHeaders;
 import io.pockethive.observability.ObservabilityContext;
 import io.pockethive.observability.ObservabilityContextUtil;
+import io.pockethive.observability.StatusEnvelopeBuilder;
 import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Qualifier;
 
-import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
 @Component
@@ -85,37 +85,27 @@ public class Processor {
   private void sendStatusDelta(long tps){
     String role = "processor";
     String rk = "ev.status-delta."+role+"."+instanceId;
-    rabbit.convertAndSend(Topology.CONTROL_EXCHANGE, rk, envelope(role, new String[]{Topology.MOD_QUEUE}, null, tps, "status-delta"));
+    String payload = new StatusEnvelopeBuilder()
+        .kind("status-delta")
+        .role(role)
+        .instance(instanceId)
+        .traffic(Topology.EXCHANGE)
+        .inQueues(Topology.MOD_QUEUE)
+        .tps(tps)
+        .toJson();
+    rabbit.convertAndSend(Topology.CONTROL_EXCHANGE, rk, payload);
   }
   private void sendStatusFull(long tps){
     String role = "processor";
     String rk = "ev.status-full."+role+"."+instanceId;
-    rabbit.convertAndSend(Topology.CONTROL_EXCHANGE, rk, envelope(role, new String[]{Topology.MOD_QUEUE}, null, tps, "status-full"));
-  }
-  private String envelope(String role, String[] inQueues, String[] outQueues, long tps, String kind){
-    String location = System.getenv().getOrDefault("PH_LOCATION", System.getenv().getOrDefault("HOSTNAME", "local"));
-    String messageId = UUID.randomUUID().toString();
-    String timestamp = java.time.Instant.now().toString();
-    String traffic = Topology.EXCHANGE;
-    StringBuilder sb = new StringBuilder(256);
-    sb.append('{')
-      .append("\"event\":\"status\",")
-      .append("\"kind\":\"").append(kind).append("\",")
-      .append("\"version\":\"1.0\",")
-      .append("\"role\":\"").append(role).append("\",")
-      .append("\"instance\":\"").append(instanceId).append("\",")
-      .append("\"location\":\"").append(location).append("\",")
-      .append("\"messageId\":\""+messageId+"\",")
-      .append("\"timestamp\":\""+timestamp+"\",")
-      .append("\"traffic\":\""+traffic+"\"");
-    if((inQueues!=null && inQueues.length>0) || (outQueues!=null && outQueues.length>0)){
-      sb.append(',').append("\"queues\":{");
-      if(inQueues!=null && inQueues.length>0){ sb.append("\"in\":["); for(int i=0;i<inQueues.length;i++){ if(i>0) sb.append(','); sb.append('"').append(inQueues[i]).append('"'); } sb.append(']'); }
-      if(outQueues!=null && outQueues.length>0){ if(inQueues!=null && inQueues.length>0) sb.append(','); sb.append("\"out\":["); for(int i=0;i<outQueues.length;i++){ if(i>0) sb.append(','); sb.append('"').append(outQueues[i]).append('"'); } sb.append(']'); }
-      sb.append('}');
-    }
-    sb.append(',').append("\"data\":{\"tps\":").append(tps).append('}');
-    sb.append('}');
-    return sb.toString();
+    String payload = new StatusEnvelopeBuilder()
+        .kind("status-full")
+        .role(role)
+        .instance(instanceId)
+        .traffic(Topology.EXCHANGE)
+        .inQueues(Topology.MOD_QUEUE)
+        .tps(tps)
+        .toJson();
+    rabbit.convertAndSend(Topology.CONTROL_EXCHANGE, rk, payload);
   }
 }


### PR DESCRIPTION
## Summary
- add reusable StatusEnvelopeBuilder for constructing status event payloads
- refactor Generator, Moderator, Processor and PostProcessor to use the shared builder instead of local helpers

## Testing
- `mvn -q -pl observability,generator-service,moderator-service,processor-service,postprocessor-service -am test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d7ea0cec8328a5b390bc8225287d