### PR TITLE
feat: add start scripts for PocketHive stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ flowchart LR
 
 ## Quick start
 1. Install Docker.
-2. Run `docker compose up -d` to launch RabbitMQ, services and the UI.
+2. Run `./start-hive.sh` (Linux/macOS) or `start-hive.bat` (Windows) to clean previous runs, build the images and launch RabbitMQ, services and the UI. Use `--help` to run individual stages (clean, build, start) when needed.
+   - Alternatively run `docker compose up -d` directly to start the stack with your existing images.
 3. Open <http://localhost:8088>. Only the Orchestrator (Queen) runs initially. Create and start swarms from the Hive view by selecting a scenario.
 
 ## Documentation

--- a/start-hive.bat
+++ b/start-hive.bat
@@ -1,0 +1,156 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+set "SCRIPT_DIR=%~dp0"
+pushd "%SCRIPT_DIR%" >nul
+
+where docker >nul 2>&1
+if errorlevel 1 (
+  echo Docker is required but was not found in PATH.
+  popd >nul
+  exit /b 1
+)
+
+docker compose version >nul 2>&1
+if errorlevel 1 (
+  echo Docker Compose v2 is required (docker compose command).
+  popd >nul
+  exit /b 1
+)
+
+set "ALL_STAGES=clean build-core build-bees start"
+set "STAGES="
+
+if "%~1"=="" (
+  set "STAGES=%ALL_STAGES%"
+  goto :run
+)
+
+:parse
+if "%~1"=="" goto :postparse
+if /I "%~1"=="-h" goto :usage
+if /I "%~1"=="--help" goto :usage
+if /I "%~1"=="--all" (
+  set "STAGES=%ALL_STAGES%"
+  shift
+  goto :parse
+)
+if /I "%~1"=="all" (
+  set "STAGES=%ALL_STAGES%"
+  shift
+  goto :parse
+)
+if /I "%~1"=="clean" goto :addStage
+if /I "%~1"=="build-core" goto :addStage
+if /I "%~1"=="build-bees" goto :addStage
+if /I "%~1"=="start" goto :addStage
+echo Unknown stage: %~1
+call :usage 1
+
+:addStage
+call :appendStage %~1
+shift
+goto :parse
+
+:postparse
+if not defined STAGES (
+  echo No stages selected.
+  call :usage 1
+)
+
+goto :run
+
+:usage
+if "%~1"=="" (
+  set "ERR=0"
+) else (
+  set "ERR=%~1"
+)
+echo Usage: %~nx0 [stage ...]
+echo.
+echo Stages:
+echo   clean        Stop the compose stack and remove stray swarm containers.
+echo   build-core   Build core PocketHive service images ^(RabbitMQ, UI, etc.^).
+echo   build-bees   Build swarm controller and bee images.
+echo   start        Launch the PocketHive stack via docker compose up -d.
+echo.
+echo Examples:
+echo   %~nx0            Run all stages in order.
+echo   %~nx0 clean start  Only clean the stack and start it ^(skip builds^).
+echo   %~nx0 build-bees   Build the bee images only.
+popd >nul
+exit /b %ERR%
+
+:appendStage
+if defined STAGES (
+  set "STAGES=!STAGES! %~1"
+) else (
+  set "STAGES=%~1"
+)
+exit /b 0
+
+:run
+for %%S in (%STAGES%) do (
+  if /I "%%S"=="clean" (
+    call :stage_clean || goto :error
+  ) else if /I "%%S"=="build-core" (
+    call :stage_build_core || goto :error
+  ) else if /I "%%S"=="build-bees" (
+    call :stage_build_bees || goto :error
+  ) else if /I "%%S"=="start" (
+    call :stage_start || goto :error
+  ) else (
+    echo Unknown stage "%%S"
+    goto :error
+  )
+)
+
+echo.
+echo PocketHive stack setup complete.
+popd >nul
+exit /b 0
+
+:stage_header
+set "LABEL=%~1"
+echo.
+echo === %LABEL% ===
+exit /b 0
+
+:stage_clean
+call :stage_header "Cleaning previous PocketHive stack"
+echo Stopping docker compose services...
+docker compose down --remove-orphans
+if errorlevel 1 exit /b 1
+
+echo Removing stray swarm containers ^(bees^)...
+set "FOUND=0"
+for /f "tokens=1,2" %%A in ('docker ps -a --format "{{.ID}} {{.Names}}" ^| findstr /R /C:"-bee-"') do (
+  if "!FOUND!"=="0" (
+    set "FOUND=1"
+  )
+  echo  - Removing %%B (%%A)
+  docker rm -f %%A >nul
+)
+if "!FOUND!"=="0" echo No stray swarm containers found.
+exit /b 0
+
+:stage_build_core
+call :stage_header "Building core PocketHive services"
+docker compose build rabbitmq log-aggregator scenario-manager orchestrator ui prometheus grafana loki wiremock
+exit /b %ERRORLEVEL%
+
+:stage_build_bees
+call :stage_header "Building swarm controller and bee images"
+docker compose --profile bees build swarm-controller generator moderator processor postprocessor trigger
+exit /b %ERRORLEVEL%
+
+:stage_start
+call :stage_header "Starting PocketHive stack"
+docker compose up -d
+exit /b %ERRORLEVEL%
+
+:error
+echo.
+echo Failed to complete requested stages.
+popd >nul
+exit /b 1

