### PR TITLE
docs: add topology core README

### DIFF
--- a/common/topology-core/README.md
+++ b/common/topology-core/README.md
@@ -1,0 +1,46 @@
+# Topology Core
+
+Shared constants for PocketHive's RabbitMQ topology.
+
+## Constants
+
+The `io.pockethive.Topology` class exposes the following names:
+
+| Constant | Environment variable | Default |
+| --- | --- | --- |
+| `Topology.SWARM_ID` | `PH_SWARM_ID` | `default` |
+| `Topology.EXCHANGE` | `PH_TRAFFIC_EXCHANGE` | `ph.<swarm>.hive` |
+| `Topology.GEN_QUEUE` | `PH_GEN_QUEUE` | `ph.<swarm>.gen` |
+| `Topology.MOD_QUEUE` | `PH_MOD_QUEUE` | `ph.<swarm>.mod` |
+| `Topology.FINAL_QUEUE` | `PH_FINAL_QUEUE` | `ph.<swarm>.final` |
+| `Topology.CONTROL_QUEUE` | `PH_CONTROL_QUEUE` | `ph.control` |
+| `Topology.CONTROL_EXCHANGE` | `PH_CONTROL_EXCHANGE` | `ph.control` |
+
+Each constant first checks an environment variable (or JVM system property) and falls back to the default value shown.
+
+## Usage
+
+```java
+import io.pockethive.Topology;
+import com.rabbitmq.client.Channel;
+
+Channel channel = // obtain channel
+channel.exchangeDeclare(Topology.EXCHANGE, "topic", true);
+channel.queueDeclare(Topology.GEN_QUEUE, true, false, false, null);
+```
+
+All services rely on these constants to keep queue and exchange names consistent.
+
+## Overrides
+
+Supply environment variables or `-D` system properties at runtime to override defaults:
+
+```bash
+PH_SWARM_ID=beta PH_GEN_QUEUE=ph.beta.custom ./run-service
+```
+
+```bash
+java -DPH_SWARM_ID=beta -DPH_GEN_QUEUE=ph.beta.custom ...
+```
+
+This allows services to join different swarms or adjust routing without code changes.

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,5 +23,8 @@ Welcome to the PocketHive documentation hub. Use these resources to understand t
 - [Trigger](../trigger-service/README.md)
 - [Log Aggregator](../log-aggregator-service/README.md)
 
+## Core Modules
+- [Topology Core](../common/topology-core/README.md)
+
 ## Contributing
 - [Contributor Guide](../CONTRIBUTING.md)


### PR DESCRIPTION
## Summary
- document RabbitMQ constants in `Topology`
- link topology-core docs from main index

## Testing
- `npm run build`
- `npm test` *(fails: Invalid Chai property: toBeInTheDocument)*
- `npm run lint` *(fails: 13 errors)*
- `mvn -q -pl common/topology-core test` *(fails: missing dependency versions / network)*
- `npx commitlint --from=HEAD~1 --to=HEAD` *(fails: cannot find module @commitlint/config-conventional)*

------
https://chatgpt.com/codex/tasks/task_e_68c151ef06f4832898dd2e238279ec1e