### PR TITLE
fix(ui): harden stomp client read-only access

### DIFF
--- a/ui/src/lib/config.ts
+++ b/ui/src/lib/config.ts
@@ -13,14 +13,19 @@ export type UIConfig = {
 
 const host = typeof window !== 'undefined' ? window.location.hostname : 'localhost'
 
+const readOnlyUser =
+  import.meta.env.VITE_STOMP_READONLY_USER || import.meta.env.VITE_STOMP_USER || 'ph-observer'
+const readOnlyPasscode =
+  import.meta.env.VITE_STOMP_READONLY_PASSCODE || import.meta.env.VITE_STOMP_PASSCODE || 'ph-observer'
+
 const config: UIConfig = {
   rabbitmq: `http://${host}:15672/`,
   prometheus: `http://${host}:9090/`,
   grafana: `http://${host}:3000/`,
   wiremock: `http://${host}:8080/__admin/`,
   stompUrl: `/ws`,
-  stompUser: 'guest',
-  stompPasscode: 'guest',
+  stompUser: readOnlyUser,
+  stompPasscode: readOnlyPasscode,
   stompSubscription: '/exchange/ph.control/ev.#',
 }
 

--- a/ui/src/lib/stompClient.test.ts
+++ b/ui/src/lib/stompClient.test.ts
@@ -10,6 +10,15 @@ import { useUIStore } from '../store'
 
 
 describe('swarm lifecycle', () => {
+  it('does not decorate publish on the provided client', () => {
+    const publish = vi.fn()
+    const subscribe = vi.fn().mockReturnValue({ unsubscribe() {} })
+    const raw = { active: true, publish, subscribe }
+    setClient(raw as unknown as Client)
+    expect(raw.publish).toBe(publish)
+    setClient(null)
+  })
+
   it('logs error events and sets toast', () => {
     resetLogs()
     useUIStore.setState({ toast: null })
@@ -33,5 +42,6 @@ describe('swarm lifecycle', () => {
     expect(entries[0].destination).toContain('ev.error.swarm-create.sw1')
     expect(entries[0].body).toBe('boom')
     expect(useUIStore.getState().toast).toBe('Error: error swarm-create sw1: boom')
+    setClient(null)
   })
 })

--- a/ui/src/lib/stompClient.ts
+++ b/ui/src/lib/stompClient.ts
@@ -1,7 +1,7 @@
 import { Client, type StompSubscription } from '@stomp/stompjs'
 import type { Component } from '../types/hive'
 import { isControlEvent, type ControlEvent } from '../types/control'
-import { logIn, logOut, logError } from './logs'
+import { logIn, logError } from './logs'
 import { useUIStore } from '../store'
 
 export type ComponentListener = (components: Component[]) => void
@@ -92,15 +92,6 @@ export function setClient(newClient: Client | null, destination = controlDestina
   if (client) {
     const wrapped = client._phWrapped
     if (!wrapped) {
-      const origPublish = client.publish.bind(client)
-      client.publish = ((params) => {
-        const body = params.body ?? ''
-        const correlationId = crypto.randomUUID()
-        const headers = { ...(params.headers || {}), 'x-correlation-id': correlationId }
-        logOut(params.destination, body, 'ui', 'stomp', correlationId)
-        origPublish({ ...params, headers })
-      }) as typeof client.publish
-
       const origSubscribe = client.subscribe.bind(client)
       client.subscribe = ((dest, callback, headers) => {
         return origSubscribe(


### PR DESCRIPTION
## Summary
- remove the STOMP publish wrapper so the UI client only wraps subscriptions for logging and error toasts
- default the STOMP configuration to read-only credentials supplied via environment variables and add coverage to guard the publish surface

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c856e9801483289f82ca15c4dda54b