### PR TITLE
docs: document control exchange and integration plan

### DIFF
--- a/SWARM_CONTROLLER_PLAN.md
+++ b/SWARM_CONTROLLER_PLAN.md
@@ -1,17 +1,22 @@
 # SwarmController Integration Plan
 
-1. **Implement swarm signal listener**
-   - Subscribe to the `ph.control` exchange for `sig.swarm-start.<swarmId>` and `sig.swarm-stop.<swarmId>`.
-   - Filter messages so the controller acts only on its `Topology.SWARM_ID`.
-2. **Resolve membership**
-   - Query Herald or another registry to obtain the list of bees in the swarm.
-   - Cache memberships and update on new swarm member events.
-3. **Fan-out per-bee commands**
-   - Emit `sig.config-update.<role>.<instance>` or `sig.status-request.<role>.<instance>` for each resolved bee.
-4. **Metrics and logging**
-   - Tag metrics with `swarm_id`, `service`, and `instance`.
-   - Emit traceable logs for received and dispatched signals.
-5. **UI and service integration**
-   - Surface SwarmController status in the UI and wire create/start/stop controls.
-   - Drop swarm-level listeners from other services once they rely on the controller.
-   - Extend integration tests to cover swarm start/stop through SwarmController.
+## Phase 1 – Control channel handshake
+- Subscribe to the `ph.control` exchange and declare `ph.control.herald.<instance>`.
+- Emit `ev.ready.herald.<instance>` on startup.
+- Queen responds with `sig.swarm-start.<swarmId>` carrying the SwarmPlan.
+
+## Phase 2 – Plan expansion and queue provisioning
+- Parse the SwarmPlan to resolve bee roles and queue suffixes.
+- Declare `ph.<swarmId>.hive` and bind all `work.in/out` queues.
+
+## Phase 3 – Bee lifecycle management
+- Launch bee containers using the images from the plan.
+- Fan-out `sig.config-update.<role>.<instance>` and `sig.status-request.<role>.<instance>` to individual bees as needed.
+
+## Phase 4 – Swarm shutdown
+- Handle `sig.swarm-stop.<swarmId>` by stopping bees and deleting queues.
+
+## Phase 5 – Observability and UI integration
+- Tag metrics with `swarm_id`, `service`, and `instance` and emit traceable logs.
+- Surface controller status in the UI and wire create/start/stop controls.
+- Extend integration tests to cover swarm start/stop through SwarmController.


### PR DESCRIPTION
## Summary
- describe Queen↔Herald handshake on ph.control and swarm plan template
- outline phased SwarmController implementation plan

## Testing
- `npm run build`
- `npm test`
- `npm run lint` *(fails: Unexpected any in existing UI files)*
- `npx --yes commitlint --from=HEAD~1 --to=HEAD` *(fails: Cannot find module @commitlint/config-conventional)*

------
https://chatgpt.com/codex/tasks/task_e_68c05f9281408328b77da04887c2ecff