### PR TITLE
fix: stop leaking control args

### DIFF
--- a/generator-service/src/main/java/io/pockethive/generator/Generator.java
+++ b/generator-service/src/main/java/io/pockethive/generator/Generator.java
@@ -264,9 +264,6 @@ public class Generator {
     payload.put("signal", cs.signal());
     payload.put("result", result);
     payload.set("scope", scopeNode(cs, role, instance));
-    if (cs.args() != null) {
-      payload.set("args", objectMapper.valueToTree(cs.args()));
-    }
     if (cs.correlationId() != null) {
       payload.put("correlationId", cs.correlationId());
     }

--- a/generator-service/src/test/java/io/pockethive/generator/GeneratorTest.java
+++ b/generator-service/src/test/java/io/pockethive/generator/GeneratorTest.java
@@ -95,7 +95,7 @@ class GeneratorTest {
         assertThat(node.path("scope").path("role").asText()).isEqualTo("generator");
         assertThat(node.path("scope").path("instance").asText()).isEqualTo("inst");
         assertThat(node.path("scope").path("swarmId").asText()).isEqualTo("sw1");
-        assertThat(node.path("args").path("data").path("enabled").asBoolean()).isTrue();
+        assertThat(node.has("args")).isFalse();
     }
 
     @Test

--- a/moderator-service/src/main/java/io/pockethive/moderator/Moderator.java
+++ b/moderator-service/src/main/java/io/pockethive/moderator/Moderator.java
@@ -219,9 +219,6 @@ public class Moderator {
     payload.put("signal", cs.signal());
     payload.put("result", result);
     payload.set("scope", scopeNode(cs, role, instance));
-    if (cs.args() != null) {
-      payload.set("args", objectMapper.valueToTree(cs.args()));
-    }
     if (cs.correlationId() != null) {
       payload.put("correlationId", cs.correlationId());
     }

--- a/moderator-service/src/test/java/io/pockethive/moderator/ModeratorTest.java
+++ b/moderator-service/src/test/java/io/pockethive/moderator/ModeratorTest.java
@@ -82,7 +82,7 @@ class ModeratorTest {
         assertThat(node.path("scope").path("role").asText()).isEqualTo("moderator");
         assertThat(node.path("scope").path("instance").asText()).isEqualTo("inst");
         assertThat(node.path("scope").path("swarmId").asText()).isEqualTo("sw1");
-        assertThat(node.path("args").path("data").path("enabled").asBoolean()).isTrue();
+        assertThat(node.has("args")).isFalse();
     }
 
     @Test

--- a/postprocessor-service/src/main/java/io/pockethive/postprocessor/PostProcessor.java
+++ b/postprocessor-service/src/main/java/io/pockethive/postprocessor/PostProcessor.java
@@ -258,9 +258,6 @@ public class PostProcessor {
     payload.put("signal", cs.signal());
     payload.put("result", result);
     payload.set("scope", scopeNode(cs, role, instance));
-    if(cs.args()!=null){
-      payload.set("args", MAPPER.valueToTree(cs.args()));
-    }
     if(cs.correlationId()!=null){
       payload.put("correlationId", cs.correlationId());
     }

--- a/postprocessor-service/src/test/java/io/pockethive/postprocessor/PostProcessorTest.java
+++ b/postprocessor-service/src/test/java/io/pockethive/postprocessor/PostProcessorTest.java
@@ -81,7 +81,7 @@ class PostProcessorTest {
         assertThat(node.path("scope").path("role").asText()).isEqualTo("postprocessor");
         assertThat(node.path("scope").path("instance").asText()).isEqualTo("inst");
         assertThat(node.path("scope").path("swarmId").asText()).isEqualTo("sw1");
-        assertThat(node.path("args").path("data").path("enabled").asBoolean()).isTrue();
+        assertThat(node.has("args")).isFalse();
     }
 
     @Test
@@ -102,7 +102,7 @@ class PostProcessorTest {
         JsonNode node = mapper.readTree(payload.getValue());
         assertThat(node.path("correlationId").asText()).isEqualTo("corr2");
         assertThat(node.path("idempotencyKey").asText()).isEqualTo("idem2");
-        assertThat(node.path("args").path("data").path("enabled").asBoolean()).isFalse();
+        assertThat(node.has("args")).isFalse();
     }
 
     @Test

--- a/processor-service/src/main/java/io/pockethive/processor/Processor.java
+++ b/processor-service/src/main/java/io/pockethive/processor/Processor.java
@@ -274,9 +274,6 @@ public class Processor {
     payload.put("signal", cs.signal());
     payload.put("result", result);
     payload.set("scope", scopeNode(cs, role, instance));
-    if (cs.args() != null) {
-      payload.set("args", MAPPER.valueToTree(cs.args()));
-    }
     if (cs.correlationId() != null) {
       payload.put("correlationId", cs.correlationId());
     }

--- a/processor-service/src/test/java/io/pockethive/processor/ProcessorTest.java
+++ b/processor-service/src/test/java/io/pockethive/processor/ProcessorTest.java
@@ -90,7 +90,7 @@ class ProcessorTest {
         assertThat(node.path("scope").path("role").asText()).isEqualTo("processor");
         assertThat(node.path("scope").path("instance").asText()).isEqualTo("inst");
         assertThat(node.path("scope").path("swarmId").asText()).isEqualTo("sw1");
-        assertThat(node.path("args").path("data").path("enabled").asBoolean()).isTrue();
+        assertThat(node.has("args")).isFalse();
         verify(rabbit, never()).convertAndSend(eq(Topology.CONTROL_EXCHANGE), eq("ev.error.config-update.processor.inst"), anyString());
     }
 

--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmSignalListener.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmSignalListener.java
@@ -257,9 +257,6 @@ public class SwarmSignalListener {
     payload.put("signal", cs.signal());
     payload.put("result", "success");
     payload.set("scope", scopeNode(cs));
-    if (cs.args() != null) {
-      payload.set("args", mapper.valueToTree(cs.args()));
-    }
     payload.put("idempotencyKey", cs.idempotencyKey());
     payload.put("correlationId", cs.correlationId());
     String json = payload.toString();
@@ -280,9 +277,6 @@ public class SwarmSignalListener {
     payload.put("signal", cs.signal());
     payload.put("result", "error");
     payload.set("scope", scopeNode(cs));
-    if (cs.args() != null) {
-      payload.set("args", mapper.valueToTree(cs.args()));
-    }
     payload.put("idempotencyKey", cs.idempotencyKey());
     payload.put("correlationId", cs.correlationId());
     payload.put("code", e.getClass().getSimpleName());

--- a/trigger-service/src/main/java/io/pockethive/trigger/Trigger.java
+++ b/trigger-service/src/main/java/io/pockethive/trigger/Trigger.java
@@ -269,9 +269,6 @@ public class Trigger {
     payload.put("signal", cs.signal());
     payload.put("result", result);
     payload.set("scope", scopeNode(cs, role, instance));
-    if (cs.args() != null) {
-      payload.set("args", objectMapper.valueToTree(cs.args()));
-    }
     if (cs.correlationId() != null) {
       payload.put("correlationId", cs.correlationId());
     }

--- a/trigger-service/src/test/java/io/pockethive/trigger/TriggerTest.java
+++ b/trigger-service/src/test/java/io/pockethive/trigger/TriggerTest.java
@@ -96,7 +96,7 @@ class TriggerTest {
         assertThat(node.path("scope").path("role").asText()).isEqualTo("trigger");
         assertThat(node.path("scope").path("instance").asText()).isEqualTo("inst");
         assertThat(node.path("scope").path("swarmId").asText()).isEqualTo("sw1");
-        assertThat(node.path("args").path("data").path("enabled").asBoolean()).isTrue();
+        assertThat(node.has("args")).isFalse();
 
         verify(rabbit, never()).convertAndSend(eq(Topology.CONTROL_EXCHANGE), eq("ev.error.config-update.trigger.inst"), anyString());
     }
@@ -141,6 +141,6 @@ class TriggerTest {
         ArgumentCaptor<String> payload = ArgumentCaptor.forClass(String.class);
         verify(rabbit).convertAndSend(eq(Topology.CONTROL_EXCHANGE), eq("ev.ready.config-update.trigger.inst"), payload.capture());
         JsonNode node = mapper.readTree(payload.getValue());
-        assertThat(node.path("args").path("singleRequest").asBoolean()).isTrue();
+        assertThat(node.has("args")).isFalse();
     }
 }


### PR DESCRIPTION
## Summary
- stop copying control-signal args into success/error confirmation payloads across the controller and component services to avoid leaking sensitive configuration values
- adjust unit tests to assert confirmation payloads no longer include raw args data

## Testing
- mvn -pl generator-service,moderator-service,trigger-service,postprocessor-service,processor-service,swarm-controller-service -am test

------
https://chatgpt.com/codex/tasks/task_e_68c95387491c8328b62741d64aa78c0b