### PR TITLE
docs: clarify queen and herald roles

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,6 +13,12 @@ PocketHive coordinates work through a layered control plane:
 - **Herald** – per‑swarm controller started by the Queen; it provisions message queues and launches worker containers.
 - **Bees** – the worker services inside each swarm.
 
+### Queen (Orchestrator)
+The Queen coordinates the entire hive. It loads scenario plans, spins up or tears down swarms, and hands each Herald the fragment of the plan it should execute.
+
+### Herald (Swarm Controller)
+A Herald governs one swarm. After receiving its plan from the Queen it declares the swarm's exchanges and queues, launches the bee containers described in the template and fans out config signals to individual bees.
+
 ### Swarm bootstrap
 When a new swarm is requested, the Queen spawns a Herald. The Herald declares the required exchanges and queues, then starts the bee containers defined by the swarm template.
 

--- a/orchestrator-service/README.md
+++ b/orchestrator-service/README.md
@@ -1,9 +1,11 @@
 # Orchestrator Service
 
-Acts as the queen, managing swarm containers and their lifecycle.
+Acts as the Queen of the hive. It reads scenario plans and ensures each swarm is started, monitored and stopped at the right time.
 
 ## Responsibilities
+- Load scenario definitions and expand them into swarm plans.
 - Launch and stop service containers based on swarm templates.
-- Publish swarm-level events on the control exchange.
+- Create a Herald for each swarm and hand off the relevant plan fragment.
+- Publish swarm-level events on the control exchange and track swarm status.
 
 See [control-plane rules](../docs/rules/control-plane-rules.md) for signal formats.

--- a/swarm-controller-service/README.md
+++ b/swarm-controller-service/README.md
@@ -1,7 +1,8 @@
 # SwarmController Service
 
-SwarmController manages the lifecycle of a single swarm. It consumes swarm-level signals and fans out
-existing per-bee control messages without introducing new routing patterns.
+Acts as the Herald for a swarm. SwarmController manages the lifecycle of a single swarm, provisioning
+its queues and relaying control signals. It consumes swarm-level signals and fans out existing per-bee
+control messages without introducing new routing patterns.
 
 ## Responsibilities
 - Listen for `sig.swarm-start.<swarmId>` and `sig.swarm-stop.<swarmId>` events.


### PR DESCRIPTION
## Summary
- refine architecture docs: Queen delegates plan fragments; Herald fans out config signals

## Testing
- `npm run build`
- `npm test`
- `npm run lint` *(fails: Unexpected any; Empty block statement)*
- `mvn -q -pl orchestrator-service,swarm-controller-service test` *(fails: Non-resolvable import POM: Network is unreachable)*
- `npx --yes commitlint --from=HEAD^ --to=HEAD`


------
https://chatgpt.com/codex/tasks/task_e_68c052e125e48328ba58dcb1d733738b