### PR TITLE
feat: add component config update endpoint

### DIFF
--- a/orchestrator-service/src/main/java/io/pockethive/orchestrator/app/ComponentController.java
+++ b/orchestrator-service/src/main/java/io/pockethive/orchestrator/app/ComponentController.java
@@ -1,0 +1,76 @@
+package io.pockethive.orchestrator.app;
+
+import io.pockethive.Topology;
+import io.pockethive.orchestrator.domain.ControlSignal;
+import io.pockethive.orchestrator.domain.IdempotencyStore;
+import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * REST endpoint for component-level actions.
+ */
+@RestController
+@RequestMapping("/api/components")
+public class ComponentController {
+    private static final long CONFIG_UPDATE_TIMEOUT_MS = 60_000L;
+
+    private final AmqpTemplate rabbit;
+    private final IdempotencyStore idempotency;
+
+    public ComponentController(AmqpTemplate rabbit, IdempotencyStore idempotency) {
+        this.rabbit = rabbit;
+        this.idempotency = idempotency;
+    }
+
+    @PostMapping("/{role}/{instance}/config")
+    public ResponseEntity<ControlResponse> updateConfig(@PathVariable String role,
+                                                        @PathVariable String instance,
+                                                        @RequestBody ConfigUpdateRequest request) {
+        String scope = scope(role, instance, request.swarmId());
+        return idempotency.findCorrelation(scope, "config-update", request.idempotencyKey())
+            .map(correlation -> accepted(correlation, request.idempotencyKey(), role, instance))
+            .orElseGet(() -> {
+                String correlation = UUID.randomUUID().toString();
+                ControlSignal payload = ControlSignal.forInstance("config-update", request.swarmId(), role, instance,
+                    correlation, request.idempotencyKey());
+                rabbit.convertAndSend(Topology.CONTROL_EXCHANGE, routingKey(role, instance), payload);
+                idempotency.record(scope, "config-update", request.idempotencyKey(), correlation);
+                return accepted(correlation, request.idempotencyKey(), role, instance);
+            });
+    }
+
+    private static String routingKey(String role, String instance) {
+        return "sig.config-update." + role + "." + instance;
+    }
+
+    private static String scope(String role, String instance, String swarmId) {
+        if (swarmId != null && !swarmId.isBlank()) {
+            return swarmId;
+        }
+        return role + ":" + instance;
+    }
+
+    private ResponseEntity<ControlResponse> accepted(String correlationId, String idempotencyKey,
+                                                      String role, String instance) {
+        ControlResponse.Watch watch = new ControlResponse.Watch(
+            "ev.ready.config-update." + role + "." + instance,
+            "ev.error.config-update." + role + "." + instance
+        );
+        ControlResponse response = new ControlResponse(correlationId, idempotencyKey, watch, CONFIG_UPDATE_TIMEOUT_MS);
+        return ResponseEntity.accepted().body(response);
+    }
+
+    public record ConfigUpdateRequest(String idempotencyKey,
+                                      Map<String, Object> patch,
+                                      String notes,
+                                      String swarmId) { }
+}
+

--- a/orchestrator-service/src/main/java/io/pockethive/orchestrator/app/ControlResponse.java
+++ b/orchestrator-service/src/main/java/io/pockethive/orchestrator/app/ControlResponse.java
@@ -1,0 +1,9 @@
+package io.pockethive.orchestrator.app;
+
+/**
+ * Envelope returned to clients initiating control-plane actions.
+ */
+public record ControlResponse(String correlationId, String idempotencyKey, Watch watch, long timeoutMs) {
+    public record Watch(String successTopic, String errorTopic) {}
+}
+

