### PR TITLE
chore: fix lint script path

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ docker compose up -d --build ui
 
 - Node tooling (linting/tests) lives in `package.json` at the repo root:
   - `npm install` installs dev dependencies.
-  - `npm run lint` runs ESLint.
+  - `npm run lint` runs ESLint on `ui/src/**/*.{ts,tsx}`.
   - `npm test` executes Vitest.
 
 ---

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Development tooling for PocketHive",
   "scripts": {
     "build": "echo \"no build step\"",
-    "lint": "eslint ui/assets/js",
+    "lint": "eslint -c ui/eslint.config.js \"ui/src/**/*.{ts,tsx}\"",
     "test": "vitest run --passWithNoTests"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- lint UI sources using ESLint
- document new lint target

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type @typescript-eslint/no-explicit-any)*

------
https://chatgpt.com/codex/tasks/task_e_68bff3e806b08328a71cee4be89caffb