### PR TITLE
feat: add bee name generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,10 +178,12 @@ docker compose up -d --build
 
 Every service generates a whimsical "bee name" when it starts to make log lines and metrics
 easier to trace back to a specific instance. Names follow the pattern
-`<Role> Bee <FunnyName>-<ID>` where `<ID>` is a random four character segment of a UUID
-for uniqueness. The chosen name is logged on startup and exposed through the
-`/actuator/info` endpoint under `beeName`. Future services should call
-`BeeNameGenerator.generate()` from the `observability` module to stay consistent.
+`<role>-bee-<funny1>-<funny2>-<id>` where `role` matches the component type and `id` is a
+random four character segment of a UUID for uniqueness. The two `funny` parts are chosen from
+predefined lists to maximize variety while avoiding spaces or `. # *`. The chosen name is
+logged on startup and exposed through the `/actuator/info` endpoint under `beeName`. Future
+services should call `BeeNameGenerator.generate("<role>")` from the `observability` module
+to stay consistent.
 
 ## Service Configuration
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ The legacy static interface now lives under `UI-Legacy` for reference. A new Rea
 - Events (topic): `ev.{kind}.{role}.{instance}`
   - `kind`: `status-full`, `status-delta`, `lifecycle.*`, `metric.*`, `alert`
   - `role`: `generator|moderator|processor`
-  - `instance`: UUID/unique ID
+  - `instance`: bee name generated on startup
   - Envelope fields: `event, kind, version, role, instance, messageId, timestamp, queues{in,out}? , data`
 - Signals (topic-friendly): `sig.<type>[.<role>[.<instance>]]`
   - Types are single-segment (no dots): `status-request`, `config-update`, `ping`, `link-request`
@@ -173,6 +173,15 @@ docker compose up -d --build
 - Grafana: http://localhost:3000 (admin / admin) with Prometheus and Loki datasources
 - Prometheus scrapes metrics from `postprocessor` at `/actuator/prometheus`.
 - The log‑aggregator service consumes log events from RabbitMQ and pushes them to Loki.
+
+## Service Naming
+
+Every service generates a whimsical "bee name" when it starts to make log lines and metrics
+easier to trace back to a specific instance. Names follow the pattern
+`<Role> Bee <FunnyName>-<ID>` where `<ID>` is a random four character segment of a UUID
+for uniqueness. The chosen name is logged on startup and exposed through the
+`/actuator/info` endpoint under `beeName`. Future services should call
+`BeeNameGenerator.generate()` from the `observability` module to stay consistent.
 
 ## Service Configuration
 

--- a/README.md
+++ b/README.md
@@ -178,12 +178,20 @@ docker compose up -d --build
 
 Every service generates a whimsical "bee name" when it starts to make log lines and metrics
 easier to trace back to a specific instance. Names follow the pattern
-`<role>-bee-<funny1>-<funny2>-<id>` where `role` matches the component type and `id` is a
-random four character segment of a UUID for uniqueness. The two `funny` parts are chosen from
-predefined lists to maximize variety while avoiding spaces or `. # *`. The chosen name is
-logged on startup and exposed through the `/actuator/info` endpoint under `beeName`. Future
-services should call `BeeNameGenerator.generate("<role>")` from the `observability` module
-to stay consistent.
+`<bee-role>-bee-<funny1>-<funny2>-<id>` where `bee-role` is a themed alias for the component type and `id`
+is a random four character segment of a UUID for uniqueness. The mapping is:
+
+- generator → seeder
+- moderator → guardian
+- processor → worker
+- postprocessor → forager
+- trigger → herald
+- log-aggregator → scribe
+
+The two `funny` parts are chosen from predefined lists to maximize variety while avoiding spaces
+or `. # *`. The chosen name is logged on startup and exposed through the `/actuator/info` endpoint
+under `beeName`. Future services should call `BeeNameGenerator.generate("<role>")` from the
+`observability` module; the utility applies the mapping automatically to stay consistent.
 
 ## Service Configuration
 

