### PR TITLE
fix: include template id in swarm create request

### DIFF
--- a/docs/ORCHESTRATOR-REST.md
+++ b/docs/ORCHESTRATOR-REST.md
@@ -20,10 +20,15 @@ Client sends **`idempotencyKey`** (UUID v4) per new action (reuse on retry). Ser
 - Launch Controller runtime for `{swarmId}` (no AMQP signal).
 - On controller handshake `ev.ready.swarm-controller.<instance>`, emit **`ev.ready.swarm-create.<swarmId>`** (echo ids).
 - On failure, emit **`ev.error.swarm-create.<swarmId>`**.
+- Requires a `templateId` referencing the scenario template to instantiate.
 
 **Request**
 ```json
-{ "idempotencyKey": "uuid-v4", "notes": "optional" }
+{
+  "templateId": "scenario-id",
+  "idempotencyKey": "uuid-v4",
+  "notes": "optional"
+}
 ```
 
 **Response (202)**

--- a/ui/src/lib/orchestratorApi.ts
+++ b/ui/src/lib/orchestratorApi.ts
@@ -2,7 +2,16 @@ import { apiFetch } from './api'
 import type { Component } from '../types/hive'
 
 export async function createSwarm(id: string, templateId: string) {
-  const body = JSON.stringify({ idempotencyKey: crypto.randomUUID(), notes: templateId })
+  const payload: Record<string, unknown> = {
+    templateId,
+    idempotencyKey: crypto.randomUUID(),
+  }
+
+  if (templateId?.trim()) {
+    payload.notes = templateId
+  }
+
+  const body = JSON.stringify(payload)
   await apiFetch(`/orchestrator/swarms/${id}/create`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- send the selected templateId to the orchestrator when creating a swarm so the runtime launch succeeds
- document that the REST create endpoint requires a templateId and show it in the request example

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca90e846748328974812f9e0a5dd43