--- a/orchestrator-service/src/main/java/io/pockethive/orchestrator/app/SwarmController.java
+++ b/orchestrator-service/src/main/java/io/pockethive/orchestrator/app/SwarmController.java
@@ -75,7 +75,8 @@ public class SwarmController {
         return idempotency.findCorrelation(swarmId, signal, idempotencyKey)
             .map(corr -> {
                 ControlResponse resp = new ControlResponse(corr, idempotencyKey,
-                    new Watch("ev.ready." + signal + "." + swarmId, "ev.error." + signal + "." + swarmId), timeoutMs);
+                    new ControlResponse.Watch("ev.ready." + signal + "." + swarmId,
+                        "ev.error." + signal + "." + swarmId), timeoutMs);
                 return ResponseEntity.accepted().body(resp);
             })
             .orElseGet(() -> {
@@ -83,14 +84,13 @@ public class SwarmController {
                 action.accept(corr);
                 idempotency.record(swarmId, signal, idempotencyKey, corr);
                 ControlResponse resp = new ControlResponse(corr, idempotencyKey,
-                    new Watch("ev.ready." + signal + "." + swarmId, "ev.error." + signal + "." + swarmId), timeoutMs);
+                    new ControlResponse.Watch("ev.ready." + signal + "." + swarmId,
+                        "ev.error." + signal + "." + swarmId), timeoutMs);
                 return ResponseEntity.accepted().body(resp);
             });
     }
 
     public record ControlRequest(String idempotencyKey, String notes) {}
-    public record Watch(String successTopic, String errorTopic) {}
-    public record ControlResponse(String correlationId, String idempotencyKey, Watch watch, long timeoutMs) {}
 
     @GetMapping("/{swarmId}")
     public ResponseEntity<SwarmView> view(@PathVariable String swarmId) {

--- a/orchestrator-service/src/test/java/io/pockethive/orchestrator/app/ComponentControllerTest.java
+++ b/orchestrator-service/src/test/java/io/pockethive/orchestrator/app/ComponentControllerTest.java
@@ -1,0 +1,63 @@
+package io.pockethive.orchestrator.app;
+
+import io.pockethive.Topology;
+import io.pockethive.orchestrator.domain.ControlSignal;
+import io.pockethive.orchestrator.infra.InMemoryIdempotencyStore;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.http.ResponseEntity;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ComponentControllerTest {
+
+    @Mock
+    AmqpTemplate rabbit;
+
+    @Test
+    void updateConfigPublishesControlSignal() {
+        ComponentController controller = new ComponentController(rabbit, new InMemoryIdempotencyStore());
+        ComponentController.ConfigUpdateRequest request =
+            new ComponentController.ConfigUpdateRequest("idem", Map.of("enabled", true), null, "sw1");
+
+        ResponseEntity<ControlResponse> response = controller.updateConfig("generator", "c1", request);
+
+        ArgumentCaptor<ControlSignal> captor = ArgumentCaptor.forClass(ControlSignal.class);
+        verify(rabbit).convertAndSend(eq(Topology.CONTROL_EXCHANGE), eq("sig.config-update.generator.c1"), captor.capture());
+        ControlSignal signal = captor.getValue();
+        assertThat(signal.signal()).isEqualTo("config-update");
+        assertThat(signal.role()).isEqualTo("generator");
+        assertThat(signal.instance()).isEqualTo("c1");
+        assertThat(signal.swarmId()).isEqualTo("sw1");
+        assertThat(signal.idempotencyKey()).isEqualTo("idem");
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().watch().successTopic()).isEqualTo("ev.ready.config-update.generator.c1");
+    }
+
+    @Test
+    void configUpdateIsIdempotent() {
+        ComponentController controller = new ComponentController(rabbit, new InMemoryIdempotencyStore());
+        ComponentController.ConfigUpdateRequest request =
+            new ComponentController.ConfigUpdateRequest("idem", Map.of(), null, null);
+
+        ResponseEntity<ControlResponse> first = controller.updateConfig("processor", "p1", request);
+        ResponseEntity<ControlResponse> second = controller.updateConfig("processor", "p1", request);
+
+        verify(rabbit, times(1)).convertAndSend(eq(Topology.CONTROL_EXCHANGE), eq("sig.config-update.processor.p1"),
+            org.mockito.ArgumentMatchers.any(ControlSignal.class));
+        assertThat(first.getBody()).isNotNull();
+        assertThat(second.getBody()).isNotNull();
+        assertThat(first.getBody().correlationId()).isEqualTo(second.getBody().correlationId());
+    }
+}
+

