### PR TITLE
Emit duplicate notices when replaying cached swarm outcomes

### DIFF
--- a/swarm-controller-service/README.md
+++ b/swarm-controller-service/README.md
@@ -4,3 +4,15 @@ Manages a single swarm by provisioning queues, launching bees, and relaying cont
 
 See the [architecture reference](../docs/ARCHITECTURE.md) and [control-plane rules](../docs/rules/control-plane-rules.md) for signal and behaviour details.
 
+## Deduplication semantics
+
+- The controller keeps an in-memory least-recently-used cache of the last 100 outcomes, keyed by
+  `(swarmId, signal, role, instance, idempotencyKey)`. Older entries are evicted when the cache is full.
+- A retry with the same idempotency key replays the cached `ev.ready.*` or `ev.error.*` confirmation without re-running the operation.
+- Every duplicate attempt also emits `ev.duplicate.<signal>` containing:
+  - the new `correlationId`,
+  - the cached `originalCorrelationId`,
+  - the original `idempotencyKey`, and
+  - the resolved `scope` (swarm/role/instance).
+  Consumers can use this notice to map the fresh attempt back to the cached confirmation.
+


### PR DESCRIPTION
## Summary
- emit `ev.duplicate.<signal>` whenever a cached outcome is replayed so callers can correlate retries
- retain original correlation identifiers in the cache and surface them through a new duplicate notice payload
- extend controller documentation with the deduplication window and behaviour

## Testing
- mvn -pl swarm-controller-service test

------
https://chatgpt.com/codex/tasks/task_e_68c986be872c8328aa92e154df904236