### PR TITLE
chore: copy swarm model module in service docker builds

### DIFF
--- a/generator-service/Dockerfile
+++ b/generator-service/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 COPY pom.xml ./
 COPY common/topology-core/pom.xml common/topology-core/pom.xml
 COPY common/docker-client/pom.xml common/docker-client/pom.xml
+COPY common/swarm-model/pom.xml common/swarm-model/pom.xml
 COPY test/pom.xml test/pom.xml
 COPY generator-service/pom.xml generator-service/pom.xml
 COPY moderator-service/pom.xml moderator-service/pom.xml
@@ -18,6 +19,7 @@ COPY swarm-controller-service/pom.xml swarm-controller-service/pom.xml
 COPY scenario-manager-service/pom.xml scenario-manager-service/pom.xml
 COPY common/topology-core/src common/topology-core/src
 COPY common/docker-client/src common/docker-client/src
+COPY common/swarm-model/src common/swarm-model/src
 COPY test/src test/src
 COPY generator-service/src generator-service/src
 COPY moderator-service/src moderator-service/src

--- a/log-aggregator-service/Dockerfile
+++ b/log-aggregator-service/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 COPY pom.xml ./
 COPY common/topology-core/pom.xml common/topology-core/pom.xml
 COPY common/docker-client/pom.xml common/docker-client/pom.xml
+COPY common/swarm-model/pom.xml common/swarm-model/pom.xml
 COPY test/pom.xml test/pom.xml
 COPY log-aggregator-service/pom.xml log-aggregator-service/pom.xml
 COPY generator-service/pom.xml generator-service/pom.xml
@@ -17,6 +18,7 @@ COPY swarm-controller-service/pom.xml swarm-controller-service/pom.xml
 COPY scenario-manager-service/pom.xml scenario-manager-service/pom.xml
 COPY common/topology-core/src common/topology-core/src
 COPY common/docker-client/src common/docker-client/src
+COPY common/swarm-model/src common/swarm-model/src
 COPY test/src test/src
 COPY log-aggregator-service/src log-aggregator-service/src
 COPY generator-service/src generator-service/src

--- a/moderator-service/Dockerfile
+++ b/moderator-service/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 COPY pom.xml ./
 COPY common/topology-core/pom.xml common/topology-core/pom.xml
 COPY common/docker-client/pom.xml common/docker-client/pom.xml
+COPY common/swarm-model/pom.xml common/swarm-model/pom.xml
 COPY test/pom.xml test/pom.xml
 COPY generator-service/pom.xml generator-service/pom.xml
 COPY moderator-service/pom.xml moderator-service/pom.xml
@@ -18,6 +19,7 @@ COPY swarm-controller-service/pom.xml swarm-controller-service/pom.xml
 COPY scenario-manager-service/pom.xml scenario-manager-service/pom.xml
 COPY common/topology-core/src common/topology-core/src
 COPY common/docker-client/src common/docker-client/src
+COPY common/swarm-model/src common/swarm-model/src
 COPY test/src test/src
 COPY generator-service/src generator-service/src
 COPY moderator-service/src moderator-service/src

--- a/postprocessor-service/Dockerfile
+++ b/postprocessor-service/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 COPY pom.xml ./
 COPY common/topology-core/pom.xml common/topology-core/pom.xml
 COPY common/docker-client/pom.xml common/docker-client/pom.xml
+COPY common/swarm-model/pom.xml common/swarm-model/pom.xml
 COPY test/pom.xml test/pom.xml
 COPY observability/pom.xml observability/pom.xml
 COPY postprocessor-service/pom.xml postprocessor-service/pom.xml
@@ -17,6 +18,7 @@ COPY swarm-controller-service/pom.xml swarm-controller-service/pom.xml
 COPY scenario-manager-service/pom.xml scenario-manager-service/pom.xml
 COPY common/topology-core/src common/topology-core/src
 COPY common/docker-client/src common/docker-client/src
+COPY common/swarm-model/src common/swarm-model/src
 COPY test/src test/src
 COPY observability/src observability/src
 COPY postprocessor-service/src postprocessor-service/src

--- a/processor-service/Dockerfile
+++ b/processor-service/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 COPY pom.xml ./
 COPY common/topology-core/pom.xml common/topology-core/pom.xml
 COPY common/docker-client/pom.xml common/docker-client/pom.xml
+COPY common/swarm-model/pom.xml common/swarm-model/pom.xml
 COPY test/pom.xml test/pom.xml
 COPY generator-service/pom.xml generator-service/pom.xml
 COPY moderator-service/pom.xml moderator-service/pom.xml
@@ -18,6 +19,7 @@ COPY swarm-controller-service/pom.xml swarm-controller-service/pom.xml
 COPY scenario-manager-service/pom.xml scenario-manager-service/pom.xml
 COPY common/topology-core/src common/topology-core/src
 COPY common/docker-client/src common/docker-client/src
+COPY common/swarm-model/src common/swarm-model/src
 COPY test/src test/src
 COPY generator-service/src generator-service/src
 COPY moderator-service/src moderator-service/src

--- a/trigger-service/Dockerfile
+++ b/trigger-service/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 COPY pom.xml ./
 COPY common/topology-core/pom.xml common/topology-core/pom.xml
 COPY common/docker-client/pom.xml common/docker-client/pom.xml
+COPY common/swarm-model/pom.xml common/swarm-model/pom.xml
 COPY test/pom.xml test/pom.xml
 COPY trigger-service/pom.xml trigger-service/pom.xml
 COPY moderator-service/pom.xml moderator-service/pom.xml
@@ -18,6 +19,7 @@ COPY swarm-controller-service/pom.xml swarm-controller-service/pom.xml
 COPY scenario-manager-service/pom.xml scenario-manager-service/pom.xml
 COPY common/topology-core/src common/topology-core/src
 COPY common/docker-client/src common/docker-client/src
+COPY common/swarm-model/src common/swarm-model/src
 COPY test/src test/src
 COPY trigger-service/src trigger-service/src
 COPY moderator-service/src moderator-service/src


### PR DESCRIPTION
## Summary
- add the common/swarm-model pom and sources to each service Docker build stage so Maven can resolve the module

## Testing
- mvn -B -DskipTests -pl postprocessor-service -am package

------
https://chatgpt.com/codex/tasks/task_e_68ca837ee8148328945a33636294d46c