### PR TITLE
build: default infra services and optional bees profile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
         condition: service_healthy
 
   swarm-controller:
+    profiles: ["bees"]
     build:
       context: .
       dockerfile: swarm-controller-service/Dockerfile
@@ -46,6 +47,7 @@ services:
         condition: service_healthy
 
   generator:
+    profiles: ["bees"]
     build:
       context: .
       dockerfile: generator-service/Dockerfile
@@ -59,6 +61,7 @@ services:
         condition: service_healthy
 
   moderator:
+    profiles: ["bees"]
     build:
       context: .
       dockerfile: moderator-service/Dockerfile
@@ -72,6 +75,7 @@ services:
         condition: service_healthy
 
   processor:
+    profiles: ["bees"]
     build:
       context: .
       dockerfile: processor-service/Dockerfile
@@ -85,6 +89,7 @@ services:
         condition: service_healthy
 
   postprocessor:
+    profiles: ["bees"]
     build:
       context: .
       dockerfile: postprocessor-service/Dockerfile
@@ -98,6 +103,7 @@ services:
         condition: service_healthy
 
   trigger:
+    profiles: ["bees"]
     build:
       context: .
       dockerfile: trigger-service/Dockerfile


### PR DESCRIPTION
## Summary
- move bee containers under optional `bees` profile
- start log-aggregator and observability services by default by dropping `infra` profile
- orchestrator waits on log-aggregator health before launching

## Testing
- `npm run lint` *(fails: Unexpected any / Empty block statement)*
- `npm test` *(fails: Invalid Chai property: toBeInTheDocument)*
- `npm run build`
- `mvn -q test` *(fails: missing dependency versions / Non-resolvable import POM)*
- `npx --yes commitlint --from=HEAD~1` *(fails: Cannot find module @commitlint/config-conventional)*

------
https://chatgpt.com/codex/tasks/task_e_68c156b3a7dc832891f32c2843cd68db