### PR TITLE
Stabilize ScenarioController smoke test configuration

### DIFF
--- a/scenario-manager-service/src/test/java/io/pockethive/scenarios/ScenarioControllerSmokeTest.java
+++ b/scenario-manager-service/src/test/java/io/pockethive/scenarios/ScenarioControllerSmokeTest.java
@@ -1,7 +1,7 @@
 package io.pockethive.scenarios;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -9,7 +9,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.ServerSocket;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -18,13 +25,13 @@ import static org.assertj.core.api.Assertions.assertThat;
     properties = "RABBITMQ_LOGGING_ENABLED=false")
 class ScenarioControllerSmokeTest {
 
-    @TempDir
-    static Path tempDir;
+    private static final Path TEMP_DIR = createTempDir();
+    private static final int PORT = findAvailablePort();
 
     @DynamicPropertySource
     static void properties(DynamicPropertyRegistry registry) {
-        registry.add("scenarios.dir", () -> tempDir.toString());
-        registry.add("server.port", () -> "1081");
+        registry.add("scenarios.dir", () -> TEMP_DIR.toString());
+        registry.add("server.port", () -> PORT);
     }
 
     @Autowired
@@ -32,9 +39,43 @@ class ScenarioControllerSmokeTest {
 
     @Test
     void servesScenariosOnExposedPort() {
-        ResponseEntity<String> resp = rest.getForEntity("http://localhost:1081/scenarios", String.class);
+        ResponseEntity<String> resp = rest.getForEntity("http://localhost:" + PORT + "/scenarios", String.class);
         assertThat(resp.getStatusCode().is2xxSuccessful()).isTrue();
         assertThat(resp.getBody()).contains("[]");
+    }
+
+    @AfterAll
+    static void cleanup() throws IOException {
+        Files.walkFileTree(TEMP_DIR, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                Files.deleteIfExists(file);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                Files.deleteIfExists(dir);
+                return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+
+    private static Path createTempDir() {
+        try {
+            return Files.createTempDirectory("scenarios-");
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static int findAvailablePort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            socket.setReuseAddress(true);
+            return socket.getLocalPort();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- provision a dedicated temporary scenario directory and dynamic server port for the smoke test
- clean up temporary resources after the test run

## Testing
- mvn -pl scenario-manager-service -am -Drevision=0.8.2 test

------
https://chatgpt.com/codex/tasks/task_e_68ca96dbe62c832898d60e001a4e171c