--- a/start-hive.sh
+++ b/start-hive.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "${SCRIPT_DIR}"
+
+CORE_SERVICES=(rabbitmq log-aggregator scenario-manager orchestrator ui prometheus grafana loki wiremock)
+BEE_SERVICES=(swarm-controller generator moderator processor postprocessor trigger)
+ALL_STAGES=(clean build-core build-bees start)
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [stage ...]
+
+Stages:
+  clean        Stop the compose stack and remove stray swarm containers.
+  build-core   Build core PocketHive service images (RabbitMQ, UI, etc.).
+  build-bees   Build swarm controller and bee images.
+  start        Launch the PocketHive stack via docker compose up -d.
+
+Examples:
+  $(basename "$0")            Run all stages in order.
+  $(basename "$0") clean start  Only clean the stack and start it (skip builds).
+  $(basename "$0") build-bees   Build the bee images only.
+USAGE
+}
+
+require_tools() {
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "Docker is required but was not found in PATH." >&2
+    exit 1
+  fi
+  if ! docker compose version >/dev/null 2>&1; then
+    echo "Docker Compose V2 is required (docker compose command)." >&2
+    exit 1
+  fi
+}
+
+stage_header() {
+  local label="$1"
+  echo
+  echo "=== ${label} ==="
+}
+
+run_clean() {
+  stage_header "Cleaning previous PocketHive stack"
+  echo "Stopping docker compose services..."
+  docker compose down --remove-orphans
+
+  echo "Removing stray swarm containers (bees)..."
+  mapfile -t bee_containers < <(docker ps -a --format '{{.ID}}\t{{.Names}}' | awk -F '\t' '$2 ~ /-bee-/')
+  if [[ ${#bee_containers[@]} -eq 0 ]]; then
+    echo "No stray swarm containers found."
+  else
+    for entry in "${bee_containers[@]}"; do
+      IFS=$'\t' read -r cid cname <<<"$entry"
+      if [[ -n "$cid" ]]; then
+        echo " - Removing $cname ($cid)"
+        docker rm -f "$cid" >/dev/null
+      fi
+    done
+  fi
+}
+
+run_build_core() {
+  stage_header "Building core PocketHive services"
+  docker compose build "${CORE_SERVICES[@]}"
+}
+
+run_build_bees() {
+  stage_header "Building swarm controller and bee images"
+  docker compose --profile bees build "${BEE_SERVICES[@]}"
+}
+
+run_start() {
+  stage_header "Starting PocketHive stack"
+  docker compose up -d
+}
+
+resolve_stages() {
+  if [[ $# -eq 0 ]]; then
+    SELECTED_STAGES=("${ALL_STAGES[@]}")
+    return
+  fi
+
+  local args=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      --all|all)
+        SELECTED_STAGES=("${ALL_STAGES[@]}")
+        return
+        ;;
+      clean|build-core|build-bees|start)
+        args+=("$1")
+        ;;
+      *)
+        echo "Unknown stage: $1" >&2
+        usage >&2
+        exit 1
+        ;;
+    esac
+    shift
+  done
+
+  if [[ ${#args[@]} -eq 0 ]]; then
+    echo "No stages selected." >&2
+    usage >&2
+    exit 1
+  fi
+
+  SELECTED_STAGES=("${args[@]}")
+}
+
+run_stage() {
+  case "$1" in
+    clean) run_clean ;;
+    build-core) run_build_core ;;
+    build-bees) run_build_bees ;;
+    start) run_start ;;
+    *) echo "Unknown stage: $1" >&2; exit 1 ;;
+  esac
+}
+
+main() {
+  require_tools
+  resolve_stages "$@"
+
+  for stage in "${SELECTED_STAGES[@]}"; do
+    run_stage "$stage"
+  done
+
+  echo
+  echo "PocketHive stack setup complete."
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add cross-platform scripts to clean, build and start the PocketHive stack with selectable stages
- document the new startup helper scripts in the quick start guide

## Testing
- bash -n start-hive.sh

------
https://chatgpt.com/codex/tasks/task_e_68cbc674459c8328be07f175d467da34