### PR TITLE
feat(orchestrator): mount docker socket for controllers

### DIFF
--- a/orchestrator-service/src/test/java/io/pockethive/orchestrator/app/SwarmCreationMock1E2ETest.java
+++ b/orchestrator-service/src/test/java/io/pockethive/orchestrator/app/SwarmCreationMock1E2ETest.java
@@ -1,6 +1,7 @@
 package io.pockethive.orchestrator.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -158,7 +159,7 @@ class SwarmCreationMock1E2ETest {
         Assumptions.assumeTrue(dockerAvailable, "Docker is required to run this test");
 
         when(docker.resolveControlNetwork()).thenReturn("ph-test-net");
-        when(docker.createAndStartContainer(anyString(), anyMap(), anyString()))
+        when(docker.createAndStartContainer(anyString(), anyMap(), anyString(), any()))
             .thenReturn("container-123");
 
         RabbitAdmin admin = new RabbitAdmin(connectionFactory);
@@ -190,7 +191,7 @@ class SwarmCreationMock1E2ETest {
 
         assertThat(swarmPlanRegistry.find(instanceId)).isPresent();
 
-        verify(docker).createAndStartContainer(eq("pockethive-swarm-controller:latest"), anyMap(), eq(instanceId));
+        verify(docker).createAndStartContainer(eq("pockethive-swarm-controller:latest"), anyMap(), eq(instanceId), any());
 
         AnonymousQueue captureQueue = new AnonymousQueue();
         String captureName = admin.declareQueue(captureQueue);

--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/infra/docker/DockerConfiguration.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/infra/docker/DockerConfiguration.java
@@ -6,14 +6,21 @@ import com.github.dockerjava.core.DockerClientImpl;
 import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
 import com.github.dockerjava.transport.DockerHttpClient;
 import io.pockethive.docker.DockerContainerClient;
+import java.util.Optional;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class DockerConfiguration {
   @Bean
-  public DockerClient dockerClient() {
-    DefaultDockerClientConfig config = DefaultDockerClientConfig.createDefaultConfigBuilder().build();
+  public DefaultDockerClientConfig dockerClientConfig() {
+    DefaultDockerClientConfig.Builder builder = DefaultDockerClientConfig.createDefaultConfigBuilder();
+    resolveDockerHostOverride().ifPresent(builder::withDockerHost);
+    return builder.build();
+  }
+
+  @Bean
+  public DockerClient dockerClient(DefaultDockerClientConfig config) {
     DockerHttpClient httpClient = new ApacheDockerHttpClient.Builder()
         .dockerHost(config.getDockerHost())
         .sslConfig(config.getSSLConfig())
@@ -24,5 +31,14 @@ public class DockerConfiguration {
   @Bean
   public DockerContainerClient dockerContainerClient(DockerClient dockerClient) {
     return new DockerContainerClient(dockerClient);
+  }
+
+  private Optional<String> resolveDockerHostOverride() {
+    return Optional.ofNullable(System.getenv("DOCKER_HOST"))
+        .filter(host -> !host.isBlank())
+        .or(() -> Optional.ofNullable(System.getProperty("DOCKER_HOST")))
+        .filter(host -> !host.isBlank())
+        .or(() -> Optional.ofNullable(System.getProperty("docker.host")))
+        .filter(host -> !host.isBlank());
   }
 }

--- a/swarm-controller-service/src/test/java/io/pockethive/swarmcontroller/infra/docker/DockerConfigurationTest.java
+++ b/swarm-controller-service/src/test/java/io/pockethive/swarmcontroller/infra/docker/DockerConfigurationTest.java
@@ -1,0 +1,41 @@
+package io.pockethive.swarmcontroller.infra.docker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.dockerjava.core.DefaultDockerClientConfig;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+class DockerConfigurationTest {
+
+  private final DockerConfiguration configuration = new DockerConfiguration();
+
+  @Test
+  void dockerClientConfigHonorsDockerHostEnvironmentVariable() {
+    Assumptions.assumeTrue(isDockerHostEnvUnset(), "DOCKER_HOST env must be unset for this test");
+    String previousUpper = System.getProperty("DOCKER_HOST");
+    String previousLower = System.getProperty("docker.host");
+    System.setProperty("DOCKER_HOST", "unix:///custom/docker.sock");
+    System.clearProperty("docker.host");
+    try {
+      DefaultDockerClientConfig config = configuration.dockerClientConfig();
+      assertThat(config.getDockerHost().toString()).isEqualTo("unix:///custom/docker.sock");
+    } finally {
+      if (previousUpper == null) {
+        System.clearProperty("DOCKER_HOST");
+      } else {
+        System.setProperty("DOCKER_HOST", previousUpper);
+      }
+      if (previousLower == null) {
+        System.clearProperty("docker.host");
+      } else {
+        System.setProperty("docker.host", previousLower);
+      }
+    }
+  }
+
+  private boolean isDockerHostEnvUnset() {
+    String envValue = System.getenv("DOCKER_HOST");
+    return envValue == null || envValue.isBlank();
+  }
+}


### PR DESCRIPTION
## Summary
- allow DockerContainerClient to accept host config customizations when creating containers
- mount the Docker socket inside swarm-controller containers launched by the orchestrator
- cover the new behavior with unit and integration tests

## Testing
- mvn -pl common/docker-client,orchestrator-service test

------
https://chatgpt.com/codex/tasks/task_e_68caf92f6aec8328ad87540de5da015f