### PR TITLE
feat: integrate scenario manager service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,6 +116,19 @@ services:
       log-aggregator:
         condition: service_healthy
 
+  scenario-manager:
+    build:
+      context: .
+      dockerfile: scenario-manager-service/Dockerfile
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8080/actuator/health | grep -q UP"]
+      interval: 5s
+      timeout: 10s
+      retries: 10
+      start_period: 30s
+    ports:
+      - "1081:8080"
+
   log-aggregator:
     build:
       context: .

--- a/observability/src/main/java/io/pockethive/util/BeeNameGenerator.java
+++ b/observability/src/main/java/io/pockethive/util/BeeNameGenerator.java
@@ -50,7 +50,7 @@ public final class BeeNameGenerator {
           "postprocessor", "forager",
           "trigger", "buzzer",
           "log-aggregator", "scribe",
-          "swarm-controller", "marshal");
+          "swarm-controller", "queen");
 
   public static String generate(String role) {
     return generate(role, null);

--- a/observability/src/test/java/io/pockethive/util/BeeNameGeneratorTest.java
+++ b/observability/src/test/java/io/pockethive/util/BeeNameGeneratorTest.java
@@ -19,8 +19,8 @@ class BeeNameGeneratorTest {
   }
 
   @Test
-  void mapsSwarmControllerToMarshal() {
+  void mapsSwarmControllerToQueen() {
     String name = BeeNameGenerator.generate("swarm-controller", "sw1");
-    assertTrue(name.startsWith("sw1-marshal-bee-"));
+    assertTrue(name.startsWith("sw1-queen-bee-"));
   }
 }

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -30,3 +30,8 @@ scrape_configs:
     metrics_path: /actuator/prometheus
     static_configs:
       - targets: ['generator:8080']
+  - job_name: 'scenario-manager'
+    scrape_interval: 5s
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['scenario-manager:8080']

--- a/scenario-manager-service/Dockerfile
+++ b/scenario-manager-service/Dockerfile
@@ -36,5 +36,6 @@ WORKDIR /app
 RUN apk add --no-cache curl
 COPY --from=build /app/scenario-manager-service/target/*.jar app.jar
 COPY scenario-manager-service/entrypoint.sh /app/entrypoint.sh
+COPY scenario-manager-service/scenarios /app/scenarios
 RUN chmod +x /app/entrypoint.sh
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/scenario-manager-service/scenarios/mock-1.yaml
+++ b/scenario-manager-service/scenarios/mock-1.yaml
@@ -1,0 +1,24 @@
+id: mock-1
+name: Mock-1
+description: Sample scenario with generator, moderator, processor and postprocessor.
+template:
+  image: swarm-controller-service:latest
+  bees:
+    - role: generator
+      image: generator-service:latest
+      work:
+        out: gen
+    - role: moderator
+      image: moderator-service:latest
+      work:
+        in: gen
+        out: mod
+    - role: processor
+      image: processor-service:latest
+      work:
+        in: mod
+        out: final
+    - role: postprocessor
+      image: postprocessor-service:latest
+      work:
+        in: final

--- a/scenario-manager-service/src/main/java/io/pockethive/scenarios/Scenario.java
+++ b/scenario-manager-service/src/main/java/io/pockethive/scenarios/Scenario.java
@@ -8,13 +8,15 @@ public class Scenario {
     @NotBlank
     private String name;
     private String description;
+    private Template template;
 
     public Scenario() {}
 
-    public Scenario(String id, String name, String description) {
+    public Scenario(String id, String name, String description, Template template) {
         this.id = id;
         this.name = name;
         this.description = description;
+        this.template = template;
     }
 
     public String getId() {
@@ -39,5 +41,87 @@ public class Scenario {
 
     public void setDescription(String description) {
         this.description = description;
+    }
+
+    public Template getTemplate() {
+        return template;
+    }
+
+    public void setTemplate(Template template) {
+        this.template = template;
+    }
+
+    public static class Template {
+        private String image;
+        private java.util.List<Bee> bees;
+
+        public String getImage() {
+            return image;
+        }
+
+        public void setImage(String image) {
+            this.image = image;
+        }
+
+        public java.util.List<Bee> getBees() {
+            return bees;
+        }
+
+        public void setBees(java.util.List<Bee> bees) {
+            this.bees = bees;
+        }
+    }
+
+    public static class Bee {
+        @NotBlank
+        private String role;
+        @NotBlank
+        private String image;
+        private Work work;
+
+        public String getRole() {
+            return role;
+        }
+
+        public void setRole(String role) {
+            this.role = role;
+        }
+
+        public String getImage() {
+            return image;
+        }
+
+        public void setImage(String image) {
+            this.image = image;
+        }
+
+        public Work getWork() {
+            return work;
+        }
+
+        public void setWork(Work work) {
+            this.work = work;
+        }
+    }
+
+    public static class Work {
+        private String in;
+        private String out;
+
+        public String getIn() {
+            return in;
+        }
+
+        public void setIn(String in) {
+            this.in = in;
+        }
+
+        public String getOut() {
+            return out;
+        }
+
+        public void setOut(String out) {
+            this.out = out;
+        }
     }
 }

--- a/scenario-manager-service/src/test/java/io/pockethive/scenarios/HealthEndpointTest.java
+++ b/scenario-manager-service/src/test/java/io/pockethive/scenarios/HealthEndpointTest.java
@@ -1,0 +1,23 @@
+package io.pockethive.scenarios;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class HealthEndpointTest {
+
+    @Autowired
+    TestRestTemplate rest;
+
+    @Test
+    void healthEndpointReportsUp() {
+        ResponseEntity<String> resp = rest.getForEntity("/actuator/health", String.class);
+        assertThat(resp.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(resp.getBody()).contains("UP");
+    }
+}

--- a/scenario-manager-service/src/test/java/io/pockethive/scenarios/ScenarioManagerApplicationTest.java
+++ b/scenario-manager-service/src/test/java/io/pockethive/scenarios/ScenarioManagerApplicationTest.java
@@ -1,0 +1,26 @@
+package io.pockethive.scenarios;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.nio.file.Path;
+
+@SpringBootTest
+class ScenarioManagerApplicationTest {
+
+    @TempDir
+    static Path tempDir;
+
+    @DynamicPropertySource
+    static void properties(DynamicPropertyRegistry registry) {
+        registry.add("scenarios.dir", () -> tempDir.toString());
+    }
+
+    @Test
+    void contextLoads() {
+        // Ensures application starts successfully
+    }
+}

--- a/ui/src/pages/hive/HivePage.test.tsx
+++ b/ui/src/pages/hive/HivePage.test.tsx
@@ -22,7 +22,7 @@ vi.mock('./TopologyView', () => ({
 
 const comps: Component[] = [
   {
-    id: 'sw1-marshal',
+    id: 'sw1-queen',
     name: 'swarm-controller',
     swarmId: 'sw1',
     lastHeartbeat: 0,
@@ -53,16 +53,16 @@ beforeEach(() => {
   ;(requestStatusFull as unknown as Mock).mockResolvedValue(undefined)
 })
 
-test('renders marshal status and start/stop controls', async () => {
+test('renders queen status and start/stop controls', async () => {
   const user = userEvent.setup()
   render(<HivePage />)
-  expect(screen.getByText(/Marshal: stopped/i)).toBeTruthy()
+  expect(screen.getByText(/Queen: stopped/i)).toBeTruthy()
   await user.click(screen.getByRole('button', { name: /start/i }))
   expect(startSwarm).toHaveBeenCalledWith('sw1')
 
   comps[0].config = { swarmStatus: 'RUNNING', enabled: true }
   if (listener) listener([...comps])
-  expect(await screen.findByText(/Marshal: running/i)).toBeTruthy()
+  expect(await screen.findByText(/Queen: running/i)).toBeTruthy()
   await user.click(screen.getAllByRole('button', { name: /stop/i })[1])
   expect(stopSwarm).toHaveBeenCalledWith('sw1')
 })

--- a/ui/src/pages/hive/HivePage.tsx
+++ b/ui/src/pages/hive/HivePage.tsx
@@ -53,8 +53,8 @@ export default function HivePage() {
   }, {})
 
   const swarmStatus = (comps: Component[]) => {
-    const marshal = comps.find((c) => c.name === 'swarm-controller')
-    const status = (marshal?.config?.swarmStatus as string | undefined)?.toLowerCase()
+    const queen = comps.find((c) => c.name === 'swarm-controller')
+    const status = (queen?.config?.swarmStatus as string | undefined)?.toLowerCase()
     if (status) return status
     const enabled = comps.map((c) => c.config?.enabled !== false)
     if (enabled.every(Boolean)) return 'running'
@@ -131,7 +131,7 @@ export default function HivePage() {
                       {id}
                     </div>
                     <div className="flex items-center gap-2">
-                      <span className="text-xs text-white/60">Marshal: {status}</span>
+                      <span className="text-xs text-white/60">Queen: {status}</span>
                       {status !== 'running' && (
                         <button
                           className="p-1 rounded bg-white/10 hover:bg-white/20 text-xs"

--- a/ui/src/pages/hive/SwarmCreateModal.tsx
+++ b/ui/src/pages/hive/SwarmCreateModal.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react'
 import { createSwarm } from '../../lib/stompClient'
-import { defaultBees } from '../../lib/defaultBees'
 
 interface Props {
   onClose: () => void
@@ -40,7 +39,7 @@ export default function SwarmCreateModal({ onClose }: Props) {
       return
     }
     try {
-      await createSwarm(swarmId.trim(), { template: { image: image.trim(), bees: defaultBees } })
+      await createSwarm(swarmId.trim(), scenario)
       setMessage('Swarm created')
       setSwarmId('')
       setScenarioName('')


### PR DESCRIPTION
## Summary
- copy sample Mock-1 scenario and expose scenario manager in docker compose with health check and Prometheus scrape
- model templates in Scenario and load pre-baked scenario
- update UI to start scenarios and label Queen status
- rename swarm-controller nicknames from Marshal to Queen

## Testing
- `mvn -q -pl scenario-manager-service,observability test` *(fails: Non-resolvable import POM: Network is unreachable)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1e852118c8328bc70145415adafaf