--- a/generator-service/src/main/java/io/pockethive/generator/Application.java
+++ b/generator-service/src/main/java/io/pockethive/generator/Application.java
@@ -16,7 +16,7 @@ public class Application {
   private static final Logger log = LoggerFactory.getLogger(Application.class);
 
   public static void main(String[] args){
-    String beeName = BeeNameGenerator.generate();
+    String beeName = BeeNameGenerator.generate("generator");
     System.setProperty("bee.name", beeName);
     log.info("Bee name: {}", beeName);
     SpringApplication.run(Application.class, args);

--- a/generator-service/src/main/java/io/pockethive/generator/Application.java
+++ b/generator-service/src/main/java/io/pockethive/generator/Application.java
@@ -1,11 +1,29 @@
 package io.pockethive.generator;
 
+import io.pockethive.util.BeeNameGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.info.InfoContributor;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @EnableRabbit
 @SpringBootApplication
 public class Application {
-  public static void main(String[] args){ SpringApplication.run(Application.class, args); }
+
+  private static final Logger log = LoggerFactory.getLogger(Application.class);
+
+  public static void main(String[] args){
+    String beeName = BeeNameGenerator.generate();
+    System.setProperty("bee.name", beeName);
+    log.info("Bee name: {}", beeName);
+    SpringApplication.run(Application.class, args);
+  }
+
+  @Bean
+  InfoContributor beeInfoContributor() {
+    return (builder) -> builder.withDetail("beeName", System.getProperty("bee.name"));
+  }
 }

--- a/generator-service/src/main/java/io/pockethive/generator/RabbitConfig.java
+++ b/generator-service/src/main/java/io/pockethive/generator/RabbitConfig.java
@@ -6,14 +6,16 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.UUID;
+import io.pockethive.util.BeeNameGenerator;
 
 @Configuration
 public class RabbitConfig {
   private static final String ROLE = "generator";
 
   @Bean
-  public String instanceId(){ return UUID.randomUUID().toString(); }
+  public String instanceId(){
+    return System.getProperty("bee.name", BeeNameGenerator.generate());
+  }
 
   @Bean
   TopicExchange direct(){ return new TopicExchange(Topology.EXCHANGE, true, false); }

--- a/generator-service/src/main/java/io/pockethive/generator/RabbitConfig.java
+++ b/generator-service/src/main/java/io/pockethive/generator/RabbitConfig.java
@@ -14,7 +14,7 @@ public class RabbitConfig {
 
   @Bean
   public String instanceId(){
-    return System.getProperty("bee.name", BeeNameGenerator.generate());
+    return System.getProperty("bee.name", BeeNameGenerator.generate(ROLE));
   }
 
   @Bean

--- a/log-aggregator-service/pom.xml
+++ b/log-aggregator-service/pom.xml
@@ -40,6 +40,11 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.pockethive</groupId>
+      <artifactId>observability</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>net.logstash.logback</groupId>
       <artifactId>logstash-logback-encoder</artifactId>
       <version>${logstash.logback.version}</version>

--- a/log-aggregator-service/src/main/java/io/pockethive/logaggregator/Application.java
+++ b/log-aggregator-service/src/main/java/io/pockethive/logaggregator/Application.java
@@ -1,13 +1,29 @@
 package io.pockethive.logaggregator;
 
+import io.pockethive.util.BeeNameGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.info.InfoContributor;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @EnableRabbit
 @SpringBootApplication
 public class Application {
+
+  private static final Logger log = LoggerFactory.getLogger(Application.class);
+
   public static void main(String[] args){
+    String beeName = BeeNameGenerator.generate();
+    System.setProperty("bee.name", beeName);
+    log.info("Bee name: {}", beeName);
     SpringApplication.run(Application.class, args);
+  }
+
+  @Bean
+  InfoContributor beeInfoContributor() {
+    return (builder) -> builder.withDetail("beeName", System.getProperty("bee.name"));
   }
 }

--- a/log-aggregator-service/src/main/java/io/pockethive/logaggregator/Application.java
+++ b/log-aggregator-service/src/main/java/io/pockethive/logaggregator/Application.java
@@ -16,7 +16,7 @@ public class Application {
   private static final Logger log = LoggerFactory.getLogger(Application.class);
 
   public static void main(String[] args){
-    String beeName = BeeNameGenerator.generate();
+    String beeName = BeeNameGenerator.generate("log-aggregator");
     System.setProperty("bee.name", beeName);
     log.info("Bee name: {}", beeName);
     SpringApplication.run(Application.class, args);

--- a/moderator-service/src/main/java/io/pockethive/moderator/Application.java
+++ b/moderator-service/src/main/java/io/pockethive/moderator/Application.java
@@ -1,13 +1,29 @@
 package io.pockethive.moderator;
 
+import io.pockethive.util.BeeNameGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.info.InfoContributor;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @EnableRabbit
 @SpringBootApplication
 public class Application {
+
+  private static final Logger log = LoggerFactory.getLogger(Application.class);
+
   public static void main(String[] args) {
+    String beeName = BeeNameGenerator.generate();
+    System.setProperty("bee.name", beeName);
+    log.info("Bee name: {}", beeName);
     SpringApplication.run(Application.class, args);
+  }
+
+  @Bean
+  InfoContributor beeInfoContributor() {
+    return (builder) -> builder.withDetail("beeName", System.getProperty("bee.name"));
   }
 }

--- a/moderator-service/src/main/java/io/pockethive/moderator/Application.java
+++ b/moderator-service/src/main/java/io/pockethive/moderator/Application.java
@@ -16,7 +16,7 @@ public class Application {
   private static final Logger log = LoggerFactory.getLogger(Application.class);
 
   public static void main(String[] args) {
-    String beeName = BeeNameGenerator.generate();
+    String beeName = BeeNameGenerator.generate("moderator");
     System.setProperty("bee.name", beeName);
     log.info("Bee name: {}", beeName);
     SpringApplication.run(Application.class, args);

--- a/moderator-service/src/main/java/io/pockethive/moderator/RabbitConfig.java
+++ b/moderator-service/src/main/java/io/pockethive/moderator/RabbitConfig.java
@@ -6,14 +6,16 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.UUID;
+import io.pockethive.util.BeeNameGenerator;
 
 @Configuration
 public class RabbitConfig {
   private static final String ROLE = "moderator";
 
   @Bean
-  public String instanceId(){ return UUID.randomUUID().toString(); }
+  public String instanceId(){
+    return System.getProperty("bee.name", BeeNameGenerator.generate());
+  }
 
   @Bean
   TopicExchange direct(){ return new TopicExchange(Topology.EXCHANGE, true, false); }

--- a/moderator-service/src/main/java/io/pockethive/moderator/RabbitConfig.java
+++ b/moderator-service/src/main/java/io/pockethive/moderator/RabbitConfig.java
@@ -14,7 +14,7 @@ public class RabbitConfig {
 
   @Bean
   public String instanceId(){
-    return System.getProperty("bee.name", BeeNameGenerator.generate());
+    return System.getProperty("bee.name", BeeNameGenerator.generate(ROLE));
   }
 
   @Bean

--- a/observability/src/main/java/io/pockethive/util/BeeNameGenerator.java
+++ b/observability/src/main/java/io/pockethive/util/BeeNameGenerator.java
@@ -1,6 +1,7 @@
 package io.pockethive.util;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -41,13 +42,23 @@ public final class BeeNameGenerator {
 
   private BeeNameGenerator() {}
 
+  private static final Map<String, String> ROLE_MAP =
+      Map.of(
+          "generator", "seeder",
+          "moderator", "guardian",
+          "processor", "worker",
+          "postprocessor", "forager",
+          "trigger", "herald",
+          "log-aggregator", "scribe");
+
   public static String generate(String role) {
+    String mappedRole = ROLE_MAP.getOrDefault(role.toLowerCase(), role);
     String first = randomFrom(FIRST_PARTS);
     String second = randomFrom(SECOND_PARTS);
     String id = UUID.randomUUID().toString().substring(0, 4);
     return String.format(
         "%s-bee-%s-%s-%s",
-        sanitize(role), sanitize(first), sanitize(second), id);
+        sanitize(mappedRole), sanitize(first), sanitize(second), id);
   }
 
   private static String randomFrom(List<String> options) {

--- a/observability/src/main/java/io/pockethive/util/BeeNameGenerator.java
+++ b/observability/src/main/java/io/pockethive/util/BeeNameGenerator.java
@@ -1,0 +1,39 @@
+package io.pockethive.util;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Generates whimsical names for service instances.
+ */
+public final class BeeNameGenerator {
+
+  private static final List<String> ROLES =
+      List.of("Worker", "Forager", "Builder", "Scout", "Guard", "Nurse", "Drone", "Queen");
+
+  private static final List<String> FUNNY_NAMES =
+      List.of(
+          "Buzz",
+          "Bumble",
+          "Zippy",
+          "Sting",
+          "Waggle",
+          "Pollenator",
+          "Nectar",
+          "Fuzzy");
+
+  private BeeNameGenerator() {}
+
+  public static String generate() {
+    String role = randomFrom(ROLES);
+    String funny = randomFrom(FUNNY_NAMES);
+    String id = UUID.randomUUID().toString().substring(0, 4);
+    return String.format("%s Bee %s-%s", role, funny, id);
+  }
+
+  private static String randomFrom(List<String> options) {
+    return options.get(ThreadLocalRandom.current().nextInt(options.size()));
+  }
+}
+

--- a/observability/src/main/java/io/pockethive/util/BeeNameGenerator.java
+++ b/observability/src/main/java/io/pockethive/util/BeeNameGenerator.java
@@ -9,31 +9,53 @@ import java.util.concurrent.ThreadLocalRandom;
  */
 public final class BeeNameGenerator {
 
-  private static final List<String> ROLES =
-      List.of("Worker", "Forager", "Builder", "Scout", "Guard", "Nurse", "Drone", "Queen");
-
-  private static final List<String> FUNNY_NAMES =
+  private static final List<String> FIRST_PARTS =
       List.of(
-          "Buzz",
-          "Bumble",
-          "Zippy",
-          "Sting",
-          "Waggle",
-          "Pollenator",
-          "Nectar",
-          "Fuzzy");
+          "fuzzy",
+          "buzzy",
+          "zippy",
+          "stingy",
+          "waggle",
+          "pollen",
+          "nectar",
+          "honey",
+          "twirly",
+          "glowy",
+          "jolly",
+          "snappy");
+
+  private static final List<String> SECOND_PARTS =
+      List.of(
+          "buzz",
+          "wing",
+          "stripe",
+          "whirl",
+          "puff",
+          "wag",
+          "drone",
+          "comb",
+          "wiggle",
+          "dance",
+          "flutter",
+          "zing");
 
   private BeeNameGenerator() {}
 
-  public static String generate() {
-    String role = randomFrom(ROLES);
-    String funny = randomFrom(FUNNY_NAMES);
+  public static String generate(String role) {
+    String first = randomFrom(FIRST_PARTS);
+    String second = randomFrom(SECOND_PARTS);
     String id = UUID.randomUUID().toString().substring(0, 4);
-    return String.format("%s Bee %s-%s", role, funny, id);
+    return String.format(
+        "%s-bee-%s-%s-%s",
+        sanitize(role), sanitize(first), sanitize(second), id);
   }
 
   private static String randomFrom(List<String> options) {
     return options.get(ThreadLocalRandom.current().nextInt(options.size()));
+  }
+
+  private static String sanitize(String value) {
+    return value.replaceAll("[ .#*]", "");
   }
 }
 

--- a/postprocessor-service/src/main/java/io/pockethive/postprocessor/Application.java
+++ b/postprocessor-service/src/main/java/io/pockethive/postprocessor/Application.java
@@ -1,11 +1,29 @@
 package io.pockethive.postprocessor;
 
+import io.pockethive.util.BeeNameGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.info.InfoContributor;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @EnableRabbit
 @SpringBootApplication
 public class Application {
-  public static void main(String[] args){ SpringApplication.run(Application.class, args); }
+
+  private static final Logger log = LoggerFactory.getLogger(Application.class);
+
+  public static void main(String[] args){
+    String beeName = BeeNameGenerator.generate();
+    System.setProperty("bee.name", beeName);
+    log.info("Bee name: {}", beeName);
+    SpringApplication.run(Application.class, args);
+  }
+
+  @Bean
+  InfoContributor beeInfoContributor() {
+    return (builder) -> builder.withDetail("beeName", System.getProperty("bee.name"));
+  }
 }

--- a/postprocessor-service/src/main/java/io/pockethive/postprocessor/Application.java
+++ b/postprocessor-service/src/main/java/io/pockethive/postprocessor/Application.java
@@ -16,7 +16,7 @@ public class Application {
   private static final Logger log = LoggerFactory.getLogger(Application.class);
 
   public static void main(String[] args){
-    String beeName = BeeNameGenerator.generate();
+    String beeName = BeeNameGenerator.generate("postprocessor");
     System.setProperty("bee.name", beeName);
     log.info("Bee name: {}", beeName);
     SpringApplication.run(Application.class, args);

--- a/postprocessor-service/src/main/java/io/pockethive/postprocessor/RabbitConfig.java
+++ b/postprocessor-service/src/main/java/io/pockethive/postprocessor/RabbitConfig.java
@@ -6,14 +6,16 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.UUID;
+import io.pockethive.util.BeeNameGenerator;
 
 @Configuration
 public class RabbitConfig {
   private static final String ROLE = "postprocessor";
 
   @Bean
-  public String instanceId(){ return UUID.randomUUID().toString(); }
+  public String instanceId(){
+    return System.getProperty("bee.name", BeeNameGenerator.generate());
+  }
 
   @Bean
   TopicExchange direct(){ return new TopicExchange(Topology.EXCHANGE, true, false); }

--- a/postprocessor-service/src/main/java/io/pockethive/postprocessor/RabbitConfig.java
+++ b/postprocessor-service/src/main/java/io/pockethive/postprocessor/RabbitConfig.java
@@ -14,7 +14,7 @@ public class RabbitConfig {
 
   @Bean
   public String instanceId(){
-    return System.getProperty("bee.name", BeeNameGenerator.generate());
+    return System.getProperty("bee.name", BeeNameGenerator.generate(ROLE));
   }
 
   @Bean

--- a/processor-service/src/main/java/io/pockethive/processor/Application.java
+++ b/processor-service/src/main/java/io/pockethive/processor/Application.java
@@ -1,11 +1,29 @@
 package io.pockethive.processor;
 
+import io.pockethive.util.BeeNameGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.info.InfoContributor;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @EnableRabbit
 @SpringBootApplication
 public class Application {
-  public static void main(String[] args){ SpringApplication.run(Application.class, args); }
+
+  private static final Logger log = LoggerFactory.getLogger(Application.class);
+
+  public static void main(String[] args){
+    String beeName = BeeNameGenerator.generate();
+    System.setProperty("bee.name", beeName);
+    log.info("Bee name: {}", beeName);
+    SpringApplication.run(Application.class, args);
+  }
+
+  @Bean
+  InfoContributor beeInfoContributor() {
+    return (builder) -> builder.withDetail("beeName", System.getProperty("bee.name"));
+  }
 }

--- a/processor-service/src/main/java/io/pockethive/processor/Application.java
+++ b/processor-service/src/main/java/io/pockethive/processor/Application.java
@@ -16,7 +16,7 @@ public class Application {
   private static final Logger log = LoggerFactory.getLogger(Application.class);
 
   public static void main(String[] args){
-    String beeName = BeeNameGenerator.generate();
+    String beeName = BeeNameGenerator.generate("processor");
     System.setProperty("bee.name", beeName);
     log.info("Bee name: {}", beeName);
     SpringApplication.run(Application.class, args);

--- a/processor-service/src/main/java/io/pockethive/processor/RabbitConfig.java
+++ b/processor-service/src/main/java/io/pockethive/processor/RabbitConfig.java
@@ -14,7 +14,7 @@ public class RabbitConfig {
 
   @Bean
   public String instanceId(){
-    return System.getProperty("bee.name", BeeNameGenerator.generate());
+    return System.getProperty("bee.name", BeeNameGenerator.generate(ROLE));
   }
 
   @Bean

--- a/processor-service/src/main/java/io/pockethive/processor/RabbitConfig.java
+++ b/processor-service/src/main/java/io/pockethive/processor/RabbitConfig.java
@@ -6,14 +6,16 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.UUID;
+import io.pockethive.util.BeeNameGenerator;
 
 @Configuration
 public class RabbitConfig {
   private static final String ROLE = "processor";
 
   @Bean
-  public String instanceId(){ return UUID.randomUUID().toString(); }
+  public String instanceId(){
+    return System.getProperty("bee.name", BeeNameGenerator.generate());
+  }
 
   @Bean
   TopicExchange direct(){ return new TopicExchange(Topology.EXCHANGE, true, false); }

--- a/trigger-service/src/main/java/io/pockethive/trigger/Application.java
+++ b/trigger-service/src/main/java/io/pockethive/trigger/Application.java
@@ -16,7 +16,7 @@ public class Application {
   private static final Logger log = LoggerFactory.getLogger(Application.class);
 
   public static void main(String[] args){
-    String beeName = BeeNameGenerator.generate();
+    String beeName = BeeNameGenerator.generate("trigger");
     System.setProperty("bee.name", beeName);
     log.info("Bee name: {}", beeName);
     SpringApplication.run(Application.class, args);

--- a/trigger-service/src/main/java/io/pockethive/trigger/Application.java
+++ b/trigger-service/src/main/java/io/pockethive/trigger/Application.java
@@ -1,11 +1,29 @@
 package io.pockethive.trigger;
 
+import io.pockethive.util.BeeNameGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.info.InfoContributor;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @EnableRabbit
 @SpringBootApplication
 public class Application {
-  public static void main(String[] args){ SpringApplication.run(Application.class, args); }
+
+  private static final Logger log = LoggerFactory.getLogger(Application.class);
+
+  public static void main(String[] args){
+    String beeName = BeeNameGenerator.generate();
+    System.setProperty("bee.name", beeName);
+    log.info("Bee name: {}", beeName);
+    SpringApplication.run(Application.class, args);
+  }
+
+  @Bean
+  InfoContributor beeInfoContributor() {
+    return (builder) -> builder.withDetail("beeName", System.getProperty("bee.name"));
+  }
 }

--- a/trigger-service/src/main/java/io/pockethive/trigger/RabbitConfig.java
+++ b/trigger-service/src/main/java/io/pockethive/trigger/RabbitConfig.java
@@ -6,14 +6,16 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.util.UUID;
+import io.pockethive.util.BeeNameGenerator;
 
 @Configuration
 public class RabbitConfig {
   private static final String ROLE = "trigger";
 
   @Bean
-  public String instanceId(){ return UUID.randomUUID().toString(); }
+  public String instanceId(){
+    return System.getProperty("bee.name", BeeNameGenerator.generate());
+  }
 
   @Bean
   TopicExchange direct(){ return new TopicExchange(Topology.EXCHANGE, true, false); }

--- a/trigger-service/src/main/java/io/pockethive/trigger/RabbitConfig.java
+++ b/trigger-service/src/main/java/io/pockethive/trigger/RabbitConfig.java
@@ -14,7 +14,7 @@ public class RabbitConfig {
 
   @Bean
   public String instanceId(){
-    return System.getProperty("bee.name", BeeNameGenerator.generate());
+    return System.getProperty("bee.name", BeeNameGenerator.generate(ROLE));
   }
 
   @Bean


### PR DESCRIPTION
## Summary
- add BeeNameGenerator utility for whimsical instance naming
- log and expose generated bee names in all service Application classes
- use bee names instead of UUIDs for instance identifiers across services
- document naming scheme for future services

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b60025748328932a37114555bb80