### PR TITLE
fix: keep swarm template id separate from notes in UI

### DIFF
--- a/ui/src/lib/orchestratorApi.test.ts
+++ b/ui/src/lib/orchestratorApi.test.ts
@@ -15,9 +15,12 @@ describe('orchestratorApi', () => {
     const init = (apiFetch as unknown as Mock).mock.calls[0][1]
     expect(init?.method).toBe('POST')
     const body = JSON.parse(init?.body)
-    expect(body).toMatchObject({ notes: 'tpl' })
+    expect(body.templateId).toBe('tpl')
+    expect(body.notes).toBeUndefined()
     expect(body.idempotencyKey).toBeDefined()
   })
+
+  it.todo('posts swarm creation with explicit notes once supported')
 
   it('posts swarm start', async () => {
     await startSwarm('sw1')

--- a/ui/src/lib/orchestratorApi.ts
+++ b/ui/src/lib/orchestratorApi.ts
@@ -7,10 +7,6 @@ export async function createSwarm(id: string, templateId: string) {
     idempotencyKey: crypto.randomUUID(),
   }
 
-  if (templateId?.trim()) {
-    payload.notes = templateId
-  }
-
   const body = JSON.stringify(payload)
   await apiFetch(`/orchestrator/swarms/${id}/create`, {
     method: 'POST',

--- a/ui/src/pages/hive/SwarmCreateModal.test.tsx
+++ b/ui/src/pages/hive/SwarmCreateModal.test.tsx
@@ -57,7 +57,8 @@ test('submits selected scenario', async () => {
   const body = createCall?.[1]?.body
   expect(typeof body).toBe('string')
   const parsed = JSON.parse(body as string)
-  expect(parsed).toMatchObject({ notes: 'basic' })
+  expect(parsed).toMatchObject({ templateId: 'basic' })
+  expect(parsed.notes).toBeUndefined()
   expect(await screen.findByText('Swarm created')).toBeTruthy()
 })
 


### PR DESCRIPTION
## Summary
- assert that swarm creation requests pass the templateId and do not overload the notes field
- adjust the swarm creation API wrapper to omit notes and note a future test for explicit notes support
- update the swarm creation modal test to expect the new payload shape

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ca989486a483289fc25afd4299d774