### PR TITLE
fix: adjust TPS calculation

### DIFF
--- a/generator-service/src/main/java/io/pockethive/generator/Generator.java
+++ b/generator-service/src/main/java/io/pockethive/generator/Generator.java
@@ -34,6 +34,7 @@ public class Generator {
   private final String instanceId;
   private volatile boolean enabled = true;
   private static final long STATUS_INTERVAL_MS = 5000L;
+  private volatile long lastStatusTs = System.currentTimeMillis();
 
   public Generator(RabbitTemplate rabbit,
                    @Qualifier("instanceId") String instanceId) {
@@ -56,7 +57,10 @@ public class Generator {
 
   @Scheduled(fixedRate = STATUS_INTERVAL_MS)
   public void status() {
-    long tps = counter.getAndSet(0) * 1000 / STATUS_INTERVAL_MS;
+    long now = System.currentTimeMillis();
+    long elapsed = now - lastStatusTs;
+    lastStatusTs = now;
+    long tps = elapsed > 0 ? counter.getAndSet(0) * 1000 / elapsed : 0;
     sendStatusDelta(tps);
   }
 

--- a/moderator-service/src/main/java/io/pockethive/moderator/Moderator.java
+++ b/moderator-service/src/main/java/io/pockethive/moderator/Moderator.java
@@ -28,6 +28,7 @@ public class Moderator {
   private final String instanceId;
   private volatile boolean enabled = true;
   private static final long STATUS_INTERVAL_MS = 5000L;
+  private volatile long lastStatusTs = System.currentTimeMillis();
 
   public Moderator(RabbitTemplate rabbit,
                    @Qualifier("instanceId") String instanceId) {
@@ -56,7 +57,10 @@ public class Moderator {
 
   @Scheduled(fixedRate = STATUS_INTERVAL_MS)
   public void status() {
-    long tps = counter.getAndSet(0) * 1000 / STATUS_INTERVAL_MS;
+    long now = System.currentTimeMillis();
+    long elapsed = now - lastStatusTs;
+    lastStatusTs = now;
+    long tps = elapsed > 0 ? counter.getAndSet(0) * 1000 / elapsed : 0;
     sendStatusDelta(tps);
   }
 

--- a/processor-service/src/main/java/io/pockethive/processor/Processor.java
+++ b/processor-service/src/main/java/io/pockethive/processor/Processor.java
@@ -29,6 +29,7 @@ public class Processor {
   private final String instanceId;
   private volatile boolean enabled = true;
   private static final long STATUS_INTERVAL_MS = 5000L;
+  private volatile long lastStatusTs = System.currentTimeMillis();
 
   public Processor(RabbitTemplate rabbit,
                    @Qualifier("instanceId") String instanceId){
@@ -63,7 +64,10 @@ public class Processor {
 
   @Scheduled(fixedRate = STATUS_INTERVAL_MS)
   public void status(){
-    long tps = counter.getAndSet(0) * 1000 / STATUS_INTERVAL_MS;
+    long now = System.currentTimeMillis();
+    long elapsed = now - lastStatusTs;
+    lastStatusTs = now;
+    long tps = elapsed > 0 ? counter.getAndSet(0) * 1000 / elapsed : 0;
     sendStatusDelta(tps);
   }
 


### PR DESCRIPTION
## Summary
- compute TPS as messages-per-second based on the 5s status interval
- apply consistent interval constant across generator, moderator, and processor

## Testing
- `mvn -q test` *(fails: dependencies missing / network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d0f35b4883289e840a868c7d2d79