### PR TITLE
feat: declare hive and queues from swarm plan

### DIFF
--- a/swarm-controller-service/pom.xml
+++ b/swarm-controller-service/pom.xml
@@ -67,6 +67,11 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.amqp</groupId>
+      <artifactId>spring-rabbit-test</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmLifecycle.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmLifecycle.java
@@ -1,6 +1,6 @@
 package io.pockethive.swarmcontroller;
 
 public interface SwarmLifecycle {
-  void start();
+  void start(String planJson);
   void stop();
 }

--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmLifecycleManager.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmLifecycleManager.java
@@ -1,17 +1,54 @@
 package io.pockethive.swarmcontroller;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.pockethive.Topology;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.amqp.core.*;
 import org.springframework.stereotype.Component;
+
+import java.util.HashSet;
+import java.util.Set;
 
 @Component
 public class SwarmLifecycleManager implements SwarmLifecycle {
   private static final Logger log = LoggerFactory.getLogger(SwarmLifecycleManager.class);
+  private final AmqpAdmin amqp;
+  private final ObjectMapper mapper;
+
+  public SwarmLifecycleManager(AmqpAdmin amqp, ObjectMapper mapper) {
+    this.amqp = amqp;
+    this.mapper = mapper;
+  }
 
   @Override
-  public void start() {
+  public void start(String planJson) {
     log.info("Starting swarm {}", Topology.SWARM_ID);
+    try {
+      SwarmPlan plan = mapper.readValue(planJson, SwarmPlan.class);
+      TopicExchange hive = new TopicExchange("ph." + Topology.SWARM_ID + ".hive", true, false);
+      amqp.declareExchange(hive);
+
+      Set<String> suffixes = new HashSet<>();
+      if (plan.bees() != null) {
+        for (SwarmPlan.Bee bee : plan.bees()) {
+          if (bee.work() != null) {
+            if (bee.work().in() != null) suffixes.add(bee.work().in());
+            if (bee.work().out() != null) suffixes.add(bee.work().out());
+          }
+        }
+      }
+
+      for (String suffix : suffixes) {
+        Queue q = QueueBuilder.durable("ph." + Topology.SWARM_ID + "." + suffix).build();
+        amqp.declareQueue(q);
+        Binding b = BindingBuilder.bind(q).to(hive).with(suffix).noargs();
+        amqp.declareBinding(b);
+      }
+    } catch (JsonProcessingException e) {
+      log.warn("Invalid plan payload", e);
+    }
   }
 
   @Override

--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmLifecycleManager.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmLifecycleManager.java
@@ -43,7 +43,7 @@ public class SwarmLifecycleManager implements SwarmLifecycle {
       for (String suffix : suffixes) {
         Queue q = QueueBuilder.durable("ph." + Topology.SWARM_ID + "." + suffix).build();
         amqp.declareQueue(q);
-        Binding b = BindingBuilder.bind(q).to(hive).with(suffix).noargs();
+        Binding b = BindingBuilder.bind(q).to(hive).with(suffix);
         amqp.declareBinding(b);
       }
     } catch (JsonProcessingException e) {

--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmPlan.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmPlan.java
@@ -1,0 +1,11 @@
+package io.pockethive.swarmcontroller;
+
+import java.util.List;
+
+/**
+ * Plan describing the queues required to bootstrap a swarm.
+ */
+public record SwarmPlan(List<Bee> bees) {
+  public record Bee(String role, Work work) {}
+  public record Work(String in, String out) {}
+}

--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmSignalListener.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmSignalListener.java
@@ -43,7 +43,7 @@ public class SwarmSignalListener {
       String swarmId = routingKey.substring("sig.swarm-start.".length());
       if (Topology.SWARM_ID.equals(swarmId)) {
         log.info("Start signal for swarm {}", swarmId);
-        lifecycle.start();
+        lifecycle.start(body);
       }
     } else if (routingKey.startsWith("sig.swarm-stop.")) {
       String swarmId = routingKey.substring("sig.swarm-stop.".length());

--- a/swarm-controller-service/src/test/java/io/pockethive/swarmcontroller/SwarmLifecycleManagerIntegrationTest.java
+++ b/swarm-controller-service/src/test/java/io/pockethive/swarmcontroller/SwarmLifecycleManagerIntegrationTest.java
@@ -1,0 +1,53 @@
+package io.pockethive.swarmcontroller;
+
+import io.pockethive.Topology;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.core.AmqpAdmin;
+import org.springframework.amqp.rabbit.junit.RabbitAvailable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SpringBootTest
+@RabbitAvailable
+class SwarmLifecycleManagerIntegrationTest {
+  @Autowired
+  SwarmLifecycleManager manager;
+
+  @Autowired
+  AmqpAdmin amqp;
+
+  @AfterEach
+  void cleanup() {
+    amqp.deleteQueue("ph." + Topology.SWARM_ID + ".gen");
+    amqp.deleteQueue("ph." + Topology.SWARM_ID + ".mod");
+    amqp.deleteQueue("ph." + Topology.SWARM_ID + ".final");
+    ((RabbitAdmin) amqp).getRabbitTemplate().execute(ch -> {
+      ch.exchangeDelete("ph." + Topology.SWARM_ID + ".hive");
+      return null;
+    });
+  }
+
+  @Test
+  void declaresHiveAndWorkQueues() {
+    String plan = """
+        {"bees":[
+          {"role":"generator","work":{"out":"gen"}},
+          {"role":"moderator","work":{"in":"gen","out":"mod"}},
+          {"role":"processor","work":{"in":"mod","out":"final"}},
+          {"role":"postprocessor","work":{"in":"final"}}
+        ]}
+        """;
+    manager.start(plan);
+    assertNotNull(amqp.getQueueProperties("ph." + Topology.SWARM_ID + ".gen"));
+    assertNotNull(amqp.getQueueProperties("ph." + Topology.SWARM_ID + ".mod"));
+    assertNotNull(amqp.getQueueProperties("ph." + Topology.SWARM_ID + ".final"));
+    ((RabbitAdmin) amqp).getRabbitTemplate().execute(ch -> {
+      ch.exchangeDeclarePassive("ph." + Topology.SWARM_ID + ".hive");
+      return null;
+    });
+  }
+}

--- a/swarm-controller-service/src/test/java/io/pockethive/swarmcontroller/SwarmSignalListenerTest.java
+++ b/swarm-controller-service/src/test/java/io/pockethive/swarmcontroller/SwarmSignalListenerTest.java
@@ -22,8 +22,8 @@ class SwarmSignalListenerTest {
   void startsSwarmWhenIdMatches() {
     SwarmSignalListener listener = new SwarmSignalListener(lifecycle, rabbit, "inst");
     reset(rabbit);
-    listener.handle("", "sig.swarm-start." + Topology.SWARM_ID);
-    verify(lifecycle).start();
+    listener.handle("plan", "sig.swarm-start." + Topology.SWARM_ID);
+    verify(lifecycle).start("plan");
     verifyNoMoreInteractions(lifecycle);
   }
 


### PR DESCRIPTION
## Summary
- add SwarmPlan model for herald to parse bee work queues
- declare hive exchange and work queues on swarm start
- exercise queue provisioning through integration test

## Testing
- `mvn -q -pl swarm-controller-service test` *(fails: Non-resolvable import POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c080e213c48328951feec742ae8046