### PR TITLE
docs: outline multi-region queue adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 - **Completed**: Phase 1 – Orchestrator Foundation (dynamic swarm creation, control-plane hooks, Docker integration)
 - **In Progress**: Phase 2 – Multi-Swarm Support
+- **Planned**: Multi-Region & Queue Adapters – distributed queues will be pluggable. See [Multi-Region & Queue Adapters](docs/ARCHITECTURE.md#multi-region--queue-adapters).
 
 ```mermaid
 flowchart LR

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,6 +16,18 @@ PocketHive coordinates work through a layered control plane:
 ### Swarm bootstrap
 When a new swarm is requested, the Queen spawns a Herald. The Herald declares the required exchanges and queues, then starts the bee containers defined by the swarm template.
 
+## Multi-Region & Queue Adapters
+PocketHive will support swarms running in multiple geolocations. Each swarm connects to a region-local broker while the Queen coordinates them through the control plane. Regions remain isolated from each other’s traffic yet share common naming and signalling conventions.
+
+To enable broker diversity, messaging will flow through pluggable queue adapters. The core interface will expose publish and consume operations and minimal lifecycle hooks. Implementations for AMQP, Kafka, SQS and others can plug in without altering domain code.
+
+### Adding a new driver
+1. Implement the adapter interface for the target broker.
+2. Provide configuration mapping and wiring inside the swarm controller.
+3. Register the driver with the Queen so swarms may select it at launch time.
+
+This feature is planned and not yet implemented.
+
 ## Layers
 Every service follows a hexagonal layout:
 - **api** – inbound ports and DTOs.


### PR DESCRIPTION
## Summary
- document planned multi-region swarm support and pluggable queue adapters
- reference multi-region queue adapters roadmap from the README

## Testing
- `npm run lint` *(fails: Unexpected any and empty blocks)*
- `npm test`
- `npm run build`
- `mvn -q test` *(fails: unresolved Spring Boot dependencies, network unreachable)*
- `npx --yes commitlint --from=HEAD~1 --to=HEAD` *(fails: Cannot find module @commitlint/config-conventional)*

------
https://chatgpt.com/codex/tasks/task_e_68c0059f05b88328ae5ff2999e4284db