### PR TITLE
fix: align vitest spy typings in hive tests

### DIFF
--- a/ui/src/pages/hive/HivePage.test.tsx
+++ b/ui/src/pages/hive/HivePage.test.tsx
@@ -4,7 +4,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom/vitest'
-import { vi, test, expect, beforeEach, afterEach, type Mock, type SpyInstance } from 'vitest'
+import { vi, test, expect, beforeEach, afterEach, type Mock, type MockInstance } from 'vitest'
 import HivePage from './HivePage'
 import type { Component } from '../../types/hive'
 import { subscribeComponents } from '../../lib/stompClient'
@@ -38,7 +38,7 @@ const baseComponents: Component[] = [
 
 let listener: ((c: Component[]) => void) | null = null
 let comps: Component[] = []
-let apiFetchSpy: SpyInstance
+let apiFetchSpy: MockInstance<typeof apiModule.apiFetch>
 
 const extractUrl = (target: unknown) => {
   if (typeof target === 'string') return target

--- a/ui/src/pages/hive/SwarmCreateModal.test.tsx
+++ b/ui/src/pages/hive/SwarmCreateModal.test.tsx
@@ -3,10 +3,10 @@
  */
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
 import SwarmCreateModal from './SwarmCreateModal'
-import { vi, test, expect, afterEach, beforeEach, type SpyInstance } from 'vitest'
+import { vi, test, expect, afterEach, beforeEach, type MockInstance } from 'vitest'
 import * as apiModule from '../../lib/api'
 
-let apiFetchSpy: SpyInstance
+let apiFetchSpy: MockInstance<typeof apiModule.apiFetch>
 
 beforeEach(() => {
   apiFetchSpy = vi.spyOn(apiModule, 'apiFetch')


### PR DESCRIPTION
## Summary
- replace deprecated SpyInstance import with MockInstance in hive page tests
- type apiFetch spies against the real function signature to satisfy TypeScript

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c98da94e5c8328aaca4c7fe2e920c7