### PR TITLE
Fix integration test RabbitMQ configuration

### DIFF
--- a/swarm-controller-service/src/test/java/io/pockethive/swarmcontroller/SwarmLifecycleManagerIntegrationTest.java
+++ b/swarm-controller-service/src/test/java/io/pockethive/swarmcontroller/SwarmLifecycleManagerIntegrationTest.java
@@ -5,11 +5,14 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.amqp.core.*;
 import org.springframework.amqp.rabbit.junit.RabbitAvailable;
+import org.springframework.amqp.rabbit.junit.RabbitAvailableCondition;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 
 import io.pockethive.docker.DockerContainerClient;
 
@@ -20,6 +23,12 @@ import static org.junit.jupiter.api.Assertions.*;
 @SpringBootTest
 @RabbitAvailable
 class SwarmLifecycleManagerIntegrationTest {
+  @DynamicPropertySource
+  static void rabbitProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.rabbitmq.host", () -> RabbitAvailableCondition.getBrokerRunning().getHostName());
+    registry.add("spring.rabbitmq.port", () -> RabbitAvailableCondition.getBrokerRunning().getPort());
+  }
+
   @Autowired
   SwarmLifecycleManager manager;
 


### PR DESCRIPTION
## Summary
- align the swarm controller integration test with the RabbitAvailable broker by publishing its host and port through DynamicPropertySource

## Testing
- mvn -pl swarm-controller-service test

------
https://chatgpt.com/codex/tasks/task_e_68cabebbd4708328a9f618d02a9bef26