### PR TITLE
refactor: modularize panel logic

### DIFF
--- a/ui/assets/js/features/panelRenderer.js
+++ b/ui/assets/js/features/panelRenderer.js
@@ -1,0 +1,30 @@
+export function initPanel(panels, role, id) {
+  return import(`../../modules/${role}.js`)
+    .then(mod => {
+      const fn = mod[`render${role.charAt(0).toUpperCase() + role.slice(1)}Panel`];
+      if (typeof fn === 'function') {
+        const el = document.createElement('div');
+        panels[role][id] = el;
+        fn(el, id);
+      }
+    })
+    .catch(err => console.error('module load', err));
+}
+
+export function showPanel(role, instances, panels, modalRefs, client) {
+  const { modal, modalBody, modalTitle } = modalRefs;
+  const inst = instances[role];
+  if (!inst || !modal || !modalBody || !modalTitle) return;
+  const el = panels[role] && panels[role][inst.id];
+  if (!el) return;
+  modalBody.innerHTML = '';
+  modalBody.appendChild(el);
+  modalTitle.textContent = `${inst.name || role} (${inst.id})`;
+  modal.style.display = 'flex';
+  try {
+    const payload = { type: 'status-request', role, instance: inst.id };
+    client.publish({ destination: `/exchange/ph.control/sig.status-request.${role}.${inst.id}`, body: JSON.stringify(payload) });
+  } catch (err) {
+    console.error('status-request', err);
+  }
+}

