### PR TITLE
feat(orchestrator): add explicit swarm removal step

### DIFF
--- a/orchestrator-service/src/main/java/io/pockethive/orchestrator/app/ContainerLifecycleManager.java
+++ b/orchestrator-service/src/main/java/io/pockethive/orchestrator/app/ContainerLifecycleManager.java
@@ -53,12 +53,19 @@ public class ContainerLifecycleManager {
 
     public void stopSwarm(String swarmId) {
         registry.find(swarmId).ifPresent(swarm -> {
-            log.info("stopping controller container {} for swarm {}", swarm.getContainerId(), swarmId);
+            log.info("marking swarm {} as stopped", swarmId);
+            swarm.setStatus(SwarmStatus.STOPPED);
+        });
+    }
+
+    public void removeSwarm(String swarmId) {
+        registry.find(swarmId).ifPresent(swarm -> {
+            log.info("tearing down controller container {} for swarm {}", swarm.getContainerId(), swarmId);
             docker.stopAndRemoveContainer(swarm.getContainerId());
             amqp.deleteQueue("ph." + swarmId + ".gen");
             amqp.deleteQueue("ph." + swarmId + ".mod");
             amqp.deleteQueue("ph." + swarmId + ".final");
-            swarm.setStatus(SwarmStatus.STOPPED);
+            registry.remove(swarmId);
         });
     }
 }


### PR DESCRIPTION
## Summary
- refactor container lifecycle to separate stop and removal phases
- call container teardown only after `ev.ready.swarm-remove` event
- adjust tests for new stop/remove semantics

## Testing
- `mvn -pl orchestrator-service -am test`
- `npm test`
- `npm run lint`
- `npm run build`
- `npx commitlint --from=HEAD~1 --to=HEAD` *(fails: npm error canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68c5df3cf6c08328b84609130b261d3b