--- a/orchestrator-service/src/test/java/io/pockethive/orchestrator/app/SwarmControllerTest.java
+++ b/orchestrator-service/src/test/java/io/pockethive/orchestrator/app/SwarmControllerTest.java
@@ -30,7 +30,7 @@ class SwarmControllerTest {
         SwarmController ctrl = new SwarmController(rabbit, lifecycle, new SwarmCreateTracker(), new InMemoryIdempotencyStore(), new SwarmRegistry());
         SwarmController.ControlRequest req = new SwarmController.ControlRequest("idem", null);
 
-        ResponseEntity<SwarmController.ControlResponse> resp = ctrl.start("sw1", req);
+        ResponseEntity<ControlResponse> resp = ctrl.start("sw1", req);
 
         ArgumentCaptor<ControlSignal> captor = ArgumentCaptor.forClass(ControlSignal.class);
         verify(rabbit).convertAndSend(eq(Topology.CONTROL_EXCHANGE), eq("sig.swarm-start.sw1"), captor.capture());
@@ -58,8 +58,8 @@ class SwarmControllerTest {
         SwarmController ctrl = new SwarmController(rabbit, lifecycle, new SwarmCreateTracker(), new InMemoryIdempotencyStore(), new SwarmRegistry());
         SwarmController.ControlRequest req = new SwarmController.ControlRequest("idem", null);
 
-        ResponseEntity<SwarmController.ControlResponse> r1 = ctrl.start("sw1", req);
-        ResponseEntity<SwarmController.ControlResponse> r2 = ctrl.start("sw1", req);
+        ResponseEntity<ControlResponse> r1 = ctrl.start("sw1", req);
+        ResponseEntity<ControlResponse> r2 = ctrl.start("sw1", req);
 
         ArgumentCaptor<ControlSignal> captor = ArgumentCaptor.forClass(ControlSignal.class);
         verify(rabbit, times(1)).convertAndSend(eq(Topology.CONTROL_EXCHANGE), eq("sig.swarm-start.sw1"), captor.capture());

--- a/ui/src/lib/orchestratorApi.test.ts
+++ b/ui/src/lib/orchestratorApi.test.ts
@@ -37,6 +37,7 @@ describe('orchestratorApi', () => {
     const comp: Component = {
       id: 'c1',
       name: 'generator',
+      swarmId: 'sw1',
       lastHeartbeat: 0,
       queues: [],
       config: {},
@@ -45,6 +46,9 @@ describe('orchestratorApi', () => {
     const call = (apiFetch as unknown as Mock).mock.calls.pop()!
     expect(call[0]).toBe('/orchestrator/components/generator/c1/config')
     expect(call[1]?.method).toBe('POST')
-    expect(call[1]?.body).toBe(JSON.stringify({ enabled: true }))
+    const body = JSON.parse(call[1]?.body as string)
+    expect(body.idempotencyKey).toBeDefined()
+    expect(body.patch).toEqual({ enabled: true })
+    expect(body.swarmId).toBe('sw1')
   })
 })

--- a/ui/src/lib/orchestratorApi.ts
+++ b/ui/src/lib/orchestratorApi.ts
@@ -29,9 +29,16 @@ export async function stopSwarm(id: string) {
 }
 
 export async function sendConfigUpdate(component: Component, config: unknown) {
+  const payload: Record<string, unknown> = {
+    idempotencyKey: crypto.randomUUID(),
+    patch: config,
+  }
+  if (component.swarmId) {
+    payload.swarmId = component.swarmId
+  }
   await apiFetch(`/orchestrator/components/${component.name}/${component.id}/config`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(config),
+    body: JSON.stringify(payload),
   })
 }


### PR DESCRIPTION
## Summary
- add a component controller that publishes config update control signals with idempotency tracking
- extract a reusable control response envelope and update swarm controller to use it
- send idempotent payloads from the UI config client and refresh accompanying tests

## Testing
- mvn -pl orchestrator-service -am test
- npm test -- orchestratorApi

------
https://chatgpt.com/codex/tasks/task_e_68c83b94f8548328b85d1b2040eae194