### PR TITLE
Fix SUT panel fetching

### DIFF
--- a/ui/assets/js/menus/hive.js
+++ b/ui/assets/js/menus/hive.js
@@ -272,13 +272,11 @@ export function initHiveMenu() {
     modal.style.display = 'flex';
   }
   function setSutUrl(url) {
+    hive.sutUrl = url;
     try {
       const u = new URL(url, window.location.href);
       hive.sutWiremock = /wiremock/i.test(u.hostname);
-      u.hostname = window.location.hostname;
-      hive.sutUrl = u.toString();
     } catch {
-      hive.sutUrl = url;
       hive.sutWiremock = false;
     }
     redrawHive();

--- a/ui/modules/sut.js
+++ b/ui/modules/sut.js
@@ -1,7 +1,12 @@
 export function renderSutPanel(containerEl, baseUrl) {
-  const display = (baseUrl || '').replace(/\/$/, '');
-  const adminUrl = new URL('/wiremock/__admin', window.location.origin).toString();
-  const reqUrl = new URL('/wiremock/__admin/requests?limit=25', window.location.origin).toString();
+  const base = baseUrl ? new URL(baseUrl, window.location.href) : null;
+  const display = (base ? base.toString() : '').replace(/\/$/, '');
+  const adminUrl = base
+    ? new URL('__admin', base).toString()
+    : new URL('/wiremock/__admin', window.location.origin).toString();
+  const reqUrl = base
+    ? new URL('__admin/requests?limit=25', base).toString()
+    : new URL('/wiremock/__admin/requests?limit=25', window.location.origin).toString();
   containerEl.innerHTML = `
     <div class="card" data-role="sut">
       <h3>WireMock – <a href="${display}" target="_blank" rel="noopener">${display}</a></h3>


### PR DESCRIPTION
## Summary
- use provided SUT base URL for WireMock admin and request fetches
- keep original SUT URL instead of replacing hostname

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b75aaee2dc832896ebea8e34e1193a