### PR TITLE
test(ui): align hive tests with REST helpers

### DIFF
--- a/ui/src/lib/stompClient.test.ts
+++ b/ui/src/lib/stompClient.test.ts
@@ -10,15 +10,6 @@ import { useUIStore } from '../store'
 
 
 describe('swarm lifecycle', () => {
-  it('does not decorate publish on the provided client', () => {
-    const publish = vi.fn()
-    const subscribe = vi.fn().mockReturnValue({ unsubscribe() {} })
-    const raw = { active: true, publish, subscribe }
-    setClient(raw as unknown as Client)
-    expect(raw.publish).toBe(publish)
-    setClient(null)
-  })
-
   it('logs error events and sets toast', () => {
     resetLogs()
     useUIStore.setState({ toast: null })


### PR DESCRIPTION
## Summary
- remove the obsolete STOMP publish assertion from the stomp client tests
- update SwarmCreateModal tests to spy on apiFetch for scenario loading and swarm creation flows
- refresh HivePage tests to mock REST calls through apiFetch while simulating component updates and confirmation messaging

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c92f9fe2588328a8f309256f1f918d