### PR TITLE
docs: simplify component readmes

### DIFF
--- a/generator-service/README.md
+++ b/generator-service/README.md
@@ -1,23 +1,6 @@
 # Generator Service
 
-Generates traffic for the swarm by publishing messages to the hive exchange.
+Generates swarm traffic by publishing messages to the hive exchange.
 
-## Responsibilities
-- Build and send requests to `ph.<swarmId>.gen`.
-- React to `config-update` and `status-request` signals on the control channel.
+See the [architecture reference](../docs/ARCHITECTURE.md) and [control-plane rules](../docs/rules/control-plane-rules.md) for signal and behaviour details.
 
-## Parameters
-- `PH_SWARM_ID` – identifier for the swarm scope (default `default`).
-- `RABBITMQ_HOST` – broker hostname (default `rabbitmq`).
-
-## Signals
-- Consumes `sig.config-update.generator.*` for runtime changes.
-- Responds to `sig.status-request.generator.*` with `ev.status-full` events.
-
-## Docker
-```bash
-docker build -t generator-service:latest .
-docker run --rm generator-service:latest
-```
-
-See [control-plane rules](../docs/rules/control-plane-rules.md) for full signal formats.

--- a/log-aggregator-service/README.md
+++ b/log-aggregator-service/README.md
@@ -1,24 +1,6 @@
 # Log Aggregator Service
 
-Collects logs from services and ships them to Loki for storage.
+Collects service logs and forwards them to Loki for storage.
 
-## Responsibilities
-- Consume log messages from `ph.logs`.
-- Batch and forward logs to the Loki endpoint.
+See the [architecture reference](../docs/ARCHITECTURE.md) and [control-plane rules](../docs/rules/control-plane-rules.md) for signal and behaviour details.
 
-## Parameters
-- `PH_SWARM_ID` – identifier for the swarm scope (default `default`).
-- `RABBITMQ_HOST` – broker hostname (default `rabbitmq`).
-- `LOKI_URL` – destination Loki instance.
-
-## Signals
-- Consumes `sig.config-update.log-aggregator.*` for runtime changes.
-- Responds to `sig.status-request.log-aggregator.*` with `ev.status-full` events.
-
-## Docker
-```bash
-docker build -t log-aggregator-service:latest .
-docker run --rm log-aggregator-service:latest
-```
-
-See [control-plane rules](../docs/rules/control-plane-rules.md) for full signal formats.

--- a/moderator-service/README.md
+++ b/moderator-service/README.md
@@ -2,23 +2,5 @@
 
 Filters or rewrites generator output before it reaches the processor.
 
-## Responsibilities
-- Consume messages from `ph.<swarmId>.gen`.
-- Optionally modify or drop messages before publishing to `ph.<swarmId>.mod`.
-- React to control-plane signals for runtime configuration.
+See the [architecture reference](../docs/ARCHITECTURE.md) and [control-plane rules](../docs/rules/control-plane-rules.md) for signal and behaviour details.
 
-## Parameters
-- `PH_SWARM_ID` – identifier for the swarm scope (default `default`).
-- `RABBITMQ_HOST` – broker hostname (default `rabbitmq`).
-
-## Signals
-- Consumes `sig.config-update.moderator.*` for runtime changes.
-- Responds to `sig.status-request.moderator.*` with `ev.status-full` events.
-
-## Docker
-```bash
-docker build -t moderator-service:latest .
-docker run --rm moderator-service:latest
-```
-
-See [control-plane rules](../docs/rules/control-plane-rules.md) for full signal formats.

--- a/orchestrator-service/README.md
+++ b/orchestrator-service/README.md
@@ -1,24 +1,6 @@
 # Orchestrator Service
 
-Coordinates swarms in the hive. It reads scenario plans and ensures each swarm is started, monitored and stopped at the right time.
+Coordinates swarms by launching controllers and relaying plans.
 
-## Responsibilities
-- Load scenario definitions and expand them into swarm plans.
-- Launch and stop service containers based on swarm templates.
-- Create a Queen for each swarm and hand off the relevant plan fragment.
-- Publish swarm-level events on the control exchange and track swarm status.
+See the [architecture reference](../docs/ARCHITECTURE.md) and [control-plane rules](../docs/rules/control-plane-rules.md) for signal and behaviour details.
 
-## Parameters
-- `RABBITMQ_HOST` – broker hostname (default `rabbitmq`).
-
-## Signals
-- Consumes `sig.config-update.orchestrator.*` for runtime changes.
-- Responds to `sig.status-request.orchestrator.*` with `ev.status-full` events.
-
-## Docker
-```bash
-docker build -t orchestrator-service:latest .
-docker run --rm orchestrator-service:latest
-```
-
-See [control-plane rules](../docs/rules/control-plane-rules.md) for full signal formats.

--- a/postprocessor-service/README.md
+++ b/postprocessor-service/README.md
@@ -1,24 +1,6 @@
 # Postprocessor Service
 
-Aggregates metrics from final responses and publishes them for analysis.
+Aggregates final responses and emits metrics for analysis.
 
-## Responsibilities
-- Consume messages from `ph.<swarmId>.final`.
-- Record hop and total latency metrics and error counts.
-- Emit metric events to the control exchange.
+See the [architecture reference](../docs/ARCHITECTURE.md) and [control-plane rules](../docs/rules/control-plane-rules.md) for signal and behaviour details.
 
