### PR TITLE
fix(orchestrator): serialize control signals as json

### DIFF
--- a/orchestrator-service/src/main/java/io/pockethive/orchestrator/app/JacksonConfiguration.java
+++ b/orchestrator-service/src/main/java/io/pockethive/orchestrator/app/JacksonConfiguration.java
@@ -1,6 +1,8 @@
 package io.pockethive.orchestrator.app;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,6 +13,9 @@ import org.springframework.context.annotation.Configuration;
 public class JacksonConfiguration {
     @Bean
     public ObjectMapper objectMapper() {
-        return new ObjectMapper();
+        return JsonMapper.builder()
+            .findAndAddModules()
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            .build();
     }
 }

--- a/orchestrator-service/src/test/java/io/pockethive/orchestrator/app/JacksonConfigurationTest.java
+++ b/orchestrator-service/src/test/java/io/pockethive/orchestrator/app/JacksonConfigurationTest.java
@@ -11,4 +11,11 @@ class JacksonConfigurationTest {
         ObjectMapper mapper = new JacksonConfiguration().objectMapper();
         assertThat(mapper).isNotNull();
     }
+
+    @Test
+    void serializesInstantsAsIsoStrings() throws Exception {
+        ObjectMapper mapper = new JacksonConfiguration().objectMapper();
+        String json = mapper.writeValueAsString(java.time.Instant.parse("2025-09-16T09:07:45.834Z"));
+        assertThat(json).isEqualTo("\"2025-09-16T09:07:45.834Z\"");
+    }
 }

--- a/orchestrator-service/src/test/java/io/pockethive/orchestrator/app/SwarmControllerTest.java
+++ b/orchestrator-service/src/test/java/io/pockethive/orchestrator/app/SwarmControllerTest.java
@@ -1,5 +1,6 @@
 package io.pockethive.orchestrator.app;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.pockethive.Topology;
 import io.pockethive.orchestrator.domain.ControlSignal;
 import io.pockethive.orchestrator.domain.SwarmCreateTracker;
@@ -15,6 +16,7 @@ import org.springframework.amqp.core.AmqpTemplate;
 import org.springframework.http.ResponseEntity;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -25,16 +27,18 @@ class SwarmControllerTest {
     @Mock
     ContainerLifecycleManager lifecycle;
 
+    private final ObjectMapper mapper = new JacksonConfiguration().objectMapper();
+
     @Test
-    void startPublishesControlSignal() {
-        SwarmController ctrl = new SwarmController(rabbit, lifecycle, new SwarmCreateTracker(), new InMemoryIdempotencyStore(), new SwarmRegistry());
+    void startPublishesControlSignal() throws Exception {
+        SwarmController ctrl = new SwarmController(rabbit, lifecycle, new SwarmCreateTracker(), new InMemoryIdempotencyStore(), new SwarmRegistry(), mapper);
         SwarmController.ControlRequest req = new SwarmController.ControlRequest("idem", null);
 
         ResponseEntity<ControlResponse> resp = ctrl.start("sw1", req);
 
-        ArgumentCaptor<ControlSignal> captor = ArgumentCaptor.forClass(ControlSignal.class);
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(rabbit).convertAndSend(eq(Topology.CONTROL_EXCHANGE), eq("sig.swarm-start.sw1"), captor.capture());
-        ControlSignal sig = captor.getValue();
+        ControlSignal sig = mapper.readValue(captor.getValue(), ControlSignal.class);
         assertThat(sig.signal()).isEqualTo("swarm-start");
         assertThat(sig.swarmId()).isEqualTo("sw1");
         assertThat(sig.idempotencyKey()).isEqualTo("idem");
@@ -45,7 +49,7 @@ class SwarmControllerTest {
     void createRegistersPending() {
         SwarmCreateTracker tracker = new SwarmCreateTracker();
         when(lifecycle.startSwarm(eq("sw1"), anyString())).thenReturn(new Swarm("sw1", "instA", "c1"));
-        SwarmController ctrl = new SwarmController(rabbit, lifecycle, tracker, new InMemoryIdempotencyStore(), new SwarmRegistry());
+        SwarmController ctrl = new SwarmController(rabbit, lifecycle, tracker, new InMemoryIdempotencyStore(), new SwarmRegistry(), mapper);
         SwarmController.ControlRequest req = new SwarmController.ControlRequest("idem", null);
 
         ctrl.create("sw1", req);
@@ -55,13 +59,13 @@ class SwarmControllerTest {
 
     @Test
     void startIsIdempotent() {
-        SwarmController ctrl = new SwarmController(rabbit, lifecycle, new SwarmCreateTracker(), new InMemoryIdempotencyStore(), new SwarmRegistry());
+        SwarmController ctrl = new SwarmController(rabbit, lifecycle, new SwarmCreateTracker(), new InMemoryIdempotencyStore(), new SwarmRegistry(), mapper);
         SwarmController.ControlRequest req = new SwarmController.ControlRequest("idem", null);
 
         ResponseEntity<ControlResponse> r1 = ctrl.start("sw1", req);
         ResponseEntity<ControlResponse> r2 = ctrl.start("sw1", req);
 
-        ArgumentCaptor<ControlSignal> captor = ArgumentCaptor.forClass(ControlSignal.class);
+        ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
         verify(rabbit, times(1)).convertAndSend(eq(Topology.CONTROL_EXCHANGE), eq("sig.swarm-start.sw1"), captor.capture());
         assertThat(r1.getBody().correlationId()).isEqualTo(r2.getBody().correlationId());
     }
@@ -70,7 +74,7 @@ class SwarmControllerTest {
     void exposesSwarmView() {
         SwarmRegistry registry = new SwarmRegistry();
         registry.register(new Swarm("sw1", "inst", "c"));
-        SwarmController ctrl = new SwarmController(rabbit, lifecycle, new SwarmCreateTracker(), new InMemoryIdempotencyStore(), registry);
+        SwarmController ctrl = new SwarmController(rabbit, lifecycle, new SwarmCreateTracker(), new InMemoryIdempotencyStore(), registry, mapper);
 
         ResponseEntity<SwarmController.SwarmView> resp = ctrl.view("sw1");
         assertThat(resp.getBody().id()).isEqualTo("sw1");


### PR DESCRIPTION
## Summary
- configure the orchestrator ObjectMapper to auto-register Java time modules and emit ISO-8601 timestamps
- serialize ControlSignal payloads to JSON before publishing lifecycle and config AMQP messages
- update controller unit tests to assert JSON payloads and verify the mapper configuration

## Testing
- mvn -pl orchestrator-service -am test

------
https://chatgpt.com/codex/tasks/task_e_68c92967d17883288ada6bda570e59bb