### PR TITLE
feat(ui): add topology selection callbacks

### DIFF
--- a/ui/src/pages/hive/HivePage.tsx
+++ b/ui/src/pages/hive/HivePage.tsx
@@ -45,7 +45,13 @@ export default function HivePage() {
         </div>
       </div>
       <div className="hidden md:flex flex-1 overflow-auto">
-        <TopologyView />
+        <TopologyView
+          selectedId={selected?.id}
+          onSelect={(id) => {
+            const comp = components.find((c) => c.id === id)
+            if (comp) setSelected(comp)
+          }}
+        />
       </div>
       <div className="hidden lg:flex w-1/3 xl:w-1/4 border-l border-white/10 overflow-hidden">
         {selected ? (

--- a/ui/src/pages/hive/TopologyView.tsx
+++ b/ui/src/pages/hive/TopologyView.tsx
@@ -26,6 +26,11 @@ interface GraphData {
   links: GraphLink[]
 }
 
+interface Props {
+  selectedId?: string
+  onSelect?: (id: string) => void
+}
+
 type NodeShape =
   | 'circle'
   | 'square'
@@ -44,7 +49,7 @@ const shapeOrder: NodeShape[] = [
   'star',
 ]
 
-export default function TopologyView() {
+export default function TopologyView({ selectedId, onSelect }: Props) {
   const [data, setData] = useState<GraphData>({ nodes: [], links: [] })
   const containerRef = useRef<HTMLDivElement>(null)
   const graphRef = useRef<ForceGraphMethods<GraphNode, GraphLink> | undefined>(
@@ -156,6 +161,12 @@ export default function TopologyView() {
   ) => {
     const shape = getShape(node.type)
     const size = 8
+    if (selectedId === node.id) {
+      ctx.beginPath()
+      ctx.arc(node.x ?? 0, node.y ?? 0, size + 4, 0, 2 * Math.PI)
+      ctx.fillStyle = 'rgba(255,255,255,0.1)'
+      ctx.fill()
+    }
     ctx.beginPath()
     if (shape === 'square') {
       ctx.rect((node.x ?? 0) - size, (node.y ?? 0) - size, size * 2, size * 2)
@@ -276,6 +287,7 @@ export default function TopologyView() {
           drawNode(node as GraphNode, ctx, globalScale)}
         onNodeDragEnd={(n) =>
           updateNodePosition(String(n.id), n.x ?? 0, n.y ?? 0)}
+        onNodeClick={(n) => onSelect?.(String(n.id))}
       />
       <button
         className="reset-view"


### PR DESCRIPTION
## Summary
- allow TopologyView nodes to report clicks and show selected state
- sync topology node selection with hive component list

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `npm test` (ui)
- `npm run lint` (ui) *(fails: Unexpected any / Empty block statement)*
- `npx eslint src/pages/hive/HivePage.tsx src/pages/hive/TopologyView.tsx`
- `npm run build` (ui)
- `npx commitlint --from=HEAD~1 --to=HEAD`


------
https://chatgpt.com/codex/tasks/task_e_68b9926ae2ac8328916ba420c10b1265