### PR TITLE
feat(ui): add component filters

### DIFF
--- a/ui/src/pages/hive/HivePage.tsx
+++ b/ui/src/pages/hive/HivePage.tsx
@@ -3,12 +3,15 @@ import ComponentList from './ComponentList'
 import ComponentDetail from './ComponentDetail'
 import TopologyView from './TopologyView'
 import { subscribeComponents } from '../../lib/stompClient'
-import type { Component } from '../../types/hive'
+import { componentHealth } from '../../lib/health'
+import type { Component, HealthStatus } from '../../types/hive'
 
 export default function HivePage() {
   const [components, setComponents] = useState<Component[]>([])
   const [selected, setSelected] = useState<Component | null>(null)
   const [search, setSearch] = useState('')
+  const [typeFilter, setTypeFilter] = useState('all')
+  const [healthFilter, setHealthFilter] = useState<HealthStatus | 'all'>('all')
 
   useEffect(() => {
     const unsub = subscribeComponents(setComponents)
@@ -22,43 +25,87 @@ export default function HivePage() {
     }
   }, [components, selected])
 
-  const filtered = components.filter((c) =>
-    c.name.toLowerCase().includes(search.toLowerCase()) ||
-    c.id.toLowerCase().includes(search.toLowerCase()),
-  )
+  const types = Array.from(new Set(components.map((c) => c.name)))
+
+  const filtered = components
+    .filter(
+      (c) =>
+        c.name.toLowerCase().includes(search.toLowerCase()) ||
+        c.id.toLowerCase().includes(search.toLowerCase()),
+    )
+    .filter((c) => typeFilter === 'all' || c.name === typeFilter)
+    .filter(
+      (c) =>
+        healthFilter === 'all' || componentHealth(c) === healthFilter,
+    )
+
+  const visibleIds = filtered.map((c) => c.id)
+
+  useEffect(() => {
+    if (selected && !visibleIds.includes(selected.id)) {
+      setSelected(null)
+    }
+  }, [visibleIds, selected])
 
   return (
-    <div className="flex h-[calc(100vh-64px)] overflow-hidden">
-      <div className="w-full md:w-1/3 xl:w-1/4 border-r border-white/10 p-4 flex flex-col">
-        <input
-          className="w-full rounded bg-white/5 p-2 text-white"
-          placeholder="Search components"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-        />
-        <div className="mt-4 flex-1 overflow-hidden">
-          <ComponentList
-            components={filtered}
-            onSelect={(c) => setSelected(c)}
+    <div className="h-[calc(100vh-64px)] flex flex-col">
+      <div className="p-4 border-b border-white/10 flex gap-4">
+        <select
+          className="rounded bg-white/5 p-2 text-white"
+          value={typeFilter}
+          onChange={(e) => setTypeFilter(e.target.value)}
+        >
+          <option value="all">All Types</option>
+          {types.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+        <select
+          className="rounded bg-white/5 p-2 text-white"
+          value={healthFilter}
+          onChange={(e) => setHealthFilter(e.target.value as HealthStatus | 'all')}
+        >
+          <option value="all">All Health</option>
+          <option value="OK">OK</option>
+          <option value="WARN">WARN</option>
+          <option value="ALERT">ALERT</option>
+        </select>
+      </div>
+      <div className="flex flex-1 overflow-hidden">
+        <div className="w-full md:w-1/3 xl:w-1/4 border-r border-white/10 p-4 flex flex-col">
+          <input
+            className="w-full rounded bg-white/5 p-2 text-white"
+            placeholder="Search components"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          <div className="mt-4 flex-1 overflow-hidden">
+            <ComponentList
+              components={filtered}
+              onSelect={(c) => setSelected(c)}
+              selectedId={selected?.id}
+            />
+          </div>
+        </div>
+        <div className="hidden md:flex flex-1 overflow-auto">
+          <TopologyView
             selectedId={selected?.id}
+            visibleIds={visibleIds}
+            onSelect={(id) => {
+              const comp = components.find((c) => c.id === id)
+              if (comp) setSelected(comp)
+            }}
           />
         </div>
-      </div>
-      <div className="hidden md:flex flex-1 overflow-auto">
-        <TopologyView
-          selectedId={selected?.id}
-          onSelect={(id) => {
-            const comp = components.find((c) => c.id === id)
-            if (comp) setSelected(comp)
-          }}
-        />
-      </div>
-      <div className="hidden lg:flex w-1/3 xl:w-1/4 border-l border-white/10 overflow-hidden">
-        {selected ? (
-          <ComponentDetail component={selected} onClose={() => setSelected(null)} />
-        ) : (
-          <div className="p-4 text-white/50 overflow-y-auto">Select a component</div>
-        )}
+        <div className="hidden lg:flex w-1/3 xl:w-1/4 border-l border-white/10 overflow-hidden">
+          {selected ? (
+            <ComponentDetail component={selected} onClose={() => setSelected(null)} />
+          ) : (
+            <div className="p-4 text-white/50 overflow-y-auto">Select a component</div>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/ui/src/pages/hive/TopologyView.test.tsx
+++ b/ui/src/pages/hive/TopologyView.test.tsx
@@ -77,7 +77,7 @@ vi.mock('../../lib/stompClient', () => {
 })
 
 test('node position updates after drag and edge depth styles', () => {
-  render(<TopologyView />)
+  const { unmount } = render(<TopologyView />)
   const props = (globalThis as unknown as { __GRAPH_PROPS__: GraphProps }).__GRAPH_PROPS__
   expect(typeof props.width).toBe('number')
   expect(typeof props.height).toBe('number')
@@ -118,4 +118,15 @@ test('node position updates after drag and edge depth styles', () => {
     1,
   )
   expect(ctx.fillText).toHaveBeenCalledWith('2', expect.any(Number), expect.any(Number))
+  unmount()
+})
+
+test('filters nodes and edges based on visibleIds', async () => {
+  const { unmount } = render(<TopologyView visibleIds={['a']} />)
+  await Promise.resolve()
+  const props = (globalThis as unknown as { __GRAPH_PROPS__: GraphProps }).__GRAPH_PROPS__
+  expect(props.graphData.nodes).toHaveLength(1)
+  expect(props.graphData.nodes[0].id).toBe('a')
+  expect(props.graphData.links).toHaveLength(0)
+  unmount()
 })


### PR DESCRIPTION
## Summary
- add filter bar with type and health dropdowns on Hive page
- allow topology view to hide nodes and edges based on active filters
- cover topology filtering with tests

## Testing
- `npm test` *(fails: test suite hangs; only partial tests run)*
- `npm run lint` *(fails: lint errors)*
- `npm run build`
- `npx -y commitlint --from=HEAD~1` *(fails: missing commitlint config)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d408aa048328b7bb1a145f53494a