### PR TITLE
Align control spec and UI with Java status messages

### DIFF
--- a/spec/asyncapi.yaml
+++ b/spec/asyncapi.yaml
@@ -36,7 +36,7 @@ channels:
         description: Service role
         schema:
           type: string
-          enum: [generator, moderator, processor]
+          enum: [generator, moderator, processor, postprocessor, trigger]
       instance:
         description: Instance identifier (UUID or unique string)
         schema:
@@ -68,7 +68,7 @@ channels:
         schema: { type: string, enum: [status-request, config-update, ping, link-request] }
       role:
         description: Target role (optional)
-        schema: { type: string, enum: [generator, moderator, processor] }
+        schema: { type: string, enum: [generator, moderator, processor, postprocessor, trigger] }
       instance:
         description: Target instance (optional)
         schema: { type: string }
@@ -151,17 +151,34 @@ components:
         event: { type: string, enum: [status, lifecycle, metric, alert, link] }
         kind: { type: string, description: Subtype (e.g., status-full, status-delta, lifecycle.running) }
         version: { type: string, description: Semver of event schema }
-        role: { type: string, enum: [generator, moderator, processor] }
+        role: { type: string, enum: [generator, moderator, processor, postprocessor, trigger] }
         instance: { type: string }
         location: { type: string }
         messageId: { type: string, format: uuid }
         timestamp: { type: string, format: date-time }
+        enabled: { type: boolean }
         traffic: { type: string }
+        inQueue:
+          type: object
+          properties:
+            name: { type: string }
+            routingKeys: { type: array, items: { type: string } }
+        publishes: { type: array, items: { type: string } }
         queues:
           type: object
           properties:
-            in:  { type: array, items: { type: string } }
-            out: { type: array, items: { type: string } }
+            work:
+              type: object
+              properties:
+                in: { type: array, items: { type: string } }
+                out: { type: array, items: { type: string } }
+                routes: { type: array, items: { type: string } }
+            control:
+              type: object
+              properties:
+                in: { type: array, items: { type: string } }
+                out: { type: array, items: { type: string } }
+                routes: { type: array, items: { type: string } }
         data: { type: object, additionalProperties: true }
 
     ControlStatusFullPayload:

--- a/spec/control-events.schema.json
+++ b/spec/control-events.schema.json
@@ -8,17 +8,40 @@
     "event": { "type": "string", "enum": ["status", "lifecycle", "metric", "alert", "link"] },
     "kind": { "type": "string" },
     "version": { "type": "string" },
-    "role": { "type": "string", "enum": ["generator", "moderator", "processor"] },
+    "role": { "type": "string", "enum": ["generator", "moderator", "processor", "postprocessor", "trigger"] },
     "instance": { "type": "string" },
     "location": { "type": "string" },
     "messageId": { "type": "string", "format": "uuid" },
     "timestamp": { "type": "string", "format": "date-time" },
+    "enabled": { "type": "boolean" },
     "traffic": { "type": "string" },
+    "inQueue": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" },
+        "routingKeys": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "publishes": { "type": "array", "items": { "type": "string" } },
     "queues": {
       "type": "object",
       "properties": {
-        "in":  { "type": "array", "items": { "type": "string" } },
-        "out": { "type": "array", "items": { "type": "string" } }
+        "work": {
+          "type": "object",
+          "properties": {
+            "in": { "type": "array", "items": { "type": "string" } },
+            "out": { "type": "array", "items": { "type": "string" } },
+            "routes": { "type": "array", "items": { "type": "string" } }
+          }
+        },
+        "control": {
+          "type": "object",
+          "properties": {
+            "in": { "type": "array", "items": { "type": "string" } },
+            "out": { "type": "array", "items": { "type": "string" } },
+            "routes": { "type": "array", "items": { "type": "string" } }
+          }
+        }
       }
     },
     "data": { "type": "object", "additionalProperties": true }

--- a/ui/src/lib/stompClient.ts
+++ b/ui/src/lib/stompClient.ts
@@ -53,11 +53,18 @@ export function setClient(newClient: Client | null, destination = controlDestina
         comp.version = evt.version
         comp.lastHeartbeat = new Date(evt.timestamp).getTime()
         comp.status = evt.kind
-        if (evt.queues) {
-          comp.queues = [
-            ...(evt.queues.in?.map((q: string) => ({ name: q, role: 'consumer' as const })) ?? []),
-            ...(evt.queues.out?.map((q: string) => ({ name: q, role: 'producer' as const })) ?? []),
-          ]
+        if (evt.queues || evt.inQueue) {
+          const q: { name: string; role: 'producer' | 'consumer' }[] = []
+          if (evt.queues) {
+            q.push(...(evt.queues.work?.in?.map((n) => ({ name: n, role: 'consumer' as const })) ?? []))
+            q.push(...(evt.queues.work?.out?.map((n) => ({ name: n, role: 'producer' as const })) ?? []))
+            q.push(...(evt.queues.control?.in?.map((n) => ({ name: n, role: 'consumer' as const })) ?? []))
+            q.push(...(evt.queues.control?.out?.map((n) => ({ name: n, role: 'producer' as const })) ?? []))
+          }
+          if (evt.inQueue?.name) {
+            q.push({ name: evt.inQueue.name, role: 'consumer' })
+          }
+          comp.queues = q
         }
         components[id] = comp
         listeners.forEach((l) => l(Object.values(components)))

--- a/ui/src/types/control.ts
+++ b/ui/src/types/control.ts
@@ -2,15 +2,29 @@ export interface ControlEvent {
   event: 'status' | 'lifecycle' | 'metric' | 'alert' | 'link';
   kind: string;
   version: string;
-  role: 'generator' | 'moderator' | 'processor';
+  role: 'generator' | 'moderator' | 'processor' | 'postprocessor' | 'trigger';
   instance: string;
   location?: string;
   messageId: string;
   timestamp: string;
+  enabled?: boolean;
   traffic?: string;
+  inQueue?: {
+    name: string;
+    routingKeys?: string[];
+  };
+  publishes?: string[];
   queues?: {
-    in?: string[];
-    out?: string[];
+    work?: {
+      in?: string[];
+      out?: string[];
+      routes?: string[];
+    };
+    control?: {
+      in?: string[];
+      out?: string[];
+      routes?: string[];
+    };
   };
   data?: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary
- Expand control spec to include all service roles and nested queue topology fields
- Update JSON schema and TypeScript types for new status fields (enabled, inQueue, publishes, work/control queues)
- Adjust STOMP client parsing to collect queues from nested structures

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b898b0538c83288ab5efa7117e369a