### PR TITLE
feat(swarm-controller): add remove lifecycle

### DIFF
--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/RabbitConfig.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/RabbitConfig.java
@@ -53,6 +53,12 @@ public class RabbitConfig {
   }
 
   @Bean
+  Binding bindSwarmRemove(@Qualifier("controlQueue") Queue controlQueue,
+                          @Qualifier("controlExchange") TopicExchange controlExchange) {
+    return BindingBuilder.bind(controlQueue).to(controlExchange).with("sig.swarm-remove.*");
+  }
+
+  @Bean
   Binding bindScenarioPart(@Qualifier("controlQueue") Queue controlQueue,
                            @Qualifier("controlExchange") TopicExchange controlExchange) {
     return BindingBuilder.bind(controlQueue).to(controlExchange).with("sig.scenario-part.*");

--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmLifecycle.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmLifecycle.java
@@ -4,6 +4,7 @@ public interface SwarmLifecycle {
   void prepare(String templateJson);
   void start(String planJson);
   void stop();
+  void remove();
   SwarmStatus getStatus();
   /**
    * Record readiness of a component identified by role and instance.


### PR DESCRIPTION
## Summary
- decouple stop from resource cleanup and add remove() for teardown
- handle `sig.swarm-remove.*` and emit corresponding confirmations
- bind new swarm-remove routing key and expand tests

## Testing
- `mvn -pl swarm-controller-service -am test`

------
https://chatgpt.com/codex/tasks/task_e_68c61c37426c8328b6b0055325170178