### PR TITLE
chore: document swarm controller self-status handling

### DIFF
--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmSignalListener.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmSignalListener.java
@@ -123,6 +123,9 @@ public class SwarmSignalListener {
               log.debug("Ignoring status for swarm {} on routing key {}", swarmId, routingKey);
               return;
             }
+            // We purposely count the controller's own status messages here. Keeping our heartbeat in the
+            // lifecycle cache ensures the aggregate metrics still show a "degraded" swarm instead of
+            // falling back to "unknown" when other roles go quiet.
             lifecycle.updateHeartbeat(parts[0], parts[1]);
             boolean enabled = node.path("data").path("enabled").asBoolean(true);
             lifecycle.updateEnabled(parts[0], parts[1], enabled);


### PR DESCRIPTION
## Summary
- explain in the swarm controller why it counts its own status updates when aggregating lifecycle data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68caf48432ec8328a6a159e52b1be2ca