### PR TITLE
feat(swarm-controller): manage container lifecycle with docker

### DIFF
--- a/swarm-controller-service/pom.xml
+++ b/swarm-controller-service/pom.xml
@@ -10,6 +10,8 @@
   <properties>
     <java.version>21</java.version>
     <spring.boot.version>3.3.2</spring.boot.version>
+    <docker-java.version>3.3.0</docker-java.version>
+    <httpcomponents.version>5.0.3</httpcomponents.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -61,6 +63,21 @@
     <dependency>
       <groupId>org.codehaus.janino</groupId>
       <artifactId>janino</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.github.docker-java</groupId>
+      <artifactId>docker-java-core</artifactId>
+      <version>${docker-java.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.docker-java</groupId>
+      <artifactId>docker-java-transport-httpclient5</artifactId>
+      <version>${docker-java.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents.core5</groupId>
+      <artifactId>httpcore5-h2</artifactId>
+      <version>${httpcomponents.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmPlan.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmPlan.java
@@ -6,6 +6,6 @@ import java.util.List;
  * Plan describing the queues required to bootstrap a swarm.
  */
 public record SwarmPlan(List<Bee> bees) {
-  public record Bee(String role, Work work) {}
+  public record Bee(String role, String image, Work work) {}
   public record Work(String in, String out) {}
 }

--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmStatus.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmStatus.java
@@ -1,0 +1,6 @@
+package io.pockethive.swarmcontroller;
+
+public enum SwarmStatus {
+  STOPPED,
+  RUNNING
+}

--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/infra/docker/DockerConfiguration.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/infra/docker/DockerConfiguration.java
@@ -1,0 +1,27 @@
+package io.pockethive.swarmcontroller.infra.docker;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.core.DefaultDockerClientConfig;
+import com.github.dockerjava.core.DockerClientImpl;
+import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
+import com.github.dockerjava.transport.DockerHttpClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class DockerConfiguration {
+  @Bean
+  public DockerClient dockerClient() {
+    DefaultDockerClientConfig config = DefaultDockerClientConfig.createDefaultConfigBuilder().build();
+    DockerHttpClient httpClient = new ApacheDockerHttpClient.Builder()
+        .dockerHost(config.getDockerHost())
+        .sslConfig(config.getSSLConfig())
+        .build();
+    return DockerClientImpl.getInstance(config, httpClient);
+  }
+
+  @Bean
+  public DockerContainerClient dockerContainerClient(DockerClient dockerClient) {
+    return new DockerContainerClient(dockerClient);
+  }
+}

--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/infra/docker/DockerContainerClient.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/infra/docker/DockerContainerClient.java
@@ -1,0 +1,26 @@
+package io.pockethive.swarmcontroller.infra.docker;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.CreateContainerResponse;
+import com.github.dockerjava.api.model.HostConfig;
+
+public class DockerContainerClient {
+  private final DockerClient dockerClient;
+
+  public DockerContainerClient(DockerClient dockerClient) {
+    this.dockerClient = dockerClient;
+  }
+
+  public String createAndStartContainer(String image) {
+    CreateContainerResponse response = dockerClient.createContainerCmd(image)
+        .withHostConfig(HostConfig.newHostConfig())
+        .exec();
+    dockerClient.startContainerCmd(response.getId()).exec();
+    return response.getId();
+  }
+
+  public void stopAndRemoveContainer(String containerId) {
+    dockerClient.stopContainerCmd(containerId).exec();
+    dockerClient.removeContainerCmd(containerId).exec();
+  }
+}

--- a/swarm-controller-service/src/test/java/io/pockethive/swarmcontroller/SwarmLifecycleManagerIntegrationTest.java
+++ b/swarm-controller-service/src/test/java/io/pockethive/swarmcontroller/SwarmLifecycleManagerIntegrationTest.java
@@ -8,6 +8,9 @@ import org.springframework.amqp.rabbit.junit.RabbitAvailable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import io.pockethive.swarmcontroller.infra.docker.DockerContainerClient;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -19,6 +22,9 @@ class SwarmLifecycleManagerIntegrationTest {
 
   @Autowired
   AmqpAdmin amqp;
+
+  @MockBean
+  DockerContainerClient docker;
 
   @AfterEach
   void cleanup() {

--- a/swarm-controller-service/src/test/java/io/pockethive/swarmcontroller/SwarmLifecycleManagerTest.java
+++ b/swarm-controller-service/src/test/java/io/pockethive/swarmcontroller/SwarmLifecycleManagerTest.java
@@ -1,0 +1,54 @@
+package io.pockethive.swarmcontroller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.pockethive.swarmcontroller.infra.docker.DockerContainerClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.core.AmqpAdmin;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SwarmLifecycleManagerTest {
+  @Mock
+  AmqpAdmin amqp;
+  @Mock
+  DockerContainerClient docker;
+
+  ObjectMapper mapper = new ObjectMapper();
+
+  @Test
+  void startLaunchesContainers() throws Exception {
+    SwarmLifecycleManager manager = new SwarmLifecycleManager(amqp, mapper, docker);
+    SwarmPlan plan = new SwarmPlan(List.of(
+        new SwarmPlan.Bee("gen", "img1", null),
+        new SwarmPlan.Bee("mod", "img2", null)));
+    when(docker.createAndStartContainer("img1")).thenReturn("c1");
+    when(docker.createAndStartContainer("img2")).thenReturn("c2");
+
+    manager.start(mapper.writeValueAsString(plan));
+
+    verify(docker).createAndStartContainer("img1");
+    verify(docker).createAndStartContainer("img2");
+    assertEquals(SwarmStatus.RUNNING, manager.getStatus());
+  }
+
+  @Test
+  void stopRemovesContainersAndUpdatesStatus() throws Exception {
+    SwarmLifecycleManager manager = new SwarmLifecycleManager(amqp, mapper, docker);
+    SwarmPlan plan = new SwarmPlan(List.of(new SwarmPlan.Bee("gen", "img1", null)));
+    when(docker.createAndStartContainer("img1")).thenReturn("c1");
+    manager.start(mapper.writeValueAsString(plan));
+
+    manager.stop();
+
+    verify(docker).stopAndRemoveContainer("c1");
+    assertEquals(SwarmStatus.STOPPED, manager.getStatus());
+  }
+}


### PR DESCRIPTION
## Summary
- provision Docker client beans for swarm-controller
- launch and track bee containers when swarm starts
- stop/remove containers and expose swarm status
- add unit tests for container lifecycle

## Testing
- `mvn -q -f swarm-controller-service/pom.xml test` *(fails: Non-resolvable import POM, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c089e3b35883288f3d8e4892284c1a