### PR TITLE
fix: surface docker daemon availability failures

### DIFF
--- a/common/docker-client/src/main/java/io/pockethive/docker/DockerDaemonUnavailableException.java
+++ b/common/docker-client/src/main/java/io/pockethive/docker/DockerDaemonUnavailableException.java
@@ -1,0 +1,11 @@
+package io.pockethive.docker;
+
+/**
+ * Indicates that the Docker daemon could not be reached from the current runtime.
+ */
+public class DockerDaemonUnavailableException extends RuntimeException {
+
+    public DockerDaemonUnavailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
## Summary
- wrap docker daemon connection failures in a dedicated DockerDaemonUnavailableException with guidance for operators
- ensure SwarmSignalListener propagates the friendly error message and extend unit coverage around Docker outages

## Testing
- mvn -pl common/docker-client -am test
- mvn -pl swarm-controller-service -am test

------
https://chatgpt.com/codex/tasks/task_e_68caf40e751c8328a93782c3587e91ba