### PR TITLE
feat(controller): add readiness tracking and scenario hooks

### DIFF
--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/RabbitConfig.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/RabbitConfig.java
@@ -47,6 +47,18 @@ public class RabbitConfig {
   }
 
   @Bean
+  Binding bindScenarioPart(@Qualifier("controlQueue") Queue controlQueue,
+                           @Qualifier("controlExchange") TopicExchange controlExchange) {
+    return BindingBuilder.bind(controlQueue).to(controlExchange).with("sig.scenario-part.*");
+  }
+
+  @Bean
+  Binding bindScenarioStart(@Qualifier("controlQueue") Queue controlQueue,
+                            @Qualifier("controlExchange") TopicExchange controlExchange) {
+    return BindingBuilder.bind(controlQueue).to(controlExchange).with("sig.scenario-start.*");
+  }
+
+  @Bean
   Binding bindConfigGlobal(@Qualifier("controlQueue") Queue controlQueue,
                            @Qualifier("controlExchange") TopicExchange controlExchange) {
     return BindingBuilder.bind(controlQueue).to(controlExchange).with("sig.config-update");
@@ -84,6 +96,12 @@ public class RabbitConfig {
                              String instanceId) {
     return BindingBuilder.bind(controlQueue).to(controlExchange)
         .with("sig.status-request." + ROLE + "." + instanceId);
+  }
+
+  @Bean
+  Binding bindReadyEvents(@Qualifier("controlQueue") Queue controlQueue,
+                          @Qualifier("controlExchange") TopicExchange controlExchange) {
+    return BindingBuilder.bind(controlQueue).to(controlExchange).with("ev.ready.*");
   }
 
   @Bean

--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmLifecycle.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmLifecycle.java
@@ -5,4 +5,19 @@ public interface SwarmLifecycle {
   void start(String planJson);
   void stop();
   SwarmStatus getStatus();
+  /**
+   * Record readiness of a component identified by role and instance.
+   * @return true when all expected components are ready
+   */
+  boolean markReady(String role, String instance);
+
+  /**
+   * Apply the first scenario step configuration while keeping components disabled.
+   */
+  void applyScenarioStep(String stepJson);
+
+  /**
+   * Enable all components and begin scenario execution.
+   */
+  void enableAll();
 }

--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmSignalListener.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmSignalListener.java
@@ -54,13 +54,25 @@ public class SwarmSignalListener {
       if (Topology.SWARM_ID.equals(swarmId)) {
         log.info("Template signal for swarm {}", swarmId);
         lifecycle.prepare(body);
-        rabbit.convertAndSend(Topology.CONTROL_EXCHANGE, "ev.swarm-created." + swarmId, "");
       }
     } else if (routingKey.startsWith("sig.swarm-start.")) {
       String swarmId = routingKey.substring("sig.swarm-start.".length());
       if (Topology.SWARM_ID.equals(swarmId)) {
         log.info("Start signal for swarm {}", swarmId);
         lifecycle.start(body);
+        sendStatusFull();
+      }
+    } else if (routingKey.startsWith("sig.scenario-part.")) {
+      String swarmId = routingKey.substring("sig.scenario-part.".length());
+      if (Topology.SWARM_ID.equals(swarmId)) {
+        log.info("Scenario part for swarm {}", swarmId);
+        lifecycle.applyScenarioStep(body);
+      }
+    } else if (routingKey.startsWith("sig.scenario-start.")) {
+      String swarmId = routingKey.substring("sig.scenario-start.".length());
+      if (Topology.SWARM_ID.equals(swarmId)) {
+        log.info("Scenario start for swarm {}", swarmId);
+        lifecycle.enableAll();
         sendStatusFull();
       }
     } else if (routingKey.startsWith("sig.swarm-stop.")) {
@@ -82,6 +94,23 @@ public class SwarmSignalListener {
         }
       } catch (Exception e) {
         log.warn("config parse", e);
+      }
+    } else if (routingKey.startsWith("ev.ready.")) {
+      String rest = routingKey.substring("ev.ready.".length());
+      String[] parts = rest.split("\.", 2);
+      if (parts.length == 2) {
+        try {
+          JsonNode node = mapper.readTree(body);
+          boolean enabled = node.path("data").path("enabled").asBoolean(true);
+          if (!enabled) {
+            boolean allReady = lifecycle.markReady(parts[0], parts[1]);
+            if (allReady) {
+              rabbit.convertAndSend(Topology.CONTROL_EXCHANGE, "ev.swarm-created." + Topology.SWARM_ID, "");
+            }
+          }
+        } catch (Exception e) {
+          log.warn("ready parse", e);
+        }
       }
     }
     MDC.clear();
