### PR TITLE
docs(ui): update readme with project instructions

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -1,69 +1,43 @@
-# React + TypeScript + Vite
+# PocketHive UI
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+PocketHive's UI is a web console for monitoring and controlling swarms in the PocketHive ecosystem. It connects to the control plane over STOMP and lets you view topology, inspect components and stream logs in real time.
 
-Currently, two official plugins are available:
+## Getting Started
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+Install dependencies:
 
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      ...tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      ...tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      ...tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm install
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+### Development
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+Run the development server with hot reload (default at http://localhost:5173):
 
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm run dev
 ```
+
+### Build
+
+Type‑checks the project and generates production assets in `dist/`:
+
+```bash
+npm run build
+```
+
+### Test
+
+Execute the unit test suite:
+
+```bash
+npm test
+```
+
+## Key Panels
+
+- **Hive** – manage swarms, browse components, view the topology graph and inspect component details.
+- **Buzz** – stream IN/OUT/Other logs and view current configuration with adjustable message limits.
+- **Queen** – create new swarms from predefined templates.
+- **Nectar** – reserved for upcoming features.
+


### PR DESCRIPTION
## Summary
- replace Vite template README with PocketHive-specific setup and usage
- outline dev, build, test commands and highlight key panels of the UI

## Testing
- `npm test`
- `npm run lint` *(fails: No files matching the pattern "ui/assets/js" were found)*
- `npm run build`
- `npx commitlint --from=HEAD~1` *(fails: Cannot find module "@commitlint/config-conventional" from "/workspace/PocketHive")*

------
https://chatgpt.com/codex/tasks/task_e_68bff3e816f88328859f86d8b85e4eb4