### PR TITLE
docs: outline scenario manager and swarm lifecycle

### DIFF
--- a/MVP_ROADMAP.md
+++ b/MVP_ROADMAP.md
@@ -306,6 +306,27 @@ ui/src/pages/
     └── ResultsAnalysis.tsx     # Post-test analysis
 ```
 
+### Scenario Manager Service
+
+The `scenario-manager-service` stores reusable SwarmPlans and exposes a RESTful CRUD API:
+
+- `POST /scenarios` – create a new scenario definition
+- `GET /scenarios/{id}` – retrieve a scenario
+- `PUT /scenarios/{id}` – update an existing scenario
+- `DELETE /scenarios/{id}` – remove a scenario
+
+These endpoints supply the orchestrator and SwarmController with plans at runtime. See the
+[SwarmController Plan](SWARM_CONTROLLER_PLAN.md#scenario-manager-service) for controller integration details.
+
+### SwarmController Lifecycle
+
+- The SwarmController coordinates swarm execution. Key steps are outlined in the
+[SwarmController Plan](SWARM_CONTROLLER_PLAN.md#orchestrator-herald-ready-start-handshake):
+
+- [Orchestrator–herald ready-start handshake](SWARM_CONTROLLER_PLAN.md#orchestrator-herald-ready-start-handshake)
+- [SwarmPlan parsing, queue provisioning, and bee container lifecycle](SWARM_CONTROLLER_PLAN.md#swarmplan-parsing-queue-provisioning-and-bee-container-lifecycle)
+- [Swarm shutdown cleanup and observability/UI hooks](SWARM_CONTROLLER_PLAN.md#swarm-shutdown-cleanup-and-observability-ui-hooks)
+
 ---
 
 ## Success Criteria

--- a/SWARM_CONTROLLER_PLAN.md
+++ b/SWARM_CONTROLLER_PLAN.md
@@ -20,3 +20,28 @@
 - Tag metrics with `swarm_id`, `service`, and `instance` and emit traceable logs.
 - Surface controller status in the UI and wire create/start/stop controls.
 - Extend integration tests to cover swarm start/stop through SwarmController.
+
+---
+
+## Scenario Manager Service
+
+SwarmController retrieves SwarmPlans from the `scenario-manager-service` REST API. The service exposes:
+
+- `POST /scenarios` – create scenario definitions
+- `GET /scenarios/{id}` – fetch a scenario
+- `PUT /scenarios/{id}` – update a stored scenario
+- `DELETE /scenarios/{id}` – remove a scenario
+
+Refer to the [MVP Roadmap](MVP_ROADMAP.md#scenario-manager-service) for delivery milestones.
+
+## Orchestrator–herald ready-start handshake
+
+On startup the herald declares `ph.control.herald.<instance>` and publishes `ev.ready.herald.<instance>`. The orchestrator responds with `sig.swarm-start.<swarmId>` containing the target SwarmPlan.
+
+## SwarmPlan parsing, queue provisioning, and bee container lifecycle
+
+After receiving `sig.swarm-start`, the controller expands the SwarmPlan, declares the `ph.<swarmId>.hive` exchange, provisions all `work.in/out` queues, and launches bee containers for each role. Bees receive `sig.config-update` and `sig.status-request` messages to manage their lifecycle.
+
+## Swarm shutdown cleanup and observability/UI hooks
+
+Handling `sig.swarm-stop.<swarmId>` stops bee containers, deletes queues, and flushes swarm metrics. Resulting events allow the UI to remove the swarm from its dashboards. See the [MVP Roadmap](MVP_ROADMAP.md#swarmcontroller-lifecycle) for the broader execution flow.


### PR DESCRIPTION
## Summary
- document Scenario Manager service CRUD API and link with SwarmController plan
- describe orchestrator–herald handshake, SwarmPlan parsing and bee lifecycle, and shutdown/observability hooks with cross-links

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and other lint errors in existing UI code)*
- `npm run build`
- `npx commitlint --from HEAD~1 --to HEAD`

------
https://chatgpt.com/codex/tasks/task_e_68c0b3938a2083289a9f5f7023516990