### PR TITLE
Set WireMock locale to avoid MissingResourceException

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,6 +159,7 @@ services:
         "--enable-cors",                  # allow cross-origin access
       ]
     environment:
+      LANG: en_US.UTF-8
       JAVA_OPTS: >-
         -XX:+UseG1GC
         -XX:+ParallelRefProcEnabled


### PR DESCRIPTION
## Summary
- set LANG to `en_US.UTF-8` for WireMock container to ensure locale resources are available and prevent startup errors

## Testing
- `npm test`
- `mvn -q test` *(fails: dependencies could not be resolved; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b802783428832886c2dbe2e8fe7dda