### PR TITLE
feat: publish error rate metrics

### DIFF
--- a/log-aggregator-service/src/main/java/io/pockethive/Topology.java
+++ b/log-aggregator-service/src/main/java/io/pockethive/Topology.java
@@ -3,6 +3,7 @@ package io.pockethive;
 public class Topology {
   public static final String LOGS_EXCHANGE = cfg("PH_LOGS_EXCHANGE", "logs.exchange");
   public static final String LOGS_QUEUE = cfg("PH_LOGS_QUEUE", "logs.agg");
+  public static final String METRICS_EXCHANGE = cfg("PH_METRICS_EXCHANGE", "ph.metrics");
 
   private static String cfg(String key, String def){
     String v = System.getenv(key);

--- a/log-aggregator-service/src/main/java/io/pockethive/logaggregator/LogAggregator.java
+++ b/log-aggregator-service/src/main/java/io/pockethive/logaggregator/LogAggregator.java
@@ -1,21 +1,25 @@
 package io.pockethive.logaggregator;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.net.URI;
+import java.net.URLEncoder;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.nio.charset.StandardCharsets;
 
 @Component
 @EnableScheduling
@@ -25,19 +29,33 @@ public class LogAggregator {
   private final Queue<LogEntry> buffer = new ConcurrentLinkedQueue<>();
   private final HttpClient http = HttpClient.newHttpClient();
   private final URI lokiUri;
+  private final URI lokiQueryUri;
   private final int maxRetries;
   private final long backoffMs;
   private final int batchSize;
+  private final RabbitTemplate rabbit;
+  private final String metricsExchange;
+  private final String metricsRk;
+  private final String grafanaBase;
 
   public LogAggregator(
+      RabbitTemplate rabbit,
       @Value("${ph.loki.url:http://loki:3100}") String lokiBase,
       @Value("${ph.loki.maxRetries:3}") int maxRetries,
       @Value("${ph.loki.backoffMs:500}") long backoffMs,
-      @Value("${ph.loki.batchSize:100}") int batchSize) {
+      @Value("${ph.loki.batchSize:100}") int batchSize,
+      @Value("${ph.metrics.exchange:ph.metrics}") String metricsExchange,
+      @Value("${ph.metrics.errorRateRk:metrics.error-rate}") String metricsRk,
+      @Value("${ph.grafana.url:http://grafana:3000}") String grafanaBase) {
+    this.rabbit = rabbit;
     this.lokiUri = URI.create(lokiBase + "/loki/api/v1/push");
+    this.lokiQueryUri = URI.create(lokiBase + "/loki/api/v1/query");
     this.maxRetries = maxRetries;
     this.backoffMs = backoffMs;
     this.batchSize = batchSize;
+    this.metricsExchange = metricsExchange;
+    this.metricsRk = metricsRk;
+    this.grafanaBase = grafanaBase.endsWith("/") ? grafanaBase.substring(0, grafanaBase.length()-1) : grafanaBase;
   }
 
   @RabbitListener(queues = "${ph.logsQueue:logs.agg}")
@@ -60,6 +78,66 @@ public class LogAggregator {
     if(batch.isEmpty()) return;
     Map<String,Object> payload = toPayload(batch);
     send(payload);
+  }
+
+  @Scheduled(fixedRateString = "${ph.metrics.errorRateIntervalMs:60000}")
+  public void errorRate(){
+    try{
+      Map<String,Map<String,Long>> counts = new HashMap<>();
+      Map<String,Long> totals = new HashMap<>();
+      for(String w : List.of("1m","5m","15m")){
+        JsonNode res = query("sum by (service)(count_over_time({level=\"error\"}["+w+"]))");
+        long tot=0;
+        for(JsonNode r : res){
+          String svc = r.path("metric").path("service").asText();
+          long v = r.path("value").path(1).asLong();
+          counts.computeIfAbsent(svc,k->new HashMap<>()).put(w,v);
+          tot += v;
+        }
+        totals.put(w, tot);
+      }
+      Map<String,List<String>> tops = new HashMap<>();
+      JsonNode topRes = query("topk(3, count_over_time({level=\"error\"} | regexp \"(?P<exception>[\\w.]+Exception)\"[15m])) by (service,exception)");
+      for(JsonNode r : topRes){
+        String svc = r.path("metric").path("service").asText();
+        String ex = r.path("metric").path("exception").asText();
+        tops.computeIfAbsent(svc,k->new ArrayList<>()).add(ex);
+      }
+      Map<String,Object> comps = new LinkedHashMap<>();
+      for(var e : counts.entrySet()){
+        String svc = e.getKey();
+        Map<String,Long> c = e.getValue();
+        long c1 = c.getOrDefault("1m",0L);
+        long c5 = c.getOrDefault("5m",0L);
+        long c15 = c.getOrDefault("15m",0L);
+        Map<String,Object> comp = new LinkedHashMap<>();
+        comp.put("counts", Map.of("1m",c1,"5m",c5,"15m",c15));
+        comp.put("rates", Map.of("1m",c1/60d,"5m",c5/300d,"15m",c15/900d));
+        comp.put("top", tops.getOrDefault(svc, List.of()));
+        String state = c1==0?"OK": c1<5?"WARN":"CRIT";
+        comp.put("state", state);
+        String q = URLEncoder.encode("{service=\""+svc+"\",level=\"error\"}", StandardCharsets.UTF_8);
+        comp.put("grafana", grafanaBase + "/explore?query=" + q);
+        comps.put(svc, comp);
+      }
+      Map<String,Object> payload = new LinkedHashMap<>();
+      payload.put("ts", Instant.now().toString());
+      payload.put("totals", totals);
+      payload.put("components", comps);
+      String json = mapper.writeValueAsString(payload);
+      rabbit.convertAndSend(metricsExchange, metricsRk, json);
+    }catch(Exception e){
+      log.warn("error-rate", e);
+    }
+  }
+
+  private JsonNode query(String q) throws Exception {
+    String url = lokiQueryUri + "?query=" + URLEncoder.encode(q, StandardCharsets.UTF_8);
+    HttpRequest req = HttpRequest.newBuilder().uri(URI.create(url)).GET().build();
+    HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+    if(resp.statusCode()/100!=2) throw new RuntimeException("HTTP "+resp.statusCode()+": "+resp.body());
+    JsonNode root = mapper.readTree(resp.body());
+    return root.path("data").path("result");
   }
 
   private Map<String,Object> toPayload(List<LogEntry> logs){

--- a/log-aggregator-service/src/main/java/io/pockethive/logaggregator/LogEntry.java
+++ b/log-aggregator-service/src/main/java/io/pockethive/logaggregator/LogEntry.java
@@ -1,3 +1,8 @@
 package io.pockethive.logaggregator;
 
-public record LogEntry(String service, String traceId, String level, String message, String timestamp) {}
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record LogEntry(String service, String traceId, String level, String message,
+                       @JsonAlias("@timestamp") String timestamp) {}

--- a/log-aggregator-service/src/main/java/io/pockethive/logaggregator/RabbitConfig.java
+++ b/log-aggregator-service/src/main/java/io/pockethive/logaggregator/RabbitConfig.java
@@ -10,4 +10,5 @@ public class RabbitConfig {
   @Bean TopicExchange logsExchange(){ return new TopicExchange(Topology.LOGS_EXCHANGE, true, false); }
   @Bean Queue logQueue(){ return QueueBuilder.durable(Topology.LOGS_QUEUE).build(); }
   @Bean Binding bindLogs(){ return BindingBuilder.bind(logQueue()).to(logsExchange()).with("#"); }
+  @Bean TopicExchange metricsExchange(){ return new TopicExchange(Topology.METRICS_EXCHANGE, true, false); }
 }

--- a/log-aggregator-service/src/main/resources/application.yml
+++ b/log-aggregator-service/src/main/resources/application.yml
@@ -16,3 +16,9 @@ ph:
     backoffMs: ${PH_LOKI_BACKOFF_MS:500}
     batchSize: ${PH_LOKI_BATCH_SIZE:100}
     flushIntervalMs: ${PH_LOKI_FLUSH_INTERVAL_MS:1000}
+  metrics:
+    exchange: ${PH_METRICS_EXCHANGE:ph.metrics}
+    errorRateRk: ${PH_METRICS_ERROR_RATE_RK:metrics.error-rate}
+    errorRateIntervalMs: ${PH_METRICS_ERROR_RATE_INTERVAL_MS:60000}
+  grafana:
+    url: ${PH_GRAFANA_URL:http://grafana:3000}

--- a/ui/assets/js/features/stompClient.js
+++ b/ui/assets/js/features/stompClient.js
@@ -1,9 +1,10 @@
-export function setupStompClient(onStatusFull) {
+export function setupStompClient(onStatusFull, onErrorRate) {
   const client = new StompJs.Client({
     brokerURL: (location.protocol === 'https:' ? 'wss://' : 'ws://') + location.host + '/ws'
   });
   client.onConnect = () => {
     client.subscribe('/exchange/ph.control/ev.status-full.#', onStatusFull);
+    if (onErrorRate) client.subscribe('/exchange/ph.metrics/metrics.error-rate', onErrorRate);
     try {
       const payload = { type: 'status-request', timestamp: new Date().toISOString() };
       client.publish({ destination: '/exchange/ph.control/sig.status-request', body: JSON.stringify(payload) });

--- a/ui/assets/js/main.js
+++ b/ui/assets/js/main.js
@@ -5,6 +5,7 @@ import { initPanel, showPanel } from './features/panelRenderer.js';
 const panels = { generator: {}, moderator: {}, processor: {}, postprocessor: {} };
 const instances = {};
 const loaded = { generator: {}, moderator: {}, processor: {}, postprocessor: {} };
+const errCache = {};
 
 const modal = document.getElementById('panel-modal');
 const modalBody = document.getElementById('panel-body');
@@ -22,7 +23,18 @@ function handleStatusFull(msg) {
       if (!loaded[role][inst]) {
         loaded[role][inst] = true;
         // seed panel with the snapshot that announced the instance
-        initPanel(panels, role, inst, body);
+        initPanel(panels, role, inst, body).then(() => {
+          const err = errCache[role];
+          if (err) {
+            const el = panels[role][inst];
+            if (el) {
+              const rEl = el.querySelector('[data-field="err-rate"]');
+              const sEl = el.querySelector('[data-field="err-state"]');
+              if (rEl) rEl.textContent = (typeof err.rate === 'number') ? err.rate.toFixed(2) : '';
+              if (sEl) sEl.textContent = err.state || '';
+            }
+          }
+        });
       }
     }
   } catch (e) {
@@ -30,7 +42,28 @@ function handleStatusFull(msg) {
   }
 }
 
-const client = setupStompClient(handleStatusFull);
+function handleErrorRate(msg) {
+  try {
+    const body = JSON.parse(msg.body || '{}');
+    const comps = body.components || {};
+    for (const [svc, obj] of Object.entries(comps)) {
+      const rate = obj && obj.rates && obj.rates['1m'];
+      const state = obj && obj.state;
+      errCache[svc] = { rate, state };
+      const rolePanels = panels[svc] || {};
+      for (const el of Object.values(rolePanels)) {
+        const rEl = el.querySelector('[data-field="err-rate"]');
+        const sEl = el.querySelector('[data-field="err-state"]');
+        if (rEl) rEl.textContent = (typeof rate === 'number') ? rate.toFixed(2) : '';
+        if (sEl) sEl.textContent = state || '';
+      }
+    }
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+const client = setupStompClient(handleStatusFull, handleErrorRate);
 window.phClient = client;
 
 function phShowPanel(role) {

--- a/ui/modules/common.js
+++ b/ui/modules/common.js
@@ -13,6 +13,11 @@ function setupCommonInfo(infoEl){
       <div class="status-item"><span class="label">Routes</span><span class="value" data-field="ctrl-routes"></span></div>
       <div class="status-item"><span class="label">Publishes</span><span class="value" data-field="ctrl-out"></span></div>
     </div>
+    <div class="block-title">Errors</div>
+    <div class="status-block error-block">
+      <div class="status-item"><span class="label">Rate</span><span class="value" data-field="err-rate"></span></div>
+      <div class="status-item"><span class="label">State</span><span class="value" data-field="err-state"></span></div>
+    </div>
     <div class="block-title">Config</div>
     <div class="config-block" data-field="cfg"></div>
   `;
@@ -23,6 +28,8 @@ function setupCommonInfo(infoEl){
     ctrlInEl: infoEl.querySelector('[data-field="ctrl-in"]'),
     ctrlRoutesEl: infoEl.querySelector('[data-field="ctrl-routes"]'),
     ctrlOutEl: infoEl.querySelector('[data-field="ctrl-out"]'),
+    errRateEl: infoEl.querySelector('[data-field="err-rate"]'),
+    errStateEl: infoEl.querySelector('[data-field="err-state"]'),
     cfgEl: infoEl.querySelector('[data-field="cfg"]')
   };
 }


### PR DESCRIPTION
## Summary
- query Loki for recent error counts and publish aggregated error-rate metrics to RabbitMQ
- expose Grafana links and error state per component
- surface error-rate metrics in Hive component panels

## Testing
- `mvn -q -pl log-aggregator-service test` *(fails: Non-resolvable import POM: Network is unreachable)*
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b63c1e1a0c8328947e89e0a07ffca2