### PR TITLE
feat: expand swarm template with bee configuration

### DIFF
--- a/orchestrator-service/src/main/java/io/pockethive/orchestrator/app/SwarmSignalListener.java
+++ b/orchestrator-service/src/main/java/io/pockethive/orchestrator/app/SwarmSignalListener.java
@@ -58,9 +58,9 @@ public class SwarmSignalListener {
             String swarmId = routingKey.substring("sig.swarm-create.".length());
             ScenarioPlan scenario = scenarios.find(body).orElse(null);
             if (scenario != null) {
-                SwarmPlan plan = new SwarmPlan(swarmId, scenario.template());
+                SwarmPlan plan = scenario.toSwarmPlan(swarmId);
                 String beeName = BeeNameGenerator.generate("swarm-controller", swarmId);
-                lifecycle.startSwarm(swarmId, plan.template().getImage(), beeName);
+                lifecycle.startSwarm(swarmId, scenario.template().getImage(), beeName);
                 plans.register(beeName, plan);
             }
         } else if (routingKey.startsWith("sig.swarm-stop.")) {
@@ -72,7 +72,7 @@ public class SwarmSignalListener {
             String inst = routingKey.substring("ev.ready.swarm-controller.".length());
             plans.remove(inst).ifPresent(plan ->
                 rabbit.convertAndSend(Topology.CONTROL_EXCHANGE,
-                    "sig.swarm-start." + plan.id(), plan));
+                    "sig.swarm-start." + plan.id(), java.util.Map.of("bees", plan.bees())));
         } else if (routingKey.startsWith("sig.status-request")) {
             sendStatusFull();
         }

--- a/orchestrator-service/src/main/java/io/pockethive/orchestrator/domain/ScenarioPlan.java
+++ b/orchestrator-service/src/main/java/io/pockethive/orchestrator/domain/ScenarioPlan.java
@@ -1,7 +1,14 @@
 package io.pockethive.orchestrator.domain;
 
+import java.util.List;
+
 /**
  * Scenario description that can be expanded into a SwarmPlan.
  */
-public record ScenarioPlan(SwarmTemplate template) { }
+public record ScenarioPlan(SwarmTemplate template) {
+    public SwarmPlan toSwarmPlan(String id) {
+        List<SwarmPlan.Bee> bees = template.getBees();
+        return new SwarmPlan(id, bees);
+    }
+}
 

--- a/orchestrator-service/src/main/java/io/pockethive/orchestrator/domain/SwarmPlan.java
+++ b/orchestrator-service/src/main/java/io/pockethive/orchestrator/domain/SwarmPlan.java
@@ -1,6 +1,12 @@
 package io.pockethive.orchestrator.domain;
 
+import java.util.List;
+
 /**
- * Plan sent to a Marshal to bootstrap a swarm.
+ * Plan describing the bees to launch for a swarm instance.
  */
-public record SwarmPlan(String id, SwarmTemplate template) { }
+public record SwarmPlan(String id, List<Bee> bees) {
+    public record Bee(String role, String image, Work work) { }
+    public record Work(String in, String out) { }
+}
+

--- a/orchestrator-service/src/main/java/io/pockethive/orchestrator/domain/SwarmTemplate.java
+++ b/orchestrator-service/src/main/java/io/pockethive/orchestrator/domain/SwarmTemplate.java
@@ -1,7 +1,13 @@
 package io.pockethive.orchestrator.domain;
 
+import java.util.List;
+
+/**
+ * Template describing the swarm-controller image and the bees to launch.
+ */
 public class SwarmTemplate {
     private String image;
+    private List<SwarmPlan.Bee> bees;
 
     public String getImage() {
         return image;
@@ -9,5 +15,13 @@ public class SwarmTemplate {
 
     public void setImage(String image) {
         this.image = image;
+    }
+
+    public List<SwarmPlan.Bee> getBees() {
+        return bees;
+    }
+
+    public void setBees(List<SwarmPlan.Bee> bees) {
+        this.bees = bees;
     }
 }

--- a/orchestrator-service/src/main/resources/templates/swarm.yml
+++ b/orchestrator-service/src/main/resources/templates/swarm.yml
@@ -1,1 +1,12 @@
 image: swarm-controller-service:latest
+bees:
+  - role: generator
+    image: generator-service:latest
+    work:
+      in: gen
+      out: mod
+  - role: moderator
+    image: moderator-service:latest
+    work:
+      in: mod
+      out: final

--- a/orchestrator-service/src/test/java/io/pockethive/orchestrator/app/SwarmLifecycleIntegrationTest.java
+++ b/orchestrator-service/src/test/java/io/pockethive/orchestrator/app/SwarmLifecycleIntegrationTest.java
@@ -1,7 +1,6 @@
 package io.pockethive.orchestrator.app;
 
 import io.pockethive.Topology;
-import io.pockethive.orchestrator.domain.SwarmPlan;
 import io.pockethive.orchestrator.domain.SwarmPlanRegistry;
 import io.pockethive.orchestrator.domain.SwarmRegistry;
 import io.pockethive.orchestrator.infra.docker.DockerContainerClient;
@@ -51,9 +50,9 @@ class SwarmLifecycleIntegrationTest {
 
         listener.handle("", "ev.ready.swarm-controller." + beeName);
 
-        ArgumentCaptor<SwarmPlan> planCaptor = ArgumentCaptor.forClass(SwarmPlan.class);
+        ArgumentCaptor<java.util.Map<String, Object>> planCaptor = ArgumentCaptor.forClass(java.util.Map.class);
         verify(rabbit).convertAndSend(eq(Topology.CONTROL_EXCHANGE), eq("sig.swarm-start.sw1"), planCaptor.capture());
-        assertThat(planCaptor.getValue().id()).isEqualTo("sw1");
+        assertThat(planCaptor.getValue().get("bees")).isNotNull();
         assertThat(planRegistry.find(beeName)).isEmpty();
 
         listener.handle("", "sig.swarm-stop.sw1");

--- a/orchestrator-service/src/test/java/io/pockethive/orchestrator/app/TemplateConfigurationTest.java
+++ b/orchestrator-service/src/test/java/io/pockethive/orchestrator/app/TemplateConfigurationTest.java
@@ -10,6 +10,8 @@ class TemplateConfigurationTest {
     void loadsTemplateFromYaml() throws Exception {
         TemplateConfiguration cfg = new TemplateConfiguration();
         SwarmTemplate template = cfg.swarmTemplate();
-        assertEquals("generator-service:latest", template.getImage());
+        assertEquals("swarm-controller-service:latest", template.getImage());
+        assertEquals(2, template.getBees().size());
+        assertEquals("generator", template.getBees().get(0).role());
     }
 }


### PR DESCRIPTION
## Summary
- allow swarm.yml to specify bee roles, images and work queues
- build swarm plans from scenario templates for swarm-controller consumption
- send controller plans without metadata and trigger bee queue provisioning

## Testing
- `mvn -q -pl orchestrator-service,swarm-controller-service -am test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a3671e74832899dae94fb2d62ec4