### PR TITLE
docs: describe runtime controls and tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@
 - UI connects to RabbitMQ via same‑origin Web‑STOMP proxy at `/ws`.
 - Services publish/consume via the `ph.hive` exchange and `ph.gen`/`ph.mod` queues.
 - Metrics/status flow back on the `ph.control` exchange, with each service auto-declaring a durable `ph.control.<role>.<instance>` queue for broadcasts and direct signals.
+- Logs emitted by the services are routed to `logs.exchange` and consumed by the log‑aggregator, which batches them to Loki.
+- Services propagate an `x-ph-trace` header to record trace IDs and hop timing across the flow.
 
 ### Control-plane Events & Signals
 
@@ -56,6 +58,7 @@ See also: Control Bindings page (Menu → Control Bindings) and `ui/spec/asyncap
 - `grafana` (dashboard): 3000 (admin / admin)
 - `loki` (log store): 3100
 - `promtail` (log shipper): 9080
+- `log-aggregator` (RabbitMQ → Loki): internal
 - `wiremock` (HTTP stub server for NFT tests; journal disabled): 8080
 
 ## Quick Start
@@ -84,12 +87,18 @@ docker compose up -d --build
 - Prometheus: http://localhost:9090
 - Grafana: http://localhost:3000 (admin / admin) with Prometheus and Loki datasources and a "Loki Logs" dashboard for viewing application logs
 - Prometheus scrapes metrics from `postprocessor` at `/actuator/prometheus`.
+- The log‑aggregator service consumes log events from RabbitMQ and pushes them to Loki.
 
 ## Service Configuration
 
-- **Generator** builds HTTP requests from `ph.gen.message.*` settings. Defaults send a `POST /api/test` with body `hello-world` and no headers.
-- **Processor** reads `ph.proc.base-url` to determine the downstream base URL, defaulting to `http://wiremock`.
-- The UI exposes dedicated sections for both settings, and changes take effect only after pressing **Confirm Changes**.
+Services accept `config-update` messages on the control exchange to adjust behaviour at runtime:
+
+- **Generator** builds HTTP requests from `ph.gen.message.*` settings. Defaults send a `POST /api/test` with body `hello-world` and no headers. Config updates can start or stop generation, change `ratePerSec`, fire a one-off request, or modify the request method, path, headers, and body.
+- **Moderator** forwards messages from the generator when enabled. A `config-update` can toggle moderation on or off.
+- **Processor** reads `ph.proc.base-url` to determine the downstream base URL, defaulting to `http://wiremock`. Config updates may enable/disable processing or override `baseUrl` without restarts.
+- **Postprocessor** records hop and total latency metrics and error counts before emitting them as metric events. It can also be disabled via `config-update`.
+- All services propagate an `x-ph-trace` header to capture trace IDs and hop timing across the pipeline.
+- The UI exposes dedicated sections for generator and processor settings, and changes take effect only after pressing **Confirm Changes**.
 
 ## WebSocket Proxy (UI ←→ RabbitMQ)
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -9,6 +9,7 @@ PocketHive is a portable transaction swarm: a set of small, composable services 
 - Control-plane messaging flows through the `ph.control` exchange using `sig.*` routing keys for commands and `ev.*` for status or metrics.
 - Each service exposes its presence and health through periodic `status-delta` events and responds to `status-request` signals.
 - The UI connects to RabbitMQ over same-origin Web-STOMP at `/ws`.
+- Services propagate an `x-ph-trace` header to carry trace IDs and hop timing between components.
 
 ## Component Requirements
 
@@ -25,6 +26,7 @@ PocketHive is a portable transaction swarm: a set of small, composable services 
 - Produces HTTP-like transaction messages at a configurable rate per second.
 - Publishes generated messages to the `ph.hive` exchange routed to the `ph.gen` queue.
 - Processes control messages to enable/disable generation, adjust rate, issue single requests, and respond to `status-request`.
+- Control messages can also update request method, path, headers, and body at runtime.
 - Emits `status-delta` every 5 s and `status-full` on startup or when requested.
 
 ### Moderator Service
@@ -35,6 +37,7 @@ PocketHive is a portable transaction swarm: a set of small, composable services 
 ### Processor Service
 - Consumes moderated messages, appends observability context, and forwards to the final queue.
 - Supports enable/disable via control messages and replies to `status-request`.
+- Control messages may override the downstream `baseUrl` without requiring a restart.
 - Emits periodic `status-delta` and startup `status-full` events.
 
 ### PostProcessor Service


### PR DESCRIPTION
## Summary
- detail runtime `config-update` controls for generator, moderator, processor, and postprocessor
- document `x-ph-trace` header propagation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6e5cc111c8328bc055c96af20a589