### PR TITLE
build: pull images from AWS ECR

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,14 +134,14 @@ services:
       start_period: 5s
 
   prometheus:
-    image: prom/prometheus
+    image: public.ecr.aws/prometheus/prometheus
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
     ports:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana
+    image: public.ecr.aws/grafana/grafana
     environment:
       GF_SECURITY_ADMIN_USER: admin
       GF_SECURITY_ADMIN_PASSWORD: admin
@@ -155,7 +155,7 @@ services:
       - loki
 
   loki:
-    image: grafana/loki:2.9.1
+    image: public.ecr.aws/grafana/loki:2.9.1
     command: -config.file=/etc/loki/config.yml
     ports:
       - "3100:3100"
@@ -163,7 +163,7 @@ services:
       - ./loki/config.yml:/etc/loki/config.yml:ro
 
   wiremock:
-    image: wiremock/wiremock:3.13.1
+    image: public.ecr.aws/wiremock/wiremock:3.13.1
     command:
       [
         "--verbose",                          # useful logs for debugging
@@ -192,7 +192,7 @@ services:
 
   # promtail:
   #   # disabled: logs are shipped via RabbitMQ and aggregated to Loki
-  #   image: grafana/promtail:2.9.1
+  #   image: public.ecr.aws/grafana/promtail:2.9.1
   #   command: -config.file=/etc/promtail/config.yml
   #   ports:
   #     - "9080:9080"


### PR DESCRIPTION
## Summary
- pull Prometheus, Grafana, Loki, and Wiremock containers from AWS ECR

## Testing
- `npm run build`
- `npm run lint` *(fails: No files matching the pattern "ui/assets/js")*
- `npm test`
- `npx -y commitlint --verbose --from=HEAD~1 --to=HEAD`


------
https://chatgpt.com/codex/tasks/task_e_68beb5b23bec832881085e7c8149da33