--- a/ui/assets/js/features/stompClient.js
+++ b/ui/assets/js/features/stompClient.js
@@ -1,0 +1,16 @@
+export function setupStompClient(onStatusFull) {
+  const client = new StompJs.Client({
+    brokerURL: (location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + '/ws'
+  });
+  client.onConnect = () => {
+    client.subscribe('/exchange/ph.control/ev.status-full.#', onStatusFull);
+    try {
+      const payload = { type: 'status-request', timestamp: new Date().toISOString() };
+      client.publish({ destination: '/exchange/ph.control/sig.status-request', body: JSON.stringify(payload) });
+    } catch (err) {
+      console.error('status-request', err);
+    }
+  };
+  client.activate();
+  return client;
+}

--- a/ui/assets/js/main.js
+++ b/ui/assets/js/main.js
@@ -1,62 +1,40 @@
 // Main bootstrap for dynamic panels
-const client = new StompJs.Client({ brokerURL: (location.protocol==='https:'?'wss://':'ws://') + location.host + '/ws' });
-window.phClient = client;
-const panels = {generator:{}, moderator:{}, processor:{}, postprocessor:{}};
+import { setupStompClient } from './features/stompClient.js';
+import { initPanel, showPanel } from './features/panelRenderer.js';
+
+const panels = { generator: {}, moderator: {}, processor: {}, postprocessor: {} };
 const instances = {};
-const loaded = {generator:{}, moderator:{}, processor:{}, postprocessor:{}};
+const loaded = { generator: {}, moderator: {}, processor: {}, postprocessor: {} };
 
 const modal = document.getElementById('panel-modal');
 const modalTitle = document.getElementById('panel-title');
 const modalBody = document.getElementById('panel-body');
 const closeBtn = document.getElementById('panel-close');
-if(closeBtn) closeBtn.addEventListener('click', ()=>{ if(modal) modal.style.display='none'; });
-if(modal) modal.addEventListener('click', e=>{ if(e.target===modal) modal.style.display='none'; });
-client.onConnect = ()=>{
-  // discover services via status-full events
-  client.subscribe('/exchange/ph.control/ev.status-full.#', msg=>{
-    try{
-      const body = JSON.parse(msg.body||'{}');
-      const role = body.role || body.name || body.service;
-      const inst = body.instance || body.id;
-      if(role && inst){
-        instances[role] = {id:inst, name: body.name || role};
-        if(!loaded[role][inst]){
-          loaded[role][inst]=true;
-          initPanel(role, inst);
-        }
+if (closeBtn) closeBtn.addEventListener('click', () => { if (modal) modal.style.display = 'none'; });
+if (modal) modal.addEventListener('click', e => { if (e.target === modal) modal.style.display = 'none'; });
+
+function handleStatusFull(msg) {
+  try {
+    const body = JSON.parse(msg.body || '{}');
+    const role = body.role || body.name || body.service;
+    const inst = body.instance || body.id;
+    if (role && inst) {
+      instances[role] = { id: inst, name: body.name || role };
+      if (!loaded[role][inst]) {
+        loaded[role][inst] = true;
+        initPanel(panels, role, inst);
       }
-    }catch(e){ console.error(e); }
-  });
-  // request current status from all services so panels appear automatically
-  try{
-    const payload = {type:'status-request', timestamp:new Date().toISOString()};
-    client.publish({destination:'/exchange/ph.control/sig.status-request', body:JSON.stringify(payload)});
-  }catch(err){ console.error('status-request', err); }
-};
-client.activate();
-function initPanel(role, id){
-  import(`../../modules/${role}.js`).then(mod=>{
-    const fn = mod[`render${role.charAt(0).toUpperCase()+role.slice(1)}Panel`];
-    if(typeof fn==='function'){
-      const el = document.createElement('div');
-      panels[role][id] = el;
-      fn(el, id);
     }
-  }).catch(err=>console.error('module load', err));
+  } catch (e) {
+    console.error(e);
+  }
 }
 
-function showPanel(role){
-  const inst = instances[role];
-  if(!inst || !modal || !modalBody || !modalTitle) return;
-  const el = panels[role] && panels[role][inst.id];
-  if(!el) return;
-  modalBody.innerHTML='';
-  modalBody.appendChild(el);
-  modalTitle.textContent = `${inst.name || role} (${inst.id})`;
-  modal.style.display='flex';
-  try{
-    const payload = {type:'status-request', role, instance:inst.id};
-    client.publish({destination:`/exchange/ph.control/sig.status-request.${role}.${inst.id}`, body:JSON.stringify(payload)});
-  }catch(err){ console.error('status-request', err); }
+const client = setupStompClient(handleStatusFull);
+window.phClient = client;
+
+function phShowPanel(role) {
+  showPanel(role, instances, panels, { modal, modalBody, modalTitle }, client);
 }
-window.phShowPanel = showPanel;
+
+export { phShowPanel };

--- a/ui/assets/js/menus/hive.js
+++ b/ui/assets/js/menus/hive.js
@@ -1,3 +1,5 @@
+import { phShowPanel } from "../main.js";
+
 /**
  * Create the Hive panel that renders service nodes and queue edges as an SVG graph.
  *
@@ -95,7 +97,7 @@ export function initHiveMenu() {
       const n = hive.nodes[id];
       const g = document.createElementNS('http://www.w3.org/2000/svg', 'g');
       g.setAttribute('transform', `translate(${n.x - 60},${n.y - 46})`);
-      if (id !== 'sut') { g.style.cursor = 'pointer'; g.addEventListener('click', () => { if (window.phShowPanel) window.phShowPanel(id); }); }
+      if (id !== 'sut') { g.style.cursor = 'pointer'; g.addEventListener('click', () => { if (phShowPanel) phShowPanel(id); }); }
       const rect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
       rect.setAttribute('x', '0'); rect.setAttribute('y', '0');
       rect.setAttribute('width', '120'); rect.setAttribute('height', '92');

--- a/ui/bindings.html
+++ b/ui/bindings.html
@@ -25,7 +25,7 @@
     a{ color:#33E1FF; }
     .muted{ color:#9aa0a6; font-size: 14px; }
   </style>
-  <script>
+  <script type="module">
     async function load(){
       const host = document.getElementById('md');
       const mdUrl = '/rules/control-plane-rules.md';


### PR DESCRIPTION
## Summary
- convert dynamic panel bootstrap to ES modules and export `phShowPanel`
- extract panel rendering and STOMP setup helpers into reusable feature modules
- update bindings page and hive menu to use the new module APIs

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/PocketHive/package.json')*
- `mvn -q test` *(fails: Non-resolvable import POM: artifacts could not be resolved, network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68b4de9451d88328a772d9b9002c4488