### PR TITLE
fix: redeclare missing swarm queues during prepare

### DIFF
--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmLifecycleManager.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmLifecycleManager.java
@@ -152,8 +152,13 @@ public class SwarmLifecycleManager implements SwarmLifecycle {
       }
 
       for (String suffix : suffixes) {
-        if (!declaredQueues.contains(suffix)) {
-          Queue q = QueueBuilder.durable("ph." + Topology.SWARM_ID + "." + suffix).build();
+        String queueName = "ph." + Topology.SWARM_ID + "." + suffix;
+        boolean queueMissing = amqp.getQueueProperties(queueName) == null;
+        if (queueMissing) {
+          declaredQueues.remove(suffix);
+        }
+        if (queueMissing || !declaredQueues.contains(suffix)) {
+          Queue q = QueueBuilder.durable(queueName).build();
           amqp.declareQueue(q);
           Binding b = BindingBuilder.bind(q).to(hive).with(suffix);
           amqp.declareBinding(b);


### PR DESCRIPTION
## Summary
- ensure the swarm lifecycle manager re-declares queues when RabbitMQ resources disappear
- keep the declared queue tracker in sync with actual broker state to avoid stale entries

## Testing
- mvn -pl swarm-controller-service -am test

------
https://chatgpt.com/codex/tasks/task_e_68cac312da208328ac22012baf4f700f