### PR TITLE
feat(ui): add responsive layout to Hive page

### DIFF
--- a/ui/src/pages/hive/HivePage.tsx
+++ b/ui/src/pages/hive/HivePage.tsx
@@ -9,7 +9,6 @@ export default function HivePage() {
   const [components, setComponents] = useState<Component[]>([])
   const [selected, setSelected] = useState<Component | null>(null)
   const [search, setSearch] = useState('')
-  const [view, setView] = useState<'list' | 'topology'>('list')
 
   useEffect(() => {
     const unsub = subscribeComponents(setComponents)
@@ -21,7 +20,7 @@ export default function HivePage() {
       const updated = components.find((c) => c.id === selected.id)
       if (updated) setSelected(updated)
     }
-  }, [components])
+  }, [components, selected])
 
   const filtered = components.filter((c) =>
     c.name.toLowerCase().includes(search.toLowerCase()) ||
@@ -29,45 +28,32 @@ export default function HivePage() {
   )
 
   return (
-    <div className="flex flex-col h-[calc(100vh-64px)]">
-      <div className="flex gap-2 p-2 border-b border-white/10">
-        <button
-          className={`px-3 py-1 rounded ${view === 'list' ? 'bg-white/20' : 'bg-white/5'}`}
-          onClick={() => setView('list')}
-        >
-          List
-        </button>
-        <button
-          className={`px-3 py-1 rounded ${view === 'topology' ? 'bg-white/20' : 'bg-white/5'}`}
-          onClick={() => setView('topology')}
-        >
-          Topology
-        </button>
+    <div className="flex h-[calc(100vh-64px)] overflow-hidden">
+      <div className="w-full md:w-1/3 xl:w-1/4 border-r border-white/10 p-4 flex flex-col">
+        <input
+          className="w-full rounded bg-white/5 p-2 text-white"
+          placeholder="Search components"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <div className="mt-4 flex-1 overflow-hidden">
+          <ComponentList
+            components={filtered}
+            onSelect={(c) => setSelected(c)}
+            selectedId={selected?.id}
+          />
+        </div>
       </div>
-      {view === 'list' ? (
-        <div className="flex flex-1">
-          <div className="w-full md:w-1/3 border-r border-white/10 p-4">
-            <input
-              className="w-full mb-4 rounded bg-white/5 p-2 text-white"
-              placeholder="Search components"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-            />
-            <ComponentList
-              components={filtered}
-              onSelect={(c) => setSelected(c)}
-              selectedId={selected?.id}
-            />
-          </div>
-          {selected && (
-            <ComponentDetail component={selected} onClose={() => setSelected(null)} />
-          )}
-        </div>
-      ) : (
-        <div className="flex-1">
-          <TopologyView />
-        </div>
-      )}
+      <div className="hidden md:flex flex-1 overflow-auto">
+        <TopologyView />
+      </div>
+      <div className="hidden lg:flex w-1/3 xl:w-1/4 border-l border-white/10 overflow-hidden">
+        {selected ? (
+          <ComponentDetail component={selected} onClose={() => setSelected(null)} />
+        ) : (
+          <div className="p-4 text-white/50 overflow-y-auto">Select a component</div>
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- display ComponentList, TopologyView, and ComponentDetail side-by-side with responsive flex layout
- remove view toggle in favor of CSS-based pane visibility and independent scrolling

## Testing
- `npm test`
- `npm run build`
- `npm run lint` *(fails: Unexpected any and no-empty in existing files)*
- `npx --yes commitlint --last --verbose`


------
https://chatgpt.com/codex/tasks/task_e_68b97c05f8cc8328a74047e73882dec4