### PR TITLE
docs: align swarm creation guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,60 @@ PocketHive is a portable transaction swarm. It orchestrates containerised compon
 
 ## Architecture
 
+### Swarm at a glance
+
 ```mermaid
 flowchart LR
   SM[Scenario Manager] --> UI[UI]
   UI <--> O["Orchestrator (Queen)"]
+  O -. REST .-> OAPI[/POST /api/swarms/{swarmId}/create/]
   O --> SW[Swarm]
   subgraph SW
     direction TB
     M["Swarm Controller (Marshal)"] --> W["Workers (Bees)"]
   end
+  M -. AMQP .-> W
   W --> SUT[(System Under Test)]
   W --> OBS[Observability]
+```
+
+### How a swarm comes to life
+
+```mermaid
+sequenceDiagram
+  participant UI as UI
+  participant OR as Orchestrator
+  participant RT as Runtime (Docker/K8s)
+  participant SC as Swarm Controller
+
+  UI->>OR: POST /api/swarms/{swarmId}/create
+  OR->>RT: Launch swarm controller workload
+  RT-->>OR: Container ready
+  SC-->>OR: ev.ready.swarm-controller.<instance>
+  OR-->>UI: ev.ready.swarm-create.<swarmId>
+  OR->>SC: sig.swarm-template.<swarmId>
+  SC-->>OR: ev.ready.swarm-template.<swarmId>
+  OR->>SC: sig.swarm-start.<swarmId>
+  SC-->>OR: ev.ready.swarm-start.<swarmId>
+```
+
+### Swarm lifecycle states
+
+```mermaid
+stateDiagram-v2
+  [*] --> New
+  New --> Creating: POST /api/swarms/{swarmId}/create
+  Creating --> Ready: ev.ready.swarm-create
+  Ready --> Starting: sig.swarm-start
+  Starting --> Running: ev.ready.swarm-start
+  Running --> Stopping: sig.swarm-stop
+  Stopping --> Stopped: ev.ready.swarm-stop
+  Stopped --> Starting: sig.swarm-start
+  Ready --> Removing: sig.swarm-remove
+  Stopped --> Removing: sig.swarm-remove
+  Running --> Removing: sig.swarm-remove
+  Removing --> Removed: ev.ready.swarm-remove
+  Removed --> [*]
 ```
 
 ## Quick start

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -50,16 +50,21 @@ Manual checks:
 - Submit to create the swarm, then start it with the play button next to its entry.
 
 ### Scenario and swarm API
-- STOMP `sig.swarm-create.<swarmId>` to `/exchange/ph.control/sig.swarm-create.<swarmId>` with body:
+- Create swarms via the Orchestrator REST API: `POST /api/swarms/{swarmId}/create` with JSON such as:
 
   ```json
-  { "templateId": "rest" }
+  {
+    "templateId": "rest",
+    "idempotencyKey": "create-rest-001"
+  }
   ```
 
-  The orchestrator resolves the template from `scenario-manager-service`, converts it to a `SwarmPlan`, launches a Swarm Controller and then publishes `sig.swarm-template.<swarmId>` containing the full plan (all bee containers default to `enabled: false`).
-- The orchestrator emits `ev.ready.swarm-create.<swarmId>` once the controller container starts.
-- Wait for `ev.swarm-ready.<swarmId>` to confirm the swarm is provisioned but idle.
-- When ready to run, STOMP `sig.swarm-start.<swarmId>` with an empty body to enable the bees and begin execution.
+  The Orchestrator fetches the requested template from `scenario-manager-service`, expands it into a `SwarmPlan`, boots a Swarm Controller runtime, and tracks progress internally—no `sig.swarm-create` message is published by clients.
+- Subscribe to the control-plane confirmations to follow the lifecycle:
+  - `ev.ready.swarm-create.<swarmId>` — emitted by the Orchestrator after the controller handshake completes.
+  - `ev.ready.swarm-template.<swarmId>` — emitted by the Swarm Controller once the plan is applied and bees are provisioned (idle by default).
+  - `ev.ready.swarm-start.<swarmId>` — emitted after issuing a start; indicates workloads are enabled and running.
+- Start execution with `POST /api/swarms/{swarmId}/start` (body: `{ "idempotencyKey": "start-rest-001" }`). The Orchestrator sends `sig.swarm-start.<swarmId>` on your behalf and you can reuse the same event subscriptions above to detect readiness or handle the matching `ev.error.*` topics if something fails.
 
 ## Troubleshooting
 - **WebSocket errors**: ensure UI health is `ok`, RabbitMQ is running and Web-STOMP is enabled; check browser network logs for `/ws`.


### PR DESCRIPTION
## Summary
- update the usage guide to direct clients to POST /api/swarms/{swarmId}/create instead of publishing sig.swarm-create
- describe the orchestrator-driven lifecycle and the ev.ready.* confirmations that mark each phase of swarm creation and start
- document starting swarms through the REST API and reusing the confirmation topics for readiness tracking

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cc08e32244832899d58136fdad682c