### PR TITLE
feat: handle swarm templates and startup readiness

### DIFF
--- a/MVP_ROADMAP.md
+++ b/MVP_ROADMAP.md
@@ -321,9 +321,9 @@ These endpoints supply the orchestrator and SwarmController with plans at runtim
 ### SwarmController Lifecycle
 
 - The SwarmController coordinates swarm execution. Key steps are outlined in the
-[SwarmController Plan](SWARM_CONTROLLER_PLAN.md#orchestrator-herald-ready-start-handshake):
+[SwarmController Plan](SWARM_CONTROLLER_PLAN.md#orchestrator-swarm-controller-ready-start-handshake):
 
-- [Orchestrator–herald ready-start handshake](SWARM_CONTROLLER_PLAN.md#orchestrator-herald-ready-start-handshake)
+- [Orchestrator–swarm-controller ready-start handshake](SWARM_CONTROLLER_PLAN.md#orchestrator-swarm-controller-ready-start-handshake)
 - [SwarmPlan parsing, queue provisioning, and bee container lifecycle](SWARM_CONTROLLER_PLAN.md#swarmplan-parsing-queue-provisioning-and-bee-container-lifecycle)
 - [Swarm shutdown cleanup and observability/UI hooks](SWARM_CONTROLLER_PLAN.md#swarm-shutdown-cleanup-and-observability-ui-hooks)
 

--- a/SWARM_CONTROLLER_PLAN.md
+++ b/SWARM_CONTROLLER_PLAN.md
@@ -1,8 +1,8 @@
 # SwarmController Integration Plan
 
 ## Phase 1 – Control channel handshake
-- Subscribe to the `ph.control` exchange and declare `ph.control.herald.<instance>`.
-- Emit `ev.ready.herald.<instance>` on startup.
+- Subscribe to the `ph.control` exchange and declare `ph.control.swarm-controller.<instance>`.
+- Emit `ev.ready.swarm-controller.<instance>` on startup.
 - Queen responds with `sig.swarm-start.<swarmId>` carrying the SwarmPlan.
 
 ## Phase 2 – Plan expansion and queue provisioning
@@ -34,9 +34,9 @@ SwarmController retrieves SwarmPlans from the `scenario-manager-service` REST AP
 
 Refer to the [MVP Roadmap](MVP_ROADMAP.md#scenario-manager-service) for delivery milestones.
 
-## Orchestrator–herald ready-start handshake
+## Orchestrator–swarm-controller ready-start handshake
 
-On startup the herald declares `ph.control.herald.<instance>` and publishes `ev.ready.herald.<instance>`. The orchestrator responds with `sig.swarm-start.<swarmId>` containing the target SwarmPlan.
+On startup the swarm-controller declares `ph.control.swarm-controller.<instance>` and publishes `ev.ready.swarm-controller.<instance>`. The orchestrator responds with `sig.swarm-start.<swarmId>` containing the target SwarmPlan.
 
 ## SwarmPlan parsing, queue provisioning, and bee container lifecycle
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -107,16 +107,16 @@ A Marshal governs one swarm. After receiving its plan from the Queen it declares
 ## Swarm coordination
 
 ### Handshake
-1. Marshal declares its control queue `ph.control.herald.<instance>` bound to `ph.control` for `sig.*` and `ev.*` topics.
-2. Marshal emits `ev.ready.herald.<instance>` to signal readiness.
+1. Marshal declares its control queue `ph.control.swarm-controller.<instance>` bound to `ph.control` for `sig.*` and `ev.*` topics.
+2. Marshal emits `ev.ready.swarm-controller.<instance>` to signal readiness.
 3. Queen waits for the ready event and publishes `sig.swarm-start.<swarmId>` to the Marshal queue with the resolved **SwarmPlan**.
 
 ```mermaid
 sequenceDiagram
   participant Marshal
   participant Queen
-  Note over Marshal: declares ph.control.herald.<instance>
-  Marshal->>Queen: ev.ready.herald.<instance>
+  Note over Marshal: declares ph.control.swarm-controller.<instance>
+  Marshal->>Queen: ev.ready.swarm-controller.<instance>
   Queen->>Marshal: sig.swarm-start.<swarmId> (SwarmPlan)
 ```
 
@@ -186,7 +186,7 @@ Communication between the Queen and Marshal uses these topics on `ph.control`:
 | Queen → Marshal | `sig.swarm-stop.<swarmId>` | _(empty)_ | Stop swarm |
 | Queen → Marshal (optional) | `sig.config-update...` | Partial plan | Adjust running swarm |
 | Queen → Marshal (optional) | `sig.status-request...` | _(empty)_ | Request status |
-| Marshal → Queen | `ev.ready.herald.<instance>` | _(empty)_ | Marshal is listening |
+| Marshal → Queen | `ev.ready.swarm-controller.<instance>` | _(empty)_ | Marshal is listening |
 | Marshal → Queen | `ev.status-full.swarm-controller.<instance>` | Status snapshot | Report state |
 
 ## Multi-Region & Queue Adapters

--- a/orchestrator-service/src/main/java/io/pockethive/orchestrator/app/SwarmSignalListener.java
+++ b/orchestrator-service/src/main/java/io/pockethive/orchestrator/app/SwarmSignalListener.java
@@ -57,7 +57,7 @@ public class SwarmSignalListener {
             } catch (Exception e) {
                 log.error("Failed to start swarm {}", swarmId, e);
             }
-        } else if (routingKey.startsWith("ev.ready.herald.")) {
+        } else if (routingKey.startsWith("ev.ready.swarm-controller.")) {
             SwarmPlan plan = new SwarmPlan(Topology.SWARM_ID, template);
             rabbit.convertAndSend(Topology.CONTROL_EXCHANGE,
                     "sig.swarm-start." + Topology.SWARM_ID, plan);

--- a/orchestrator-service/src/test/java/io/pockethive/orchestrator/app/SwarmSignalListenerTest.java
+++ b/orchestrator-service/src/test/java/io/pockethive/orchestrator/app/SwarmSignalListenerTest.java
@@ -43,11 +43,11 @@ class SwarmSignalListenerTest {
     }
 
     @Test
-    void sendsPlanOnHeraldReady() {
+    void sendsPlanOnSwarmControllerReady() {
         SwarmTemplate template = new SwarmTemplate();
         SwarmSignalListener listener = new SwarmSignalListener(lifecycle, rabbit, "inst", template);
 
-        listener.handle("", "ev.ready.herald.inst");
+        listener.handle("", "ev.ready.swarm-controller.inst");
 
         verify(rabbit).convertAndSend(eq(io.pockethive.Topology.CONTROL_EXCHANGE),
                 eq("sig.swarm-start." + io.pockethive.Topology.SWARM_ID),

--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/ReadyEmitter.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/ReadyEmitter.java
@@ -23,7 +23,7 @@ public class ReadyEmitter {
 
     @EventListener(ApplicationReadyEvent.class)
     public void emit() {
-        String rk = "ev.ready.herald." + instanceId;
+        String rk = "ev.ready.swarm-controller." + instanceId;
         rabbit.convertAndSend(Topology.CONTROL_EXCHANGE, rk, "");
     }
 }

--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmLifecycle.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmLifecycle.java
@@ -1,6 +1,7 @@
 package io.pockethive.swarmcontroller;
 
 public interface SwarmLifecycle {
+  void prepare(String templateJson);
   void start(String planJson);
   void stop();
   SwarmStatus getStatus();

--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmSignalListener.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmSignalListener.java
@@ -49,7 +49,14 @@ public class SwarmSignalListener {
     MDC.put("swarm_id", Topology.SWARM_ID);
     MDC.put("service", ROLE);
     MDC.put("instance", instanceId);
-    if (routingKey.startsWith("sig.swarm-start.")) {
+    if (routingKey.startsWith("sig.swarm-template.")) {
+      String swarmId = routingKey.substring("sig.swarm-template.".length());
+      if (Topology.SWARM_ID.equals(swarmId)) {
+        log.info("Template signal for swarm {}", swarmId);
+        lifecycle.prepare(body);
+        rabbit.convertAndSend(Topology.CONTROL_EXCHANGE, "ev.swarm-created." + swarmId, "");
+      }
+    } else if (routingKey.startsWith("sig.swarm-start.")) {
       String swarmId = routingKey.substring("sig.swarm-start.".length());
       if (Topology.SWARM_ID.equals(swarmId)) {
         log.info("Start signal for swarm {}", swarmId);
@@ -103,6 +110,7 @@ public class SwarmSignalListener {
             "sig.status-request",
             "sig.status-request." + ROLE,
             "sig.status-request." + ROLE + "." + instanceId,
+            "sig.swarm-template.*",
             "sig.swarm-start.*",
             "sig.swarm-stop.*")
         .controlOut(rk)
@@ -128,6 +136,7 @@ public class SwarmSignalListener {
             "sig.status-request",
             "sig.status-request." + ROLE,
             "sig.status-request." + ROLE + "." + instanceId,
+            "sig.swarm-template.*",
             "sig.swarm-start.*",
             "sig.swarm-stop.*")
         .controlOut(rk)

--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/infra/docker/DockerContainerClient.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/infra/docker/DockerContainerClient.java
@@ -19,6 +19,17 @@ public class DockerContainerClient {
     return response.getId();
   }
 
+  public String createContainer(String image) {
+    CreateContainerResponse response = dockerClient.createContainerCmd(image)
+        .withHostConfig(HostConfig.newHostConfig())
+        .exec();
+    return response.getId();
+  }
+
+  public void startContainer(String containerId) {
+    dockerClient.startContainerCmd(containerId).exec();
+  }
+
   public void stopAndRemoveContainer(String containerId) {
     dockerClient.stopContainerCmd(containerId).exec();
     dockerClient.removeContainerCmd(containerId).exec();

--- a/swarm-controller-service/src/test/java/io/pockethive/swarmcontroller/ReadyEmitterTest.java
+++ b/swarm-controller-service/src/test/java/io/pockethive/swarmcontroller/ReadyEmitterTest.java
@@ -18,6 +18,6 @@ class ReadyEmitterTest {
     void emitsReadyEventOnStartup() {
         ReadyEmitter emitter = new ReadyEmitter(rabbit, "inst");
         emitter.emit();
-        verify(rabbit).convertAndSend(Topology.CONTROL_EXCHANGE, "ev.ready.herald.inst", "");
+        verify(rabbit).convertAndSend(Topology.CONTROL_EXCHANGE, "ev.ready.swarm-controller.inst", "");
     }
 }

--- a/swarm-controller-service/src/test/java/io/pockethive/swarmcontroller/SwarmSignalListenerTest.java
+++ b/swarm-controller-service/src/test/java/io/pockethive/swarmcontroller/SwarmSignalListenerTest.java
@@ -55,6 +55,17 @@ class SwarmSignalListenerTest {
   }
 
   @Test
+  void handlesTemplateWithoutStarting() {
+    when(lifecycle.getStatus()).thenReturn(SwarmStatus.STOPPED);
+    SwarmSignalListener listener = new SwarmSignalListener(lifecycle, rabbit, "inst", new ObjectMapper());
+    reset(lifecycle, rabbit);
+    listener.handle("tmpl", "sig.swarm-template." + Topology.SWARM_ID);
+    verify(lifecycle).prepare("tmpl");
+    verify(rabbit).convertAndSend(Topology.CONTROL_EXCHANGE, "ev.swarm-created." + Topology.SWARM_ID, "");
+    verifyNoMoreInteractions(lifecycle);
+  }
+
+  @Test
   void stopsSwarmWhenIdMatches() {
     when(lifecycle.getStatus()).thenReturn(SwarmStatus.RUNNING);
     SwarmSignalListener listener = new SwarmSignalListener(lifecycle, rabbit, "inst", new ObjectMapper());


### PR DESCRIPTION
## Summary
- emit `ev.ready.swarm-controller` when the controller starts
- prepare swarm templates and signal creation before start
- update orchestrator to watch for new readiness event

## Testing
- `mvn -q -pl orchestrator-service,swarm-controller-service test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c98f4bd88328906b75f96e59eb70