### PR TITLE
docs: update React version to 19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ Timestamp: 2025-09-03T19:33:17Z
 ## [0.6.1] - 2025-09-03
 Timestamp: 2025-09-03T12:18:00Z
 
-- UI: archive the static site under `UI-Legacy` and scaffold a React 18 + Vite app in `/ui` with the Hive view and menu.
+- UI: archive the static site under `UI-Legacy` and scaffold a React 19 + Vite app in `/ui` with the Hive view and menu.
 
 ## [0.6.0] - 2025-09-02
 Timestamp: 2025-09-02T22:51:35Z

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ flowchart LR
   style UI stroke:#00e676,stroke-width:3px;
 ```
 
-The UI is built with React 18 + Vite and resides in `/ui`.
+The UI is built with React 19 + Vite and resides in `/ui`.
 
 ### Architecture
 


### PR DESCRIPTION
## Summary
- state UI uses React 19 in docs

## Testing
- `npm test`
- `npm run lint` *(fails: No files matching "ui/assets/js" were found)*
- `npm run build`
- `npx --yes --package @commitlint/cli --package @commitlint/config-conventional commitlint --from HEAD~1 --to HEAD` *(fails: Cannot find module "@commitlint/config-conventional" from "/workspace/PocketHive"*)

------
https://chatgpt.com/codex/tasks/task_e_68bff3d4d7ac83289bd2cdfb2f0bbb2b