### PR TITLE
fix: guard ready emitter when RabbitMQ is unavailable

### DIFF
--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/ReadyEmitter.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/ReadyEmitter.java
@@ -3,6 +3,7 @@ package io.pockethive.swarmcontroller;
 import io.pockethive.Topology;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.event.EventListener;
@@ -29,6 +30,10 @@ public class ReadyEmitter {
     public void emit() {
         String rk = "ev.ready.swarm-controller." + instanceId;
         log.info("[CTRL] SEND rk={} inst={} payload={}", rk, instanceId, "");
-        rabbit.convertAndSend(Topology.CONTROL_EXCHANGE, rk, "");
+        try {
+            rabbit.convertAndSend(Topology.CONTROL_EXCHANGE, rk, "");
+        } catch (AmqpException e) {
+            log.warn("ready emit", e);
+        }
     }
 }

--- a/swarm-controller-service/src/test/java/io/pockethive/swarmcontroller/ReadyEmitterTest.java
+++ b/swarm-controller-service/src/test/java/io/pockethive/swarmcontroller/ReadyEmitterTest.java
@@ -5,9 +5,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.AmqpConnectException;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.doThrow;
 
 @ExtendWith(MockitoExtension.class)
 class ReadyEmitterTest {
@@ -19,5 +22,14 @@ class ReadyEmitterTest {
         ReadyEmitter emitter = new ReadyEmitter(rabbit, "inst");
         emitter.emit();
         verify(rabbit).convertAndSend(Topology.CONTROL_EXCHANGE, "ev.ready.swarm-controller.inst", "");
+    }
+
+    @Test
+    void ignoresAmqpFailures() {
+        ReadyEmitter emitter = new ReadyEmitter(rabbit, "inst");
+        doThrow(new AmqpConnectException(new IllegalStateException("boom")))
+            .when(rabbit)
+            .convertAndSend(Topology.CONTROL_EXCHANGE, "ev.ready.swarm-controller.inst", "");
+        assertDoesNotThrow(emitter::emit);
     }
 }


### PR DESCRIPTION
## Summary
- prevent the swarm controller ready emitter from failing when RabbitMQ is unreachable by logging the exception
- cover the new behaviour with a unit test that ensures AMQP failures are ignored

## Testing
- mvn -pl swarm-controller-service test

------
https://chatgpt.com/codex/tasks/task_e_68ca9aa059748328afce71a70c0a7920