### PR TITLE
docs: add AGENTS guide and policy references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# PocketHive AI Rules
+
+AI contributors must load the following resources before generating code or documentation:
+
+- [docs/ai/AI_GUIDELINES.md](docs/ai/AI_GUIDELINES.md)
+- [docs/rules/](docs/rules/)
+- [policy/project-policy.yaml](policy/project-policy.yaml)
+
+Key guidelines include:
+
+- Work within the requested scope and respect service boundaries.
+- Favour domain logic over framework code; keep domains free of technical noise.
+- Provide tests and documentation when applicable.
+- Never expose credentials or personal data.
+- Stick to approved technologies (Java 21, React, JUnit 5, Cucumber, ArchUnit, existing AMQP/HTTP libs).
+- Output must be production ready: typed, formatted and secure.
+- Follow project policy and Conventional Commits.

--- a/docs/ai/AI_GUIDELINES.md
+++ b/docs/ai/AI_GUIDELINES.md
@@ -6,4 +6,5 @@
 - Never expose credentials or personal data.
 - Stick to approved technologies: Java 21, React, JUnit 5, Cucumber, ArchUnit and AMQP/HTTP libraries already in use.
 - Output must be production ready: typed, formatted and secure.
+- Review the [rules](../rules/) and [specifications](../spec/) before making changes.
 - Follow project policy and Conventional Commits.

--- a/policy/project-policy.yaml
+++ b/policy/project-policy.yaml
@@ -1,3 +1,7 @@
+# References to consolidated rules and specifications
+docs_paths:
+  rules: docs/rules/
+  spec: docs/spec/
 java:
   version: 21
 ui:


### PR DESCRIPTION
## Summary
- add repository AGENTS file instructing AI tools to load project policies
- cross-link AI guidelines with rules and spec directories
- reference rule and spec paths from project policy

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `npx commitlint --from=HEAD~2 --to=HEAD` *(fails: Cannot find module `@commitlint/config-conventional`)*

------
https://chatgpt.com/codex/tasks/task_e_68b9769fffc0832884b0271d6519ec96