### PR TITLE
feat(ui): visualize queue depth and counts in topology

### DIFF
--- a/ui/src/pages/hive/TopologyView.css
+++ b/ui/src/pages/hive/TopologyView.css
@@ -44,3 +44,21 @@
 .legend-icon {
   flex-shrink: 0;
 }
+
+.node-badge {
+  position: relative;
+  width: 12px;
+  height: 12px;
+}
+
+.node-badge .badge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  background: #333;
+  color: #fff;
+  border-radius: 9999px;
+  padding: 0 2px;
+  font-size: 0.5rem;
+  line-height: 1;
+}


### PR DESCRIPTION
## Summary
- encode queue depth into edge color and width
- show per-node queue counts on topology graph
- document new visual encodings in topology legend and styles

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in stompClient.ts, ComponentDetail.tsx; Empty block statements)*
- `npm run build`
- `npx commitlint --from=HEAD~1 --to=HEAD` *(fails: Cannot find module `@commitlint/config-conventional`)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a42fc47c83289ea66e141ef09cac