### PR TITLE
fix(ui): strip scenario-manager prefix in nginx proxy

### DIFF
--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -61,13 +61,14 @@ server {
   # Proxy Scenario Manager API to avoid browser CORS
   location /scenario-manager/ {
     set $scenario_manager scenario-manager;
+    rewrite ^/scenario-manager/(.*)$ /$1 break;
     if ($request_method = OPTIONS) {
       add_header Access-Control-Allow-Origin "*";
       add_header Access-Control-Allow-Headers "Authorization,Content-Type";
       add_header Access-Control-Allow-Methods "GET,POST,PUT,DELETE,OPTIONS";
       return 204;
     }
-    proxy_pass http://$scenario_manager:8080/;
+    proxy_pass http://$scenario_manager:8080;
     proxy_set_header Host $host;
     add_header Access-Control-Allow-Origin "*" always;
     add_header Access-Control-Allow-Headers "Authorization,Content-Type" always;


### PR DESCRIPTION
## Summary
- strip scenario-manager path prefix before proxying in nginx

## Testing
- `npm run build`
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js' imported from ui/eslint.config.js; then ran ui-specific lint which found TypeScript errors)*
- `npx -y commitlint --from=HEAD~1 --to=HEAD` *(fails: Cannot find module "@commitlint/config-conventional")*
- `docker compose up ui -d --build` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d85797b48328b510ca8a6f3f1b67