-## Parameters
-- `PH_SWARM_ID` – identifier for the swarm scope (default `default`).
-- `RABBITMQ_HOST` – broker hostname (default `rabbitmq`).
-
-## Signals
-- Consumes `sig.config-update.postprocessor.*` for runtime changes.
-- Responds to `sig.status-request.postprocessor.*` with `ev.status-full` events.
-
-## Docker
-```bash
-docker build -t postprocessor-service:latest .
-docker run --rm postprocessor-service:latest
-```
-
-See [control-plane rules](../docs/rules/control-plane-rules.md) for full signal formats.

--- a/processor-service/README.md
+++ b/processor-service/README.md
@@ -1,24 +1,6 @@
 # Processor Service
 
-Calls the system under test with moderated messages and forwards responses.
+Calls the system under test and forwards responses downstream.
 
-## Responsibilities
-- Consume messages from `ph.<swarmId>.mod`.
-- Invoke the target system and publish results to `ph.<swarmId>.final`.
-- React to control-plane signals for runtime configuration.
+See the [architecture reference](../docs/ARCHITECTURE.md) and [control-plane rules](../docs/rules/control-plane-rules.md) for signal and behaviour details.
 
-## Parameters
-- `PH_SWARM_ID` – identifier for the swarm scope (default `default`).
-- `RABBITMQ_HOST` – broker hostname (default `rabbitmq`).
-
-## Signals
-- Consumes `sig.config-update.processor.*` for runtime changes.
-- Responds to `sig.status-request.processor.*` with `ev.status-full` events.
-
-## Docker
-```bash
-docker build -t processor-service:latest .
-docker run --rm processor-service:latest
-```
-
-See [control-plane rules](../docs/rules/control-plane-rules.md) for full signal formats.

--- a/scenario-manager-service/README.md
+++ b/scenario-manager-service/README.md
@@ -1,19 +1,6 @@
 # Scenario Manager Service
 
-REST service for managing simulation scenarios. Stores scenarios in memory and persists them as JSON or YAML files.
+Manages simulation scenarios over a REST API.
 
-Each request is logged and published to the `PH_LOGS_EXCHANGE` (default `ph.logs`) for collection by Buzz.
+See the [architecture reference](../docs/ARCHITECTURE.md) for endpoint and signal details.
 
-## Endpoints
-- `GET /scenarios` – list available scenarios as `{id, name}` summaries for UI dropdowns.
-- `GET /scenarios/{id}` – retrieve a scenario definition in JSON format.
-- `POST /scenarios` – create a new scenario.
-- `PUT /scenarios/{id}` – update an existing scenario.
-- `DELETE /scenarios/{id}` – remove a scenario.
-
-## Parameters
-- `RABBITMQ_HOST` – broker hostname (default `rabbitmq`)
-- `RABBITMQ_PORT` – broker port (default `5672`)
-- `RABBITMQ_USER` – broker username (default `guest`)
-- `RABBITMQ_PASS` – broker password (default `guest`)
-- `PH_LOGS_QUEUE` – queue to wait for before starting (default `ph.logs.agg`)

--- a/swarm-controller-service/README.md
+++ b/swarm-controller-service/README.md
@@ -1,24 +1,6 @@
 # Swarm Controller Service
 
-Marshal that manages a single swarm: provisions queues, launches bee containers and relays control signals.
+Manages a single swarm by provisioning queues, launching bees, and relaying control signals.
 
-## Responsibilities
-- Expand swarm plans into concrete queue names.
-- Launch and monitor bee containers.
-- Route config signals to individual services and report status.
+See the [architecture reference](../docs/ARCHITECTURE.md) and [control-plane rules](../docs/rules/control-plane-rules.md) for signal and behaviour details.
 
-## Parameters
-- `PH_SWARM_ID` – identifier for the swarm scope (default `default`).
-- `RABBITMQ_HOST` – broker hostname (default `rabbitmq`).
-
-## Signals
-- Consumes `sig.config-update.swarm-controller.*` for runtime changes.
-- Responds to `sig.status-request.swarm-controller.*` with `ev.status-full` events.
-
-## Docker
-```bash
-docker build -t swarm-controller-service:latest .
-docker run --rm swarm-controller-service:latest
-```
-
-See [control-plane rules](../docs/rules/control-plane-rules.md) for full signal formats.

--- a/trigger-service/README.md
+++ b/trigger-service/README.md
@@ -1,23 +1,6 @@
 # Trigger Service
 
-Executes side effects such as shell commands or HTTP calls on a schedule.
+Executes scheduled side effects such as shell commands or HTTP calls.
 
-## Responsibilities
-- Perform actions based on `ph.trigger.*` settings.
-- React to control-plane signals for runtime configuration.
+See the [architecture reference](../docs/ARCHITECTURE.md) and [control-plane rules](../docs/rules/control-plane-rules.md) for signal and behaviour details.
 
-## Parameters
-- `PH_SWARM_ID` – identifier for the swarm scope (default `default`).
-- `RABBITMQ_HOST` – broker hostname (default `rabbitmq`).
-
-## Signals
-- Consumes `sig.config-update.trigger.*` for runtime changes.
-- Responds to `sig.status-request.trigger.*` with `ev.status-full` events.
-
-## Docker
-```bash
-docker build -t trigger-service:latest .
-docker run --rm trigger-service:latest
-```
-
-See [control-plane rules](../docs/rules/control-plane-rules.md) for full signal formats.


### PR DESCRIPTION
## Summary
- simplify component README files, removing outdated signal and behavior sections
- link each component summary to central architecture and control-plane documentation

## Testing
- `npm test` *(fails: Cannot find package 'zustand'...)*
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react-hooks')*
- `npm run build`
- `mvn -q test` *(fails: Failed to load ApplicationContext for HealthEndpointTest)*

------
https://chatgpt.com/codex/tasks/task_e_68c41dab46588328aeda0d6c53e7d892