### PR TITLE
feat: aggregate swarm health metrics

### DIFF
--- a/observability/src/main/java/io/pockethive/observability/StatusEnvelopeBuilder.java
+++ b/observability/src/main/java/io/pockethive/observability/StatusEnvelopeBuilder.java
@@ -25,6 +25,7 @@ public class StatusEnvelopeBuilder {
     private final Map<String, Object> queues = new LinkedHashMap<>();
     private final Map<String, Object> work = new LinkedHashMap<>();
     private final Map<String, Object> control = new LinkedHashMap<>();
+    private final Map<String, Object> totals = new LinkedHashMap<>();
 
     public StatusEnvelopeBuilder() {
         root.put("event", "status");
@@ -61,6 +62,33 @@ public class StatusEnvelopeBuilder {
      */
     public StatusEnvelopeBuilder enabled(boolean enabled) {
         root.put("enabled", enabled);
+        return this;
+    }
+
+    public StatusEnvelopeBuilder state(String state) {
+        if (state != null && !state.isBlank()) {
+            root.put("state", state);
+        }
+        return this;
+    }
+
+    public StatusEnvelopeBuilder watermark(Instant ts) {
+        if (ts != null) {
+            root.put("watermark", ts.toString());
+        }
+        return this;
+    }
+
+    public StatusEnvelopeBuilder maxStalenessSec(long sec) {
+        root.put("maxStalenessSec", sec);
+        return this;
+    }
+
+    public StatusEnvelopeBuilder totals(int desired, int healthy, int running, int enabled) {
+        totals.put("desired", desired);
+        totals.put("healthy", healthy);
+        totals.put("running", running);
+        totals.put("enabled", enabled);
         return this;
     }
 
@@ -161,6 +189,7 @@ public class StatusEnvelopeBuilder {
         if (!work.isEmpty()) queues.put("work", work);
         if (!control.isEmpty()) queues.put("control", control);
         if (!queues.isEmpty()) root.put("queues", queues);
+        if (!totals.isEmpty()) root.put("totals", totals);
         root.put("data", data.isEmpty() ? Collections.emptyMap() : data);
         try {
             return MAPPER.writeValueAsString(root);

--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmLifecycle.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmLifecycle.java
@@ -20,6 +20,16 @@ public interface SwarmLifecycle {
   void updateHeartbeat(String role, String instance);
 
   /**
+   * Track the enabled flag for a component.
+   */
+  void updateEnabled(String role, String instance, boolean enabled);
+
+  /**
+   * Aggregate component metrics.
+   */
+  SwarmMetrics getMetrics();
+
+  /**
    * Apply the first scenario step configuration while keeping components disabled.
    */
   void applyScenarioStep(String stepJson);

--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmMetrics.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmMetrics.java
@@ -1,0 +1,5 @@
+package io.pockethive.swarmcontroller;
+
+import java.time.Instant;
+
+public record SwarmMetrics(int desired, int healthy, int running, int enabled, Instant watermark) {}


### PR DESCRIPTION
## Summary
- track per-component enabled state and last heartbeat to compute desired/healthy/running/enabled totals
- expose watermark and max staleness in controller status envelopes
- emit Degraded or Unknown state when components grow stale

## Testing
- `mvn -q -pl observability,swarm-controller-service -am test`


------
https://chatgpt.com/codex/tasks/task_e_68c6e868ed008328aef32cd26c4b379a