### PR TITLE
test: cover REST control flow and swarm lifecycle

### DIFF
--- a/orchestrator-service/src/test/java/io/pockethive/orchestrator/domain/SwarmRegistryTest.java
+++ b/orchestrator-service/src/test/java/io/pockethive/orchestrator/domain/SwarmRegistryTest.java
@@ -31,6 +31,24 @@ class SwarmRegistryTest {
     }
 
     @Test
+    void fullLifecycleTransitions() {
+        SwarmRegistry registry = new SwarmRegistry();
+        Swarm swarm = new Swarm("s1", "inst1", "container");
+        registry.register(swarm);
+
+        registry.updateStatus(swarm.getId(), SwarmStatus.CREATING);
+        registry.updateStatus(swarm.getId(), SwarmStatus.READY);
+        registry.updateStatus(swarm.getId(), SwarmStatus.STARTING);
+        registry.updateStatus(swarm.getId(), SwarmStatus.RUNNING);
+        registry.updateStatus(swarm.getId(), SwarmStatus.STOPPING);
+        registry.updateStatus(swarm.getId(), SwarmStatus.STOPPED);
+        registry.updateStatus(swarm.getId(), SwarmStatus.REMOVING);
+        registry.updateStatus(swarm.getId(), SwarmStatus.REMOVED);
+
+        assertEquals(SwarmStatus.REMOVED, swarm.getStatus());
+    }
+
+    @Test
     void countSwarms() {
         SwarmRegistry registry = new SwarmRegistry();
         registry.register(new Swarm("s1", "i1", "c1"));


### PR DESCRIPTION
## Summary
- extend SwarmSignalListener tests for create, error and stop/remove confirmations
- verify full SwarmStatus lifecycle transitions in registry
- simulate controller status and confirmation events in an integration test

## Testing
- `mvn -pl orchestrator-service -am test`

------
https://chatgpt.com/codex/tasks/task_e_68c60f371bcc83289327307c92bbf593