@@ -112,6 +141,8 @@ public class SwarmSignalListener {
             "sig.status-request." + ROLE + "." + instanceId,
             "sig.swarm-template.*",
             "sig.swarm-start.*",
+            "sig.scenario-part.*",
+            "sig.scenario-start.*",
             "sig.swarm-stop.*")
         .controlOut(rk)
         .toJson();
@@ -138,6 +169,8 @@ public class SwarmSignalListener {
             "sig.status-request." + ROLE + "." + instanceId,
             "sig.swarm-template.*",
             "sig.swarm-start.*",
+            "sig.scenario-part.*",
+            "sig.scenario-start.*",
             "sig.swarm-stop.*")
         .controlOut(rk)
         .toJson();

--- a/swarm-controller-service/src/test/java/io/pockethive/swarmcontroller/SwarmSignalListenerTest.java
+++ b/swarm-controller-service/src/test/java/io/pockethive/swarmcontroller/SwarmSignalListenerTest.java
@@ -3,12 +3,17 @@ package io.pockethive.swarmcontroller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.pockethive.Topology;
 import io.pockethive.swarmcontroller.SwarmStatus;
-import static org.mockito.ArgumentMatchers.argThat;
+import io.pockethive.swarmcontroller.SwarmPlan;
+import io.pockethive.swarmcontroller.infra.docker.DockerContainerClient;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
+
+import java.util.List;
+import static org.mockito.ArgumentMatchers.argThat;
 
 import static org.mockito.Mockito.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -61,8 +66,8 @@ class SwarmSignalListenerTest {
     reset(lifecycle, rabbit);
     listener.handle("tmpl", "sig.swarm-template." + Topology.SWARM_ID);
     verify(lifecycle).prepare("tmpl");
-    verify(rabbit).convertAndSend(Topology.CONTROL_EXCHANGE, "ev.swarm-created." + Topology.SWARM_ID, "");
     verifyNoMoreInteractions(lifecycle);
+    verifyNoInteractions(rabbit);
   }
 
   @Test
@@ -82,6 +87,37 @@ class SwarmSignalListenerTest {
     reset(lifecycle, rabbit);
     listener.handle("", "sig.swarm-stop.other");
     verifyNoInteractions(lifecycle);
+  }
+
+  @Test
+  void partialReadinessDoesNotEmitSwarmCreated() throws Exception {
+    AmqpAdmin amqp = mock(AmqpAdmin.class);
+    DockerContainerClient docker = mock(DockerContainerClient.class);
+    ObjectMapper mapper = new ObjectMapper();
+    SwarmLifecycleManager manager = new SwarmLifecycleManager(amqp, mapper, docker, rabbit, "inst");
+    SwarmSignalListener listener = new SwarmSignalListener(manager, rabbit, "inst", mapper);
+    reset(rabbit);
+    SwarmPlan plan = new SwarmPlan(List.of(new SwarmPlan.Bee("gen", "img1", null), new SwarmPlan.Bee("mod", "img2", null)));
+    listener.handle(mapper.writeValueAsString(plan), "sig.swarm-template." + Topology.SWARM_ID);
+    reset(rabbit);
+    listener.handle("{\"data\":{\"enabled\":false}}", "ev.ready.gen.a");
+    verify(rabbit, never()).convertAndSend(eq(Topology.CONTROL_EXCHANGE), eq("ev.swarm-created." + Topology.SWARM_ID), any());
+  }
+
+  @Test
+  void fullReadinessEmitsSwarmCreated() throws Exception {
+    AmqpAdmin amqp = mock(AmqpAdmin.class);
+    DockerContainerClient docker = mock(DockerContainerClient.class);
+    ObjectMapper mapper = new ObjectMapper();
+    SwarmLifecycleManager manager = new SwarmLifecycleManager(amqp, mapper, docker, rabbit, "inst");
+    SwarmSignalListener listener = new SwarmSignalListener(manager, rabbit, "inst", mapper);
+    reset(rabbit);
+    SwarmPlan plan = new SwarmPlan(List.of(new SwarmPlan.Bee("gen", "img1", null), new SwarmPlan.Bee("mod", "img2", null)));
+    listener.handle(mapper.writeValueAsString(plan), "sig.swarm-template." + Topology.SWARM_ID);
+    reset(rabbit);
+    listener.handle("{\"data\":{\"enabled\":false}}", "ev.ready.gen.a");
+    listener.handle("{\"data\":{\"enabled\":false}}", "ev.ready.mod.b");
+    verify(rabbit).convertAndSend(Topology.CONTROL_EXCHANGE, "ev.swarm-created." + Topology.SWARM_ID, "");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- track component readiness in SwarmLifecycleManager
- handle scenario-part/start and component ready events in SwarmSignalListener
- add tests for partial vs. full readiness

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c0d32bb47c832890ccc42fe7018fdc