### PR TITLE
feat(ui): group swarms in topology view

### DIFF
--- a/ui/src/pages/hive/TopologyView.css
+++ b/ui/src/pages/hive/TopologyView.css
@@ -107,3 +107,82 @@
 .react-flow__node-dragging {
   z-index: 1000 !important;
 }
+
+.swarm-group {
+  width: 220px;
+  height: 240px;
+  background: rgba(255, 255, 255, 0.95);
+  border: 2px solid #d4d4d8;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.15);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.swarm-group.selected {
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.25);
+}
+
+.swarm-group__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.swarm-group__title {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: #111827;
+}
+
+.swarm-group__details {
+  border: none;
+  background: #2563eb;
+  color: #fff;
+  border-radius: 9999px;
+  padding: 2px 8px;
+  font-size: 0.7rem;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.swarm-group__details:hover {
+  background: #1d4ed8;
+}
+
+.swarm-group__svg {
+  width: 100%;
+  height: 100%;
+  flex: 1 1 auto;
+}
+
+.swarm-group__edge {
+  opacity: 0.85;
+}
+
+.swarm-group__selection {
+  fill: rgba(59, 130, 246, 0.15);
+  stroke: #3b82f6;
+  stroke-width: 2;
+}
+
+.swarm-group__icon-label {
+  font-size: 0.55rem;
+  font-weight: 600;
+  fill: #111827;
+  pointer-events: none;
+}
+
+.swarm-group__badge {
+  fill: #1f2937;
+}
+
+.swarm-group__badge-text {
+  font-size: 0.45rem;
+  fill: #fff;
+  pointer-events: none;
+}

--- a/ui/src/pages/hive/TopologyView.tsx
+++ b/ui/src/pages/hive/TopologyView.tsx
@@ -118,6 +118,245 @@ function ShapeNode({ data, selected }: NodeProps<ShapeNodeData>) {
   )
 }
 
+interface SwarmGroupComponentData {
+  id: string
+  name: string
+  shape: NodeShape
+  enabled?: boolean
+  queueCount: number
+}
+
+interface SwarmGroupEdgeData {
+  source: string
+  target: string
+  queue: string
+  depth: number
+}
+
+interface SwarmGroupNodeData {
+  label: string
+  swarmId: string
+  controllerId: string
+  components: SwarmGroupComponentData[]
+  edges: SwarmGroupEdgeData[]
+  onDetails?: (swarmId: string) => void
+  selectedId?: string
+}
+
+function SwarmGroupNode({ data }: NodeProps<SwarmGroupNodeData>) {
+  const size = 180
+  const center = size / 2
+  const controller = data.components.find((c) => c.id === data.controllerId)
+  const ringMembers = controller
+    ? data.components.filter((c) => c.id !== controller.id)
+    : data.components
+  const ringRadius = ringMembers.length > 1 || controller
+    ? Math.min(center - 24, 60)
+    : 0
+  const placements = useMemo(() => {
+    const list: (SwarmGroupComponentData & { x: number; y: number })[] = []
+    if (controller) {
+      list.push({ ...controller, x: center, y: center })
+    }
+    if (ringMembers.length === 0 && !controller && data.components[0]) {
+      list.push({ ...data.components[0], x: center, y: center })
+      return list
+    }
+    const denominator = Math.max(ringMembers.length, 1)
+    ringMembers.forEach((comp, idx) => {
+      const angle = -Math.PI / 2 + (2 * Math.PI * idx) / denominator
+      const radius = ringRadius
+      const x = radius ? center + radius * Math.cos(angle) : center
+      const y = radius ? center + radius * Math.sin(angle) : center
+      list.push({ ...comp, x, y })
+    })
+    return list
+  }, [center, controller, data.components, ringMembers, ringRadius])
+
+  const byId = useMemo(() => {
+    const map = new Map<string, (SwarmGroupComponentData & { x: number; y: number })>()
+    placements.forEach((p) => map.set(p.id, p))
+    return map
+  }, [placements])
+
+  const hasSelected = data.selectedId
+    ? data.components.some((c) => c.id === data.selectedId)
+    : false
+
+  const renderShape = useCallback(
+    (comp: SwarmGroupComponentData & { x: number; y: number }) => {
+      const fill = comp.enabled === false ? '#999999' : '#ffcc00'
+      const iconRadius = comp.id === data.controllerId ? 14 : 11
+      const label = comp.name
+        .split(/[-_]/)
+        .filter((part) => part.length > 0)
+        .map((part) => part[0]?.toUpperCase() ?? '')
+        .join('')
+        .slice(0, 2)
+      const badgeValue = comp.queueCount > 99 ? '99+' : comp.queueCount.toString()
+      return (
+        <g key={comp.id}>
+          {comp.id === data.selectedId && (
+            <circle
+              className="swarm-group__selection"
+              cx={comp.x}
+              cy={comp.y}
+              r={iconRadius + 6}
+            />
+          )}
+          {comp.shape === 'square' && (
+            <rect
+              x={comp.x - iconRadius}
+              y={comp.y - iconRadius}
+              width={iconRadius * 2}
+              height={iconRadius * 2}
+              fill={fill}
+              stroke="black"
+            />
+          )}
+          {comp.shape === 'triangle' && (
+            <polygon
+              points={`${comp.x},${comp.y - iconRadius} ${comp.x + iconRadius},${comp.y + iconRadius} ${comp.x - iconRadius},${comp.y + iconRadius}`}
+              fill={fill}
+              stroke="black"
+            />
+          )}
+          {comp.shape === 'diamond' && (
+            <polygon
+              points={`${comp.x},${comp.y - iconRadius} ${comp.x + iconRadius},${comp.y} ${comp.x},${comp.y + iconRadius} ${comp.x - iconRadius},${comp.y}`}
+              fill={fill}
+              stroke="black"
+            />
+          )}
+          {comp.shape === 'pentagon' && (
+            <polygon
+              points={polygonPoints(5, iconRadius)
+                .split(' ')
+                .map((pair) => {
+                  const [px, py] = pair.split(',').map(Number)
+                  return `${px - iconRadius + comp.x},${py - iconRadius + comp.y}`
+                })
+                .join(' ')}
+              fill={fill}
+              stroke="black"
+            />
+          )}
+          {comp.shape === 'hexagon' && (
+            <polygon
+              points={polygonPoints(6, iconRadius)
+                .split(' ')
+                .map((pair) => {
+                  const [px, py] = pair.split(',').map(Number)
+                  return `${px - iconRadius + comp.x},${py - iconRadius + comp.y}`
+                })
+                .join(' ')}
+              fill={fill}
+              stroke="black"
+            />
+          )}
+          {comp.shape === 'star' && (
+            <polygon
+              points={starPoints(iconRadius)
+                .split(' ')
+                .map((pair) => {
+                  const [px, py] = pair.split(',').map(Number)
+                  return `${px - iconRadius + comp.x},${py - iconRadius + comp.y}`
+                })
+                .join(' ')}
+              fill={fill}
+              stroke="black"
+            />
+          )}
+          {comp.shape === 'circle' && (
+            <circle cx={comp.x} cy={comp.y} r={iconRadius} fill={fill} stroke="black" />
+          )}
+          <text
+            x={comp.x}
+            y={comp.y + 3}
+            textAnchor="middle"
+            className="swarm-group__icon-label"
+          >
+            {label || '?'}
+          </text>
+          {comp.queueCount > 0 && (
+            <g>
+              <circle
+                cx={comp.x + iconRadius * 0.85}
+                cy={comp.y - iconRadius * 0.85}
+                r={7}
+                className="swarm-group__badge"
+              />
+              <text
+                x={comp.x + iconRadius * 0.85}
+                y={comp.y - iconRadius * 0.85 + 2}
+                textAnchor="middle"
+                className="swarm-group__badge-text"
+              >
+                {badgeValue}
+              </text>
+            </g>
+          )}
+        </g>
+      )
+    },
+    [data.controllerId, data.selectedId],
+  )
+
+  return (
+    <div className={`swarm-group${hasSelected ? ' selected' : ''}`}>
+      <div className="swarm-group__header">
+        <span className="swarm-group__title">{data.label}</span>
+        <button
+          className="swarm-group__details"
+          onClick={(e) => {
+            e.stopPropagation()
+            data.onDetails?.(data.swarmId)
+          }}
+        >
+          Details
+        </button>
+      </div>
+      <svg
+        className="swarm-group__svg"
+        viewBox={`0 0 ${size} ${size}`}
+        preserveAspectRatio="xMidYMid meet"
+      >
+        {data.edges.map((edge) => {
+          const from = byId.get(edge.source)
+          const to = byId.get(edge.target)
+          if (!from || !to) return null
+          const color = edge.depth > 0 ? '#ff6666' : '#66aaff'
+          const width = 1 + Math.log(edge.depth + 1)
+          return (
+            <line
+              key={`${edge.source}-${edge.target}-${edge.queue}`}
+              x1={from.x}
+              y1={from.y}
+              x2={to.x}
+              y2={to.y}
+              stroke={color}
+              strokeWidth={width}
+              strokeLinecap="round"
+              className="swarm-group__edge"
+            />
+          )
+        })}
+        {placements.map((comp) => renderShape(comp))}
+      </svg>
+    </div>
+  )
+}
+
+type FlowNodeData = ShapeNodeData | SwarmGroupNodeData
+type FlowNode = Node<FlowNodeData>
+
+const OUTSIDE_SWARMS = new Set(['default', 'hive'])
+
+function normalizeSwarmId(id?: string) {
+  if (!id || OUTSIDE_SWARMS.has(id)) return undefined
+  return id
+}
+
 function polygonPoints(sides: number, r: number) {
   const cx = r
   const cy = r
@@ -150,9 +389,9 @@ export default function TopologyView({ selectedId, onSelect, swarmId, onSwarmSel
   const shapeMapRef = useRef<Record<string, NodeShape>>({ sut: 'circle' })
   const [queueDepths, setQueueDepths] = useState<Record<string, number>>({})
   const [queueCounts, setQueueCounts] = useState<Record<string, number>>({})
-  const flowRef = useRef<ReactFlowInstance | null>(null)
+  const flowRef = useRef<ReactFlowInstance<FlowNode, Edge> | null>(null)
   const containerRef = useRef<HTMLDivElement>(null)
-  const [rfNodes, setRfNodes] = useState<Node<ShapeNodeData>[]>([])
+  const [rfNodes, setRfNodes] = useState<FlowNode[]>([])
 
   useEffect(() => {
     const unsub = subscribeComponents((comps: Component[]) => {
@@ -237,48 +476,177 @@ export default function TopologyView({ selectedId, onSelect, swarmId, onSwarmSel
     return map[type]
   }
 
+  const handleDetails = useCallback(
+    (targetSwarm: string) => {
+      onSwarmSelect?.(targetSwarm)
+    },
+    [onSwarmSelect],
+  )
+
   useEffect(() => {
-    setRfNodes((prev) =>
-      data.nodes.map((n) => {
-        const existing = prev.find((p) => p.id === n.id)
+    setRfNodes((prev) => {
+      const prevPositions = new Map(prev.map((node) => [node.id, node.position]))
+      if (!swarmId) {
+        const controllers = new Map<string, GraphNode>()
+        data.nodes.forEach((node) => {
+          const normalized = normalizeSwarmId(node.swarmId)
+          if (node.type === 'swarm-controller' && normalized) {
+            controllers.set(normalized, node)
+          }
+        })
+        const grouped = new Map<string, GraphNode[]>()
+        const nodes: FlowNode[] = []
+        data.nodes.forEach((node) => {
+          const normalized = normalizeSwarmId(node.swarmId)
+          if (normalized && controllers.has(normalized)) {
+            const list = grouped.get(normalized) ?? []
+            list.push(node)
+            grouped.set(normalized, list)
+            return
+          }
+          const position = prevPositions.get(node.id) ?? { x: node.x ?? 0, y: node.y ?? 0 }
+          nodes.push({
+            id: node.id,
+            position,
+            data: {
+              label: node.id,
+              shape: getShape(node.type),
+              enabled: node.enabled,
+              queueCount: queueCounts[node.id] ?? 0,
+              swarmId: node.swarmId,
+            },
+            type: 'shape',
+            selected: selectedId === node.id,
+          })
+        })
+        grouped.forEach((members, swarmKey) => {
+          const controller = controllers.get(swarmKey)
+          if (!controller) return
+          const memberSet = new Set(members.map((m) => m.id))
+          const groupEdges = data.links
+            .filter((link) => memberSet.has(link.source) && memberSet.has(link.target))
+            .map((link) => ({
+              source: link.source,
+              target: link.target,
+              queue: link.queue,
+              depth: queueDepths[link.queue] ?? 0,
+            }))
+          const position =
+            prevPositions.get(controller.id) ?? {
+              x: controller.x ?? 0,
+              y: controller.y ?? 0,
+            }
+          nodes.push({
+            id: controller.id,
+            position,
+            data: {
+              label: swarmKey,
+              swarmId: swarmKey,
+              controllerId: controller.id,
+              components: members.map((member) => ({
+                id: member.id,
+                name: member.type,
+                shape: getShape(member.type),
+                enabled: member.enabled,
+                queueCount: queueCounts[member.id] ?? 0,
+              })),
+              edges: groupEdges,
+              onDetails: handleDetails,
+              selectedId,
+            },
+            type: 'swarmGroup',
+            selectable: false,
+          })
+        })
+        return nodes
+      }
+      return data.nodes.map((node) => {
+        const position = prevPositions.get(node.id) ?? { x: node.x ?? 0, y: node.y ?? 0 }
         return {
-          id: n.id,
-          position: existing?.position ?? { x: n.x ?? 0, y: n.y ?? 0 },
+          id: node.id,
+          position,
           data: {
-            label: n.id,
-            shape: getShape(n.type),
-            enabled: n.enabled,
-            queueCount: queueCounts[n.id] ?? 0,
-            swarmId: n.swarmId,
+            label: node.id,
+            shape: getShape(node.type),
+            enabled: node.enabled,
+            queueCount: queueCounts[node.id] ?? 0,
+            swarmId: node.swarmId,
           },
           type: 'shape',
-          selected: selectedId === n.id,
-        } as Node<ShapeNodeData>
-      }),
-    )
-  }, [data.nodes, queueCounts, selectedId])
+          selected: selectedId === node.id,
+        }
+      }) as FlowNode[]
+    })
+  }, [data.links, data.nodes, queueCounts, queueDepths, handleDetails, selectedId, swarmId])
 
-  const edges: Edge[] = useMemo(
-    () =>
-      data.links.map((l) => {
-        const depth = queueDepths[l.queue] ?? 0
+  const nodeById = useMemo(() => {
+    const map = new Map<string, GraphNode>()
+    data.nodes.forEach((node) => map.set(node.id, node))
+    return map
+  }, [data.nodes])
+
+  const edges: Edge[] = useMemo(() => {
+    const seen = new Set<string>()
+    if (!swarmId) {
+      const controllerIds = new Map<string, string>()
+      data.nodes.forEach((node) => {
+        const normalized = normalizeSwarmId(node.swarmId)
+        if (node.type === 'swarm-controller' && normalized) {
+          controllerIds.set(normalized, node.id)
+        }
+      })
+      return data.links.reduce<Edge[]>((acc, link) => {
+        const sourceNode = nodeById.get(link.source)
+        const targetNode = nodeById.get(link.target)
+        if (!sourceNode || !targetNode) return acc
+        const sourceSwarm = normalizeSwarmId(sourceNode.swarmId)
+        const targetSwarm = normalizeSwarmId(targetNode.swarmId)
+        const sourceId = sourceSwarm && controllerIds.get(sourceSwarm)
+          ? controllerIds.get(sourceSwarm)!
+          : sourceNode.id
+        const targetId = targetSwarm && controllerIds.get(targetSwarm)
+          ? controllerIds.get(targetSwarm)!
+          : targetNode.id
+        if (sourceId === targetId) return acc
+        const key = `${sourceId}|${targetId}|${link.queue}`
+        if (seen.has(key)) return acc
+        seen.add(key)
+        const depth = queueDepths[link.queue] ?? 0
         const color = depth > 0 ? '#ff6666' : '#66aaff'
         const width = 2 + Math.log(depth + 1)
-        return {
-          id: `${l.source}-${l.target}-${l.queue}`,
-          source: l.source,
-          target: l.target,
-          label: l.queue,
+        acc.push({
+          id: `${sourceId}-${targetId}-${link.queue}`,
+          source: sourceId,
+          target: targetId,
+          label: link.queue,
           style: { stroke: color, strokeWidth: width },
           markerEnd: { type: MarkerType.ArrowClosed, color },
           labelBgPadding: [2, 2],
           labelBgBorderRadius: 2,
           labelStyle: { fill: '#fff', fontSize: 6 },
           labelBgStyle: { fill: 'rgba(0,0,0,0.6)' },
-        }
-      }) as unknown as Edge[],
-    [data.links, queueDepths],
-  )
+        })
+        return acc
+      }, [])
+    }
+    return data.links.map((link) => {
+      const depth = queueDepths[link.queue] ?? 0
+      const color = depth > 0 ? '#ff6666' : '#66aaff'
+      const width = 2 + Math.log(depth + 1)
+      return {
+        id: `${link.source}-${link.target}-${link.queue}`,
+        source: link.source,
+        target: link.target,
+        label: link.queue,
+        style: { stroke: color, strokeWidth: width },
+        markerEnd: { type: MarkerType.ArrowClosed, color },
+        labelBgPadding: [2, 2],
+        labelBgBorderRadius: 2,
+        labelStyle: { fill: '#fff', fontSize: 6 },
+        labelBgStyle: { fill: 'rgba(0,0,0,0.6)' },
+      }
+    }) as Edge[]
+  }, [data.links, data.nodes, nodeById, queueDepths, swarmId])
 
   const onNodesChange = useCallback(
     (changes: NodeChange[]) => setRfNodes((nds) => applyNodeChanges(changes, nds)),
@@ -293,25 +661,24 @@ export default function TopologyView({ selectedId, onSelect, swarmId, onSwarmSel
 
   return (
     <div ref={containerRef} className="topology-container">
-        <ReactFlow<Node<ShapeNodeData>, Edge>
+        <ReactFlow<FlowNode, Edge>
           nodes={rfNodes}
           edges={edges}
           onNodesChange={onNodesChange}
-          nodeTypes={{ shape: ShapeNode }}
-          onInit={(inst: ReactFlowInstance<Node<ShapeNodeData>, Edge>) =>
+          nodeTypes={{ shape: ShapeNode, swarmGroup: SwarmGroupNode }}
+          onInit={(inst: ReactFlowInstance<FlowNode, Edge>) =>
             (flowRef.current = inst)
           }
           onNodeDragStop={(
             _e: unknown,
-            node: Node<ShapeNodeData>,
+            node: FlowNode,
           ) => updateNodePosition(node.id, node.position.x, node.position.y)}
           onNodeClick={(
             _e: unknown,
-            node: Node<ShapeNodeData>,
+            node: FlowNode,
           ) => {
-            const d = node.data as ShapeNodeData
-            if (swarmId) onSelect?.(node.id)
-            else onSwarmSelect?.(d.swarmId ?? 'default')
+            if (node.type === 'swarmGroup') return
+            onSelect?.(node.id)
           }}
           fitView
         >


### PR DESCRIPTION
## Summary
- render swarm controllers as grouped nodes that embed component icons and show their internal connections
- aggregate topology edges around swarm groups while keeping hive-level services outside swarm navigation
- add styling and tests covering the grouped presentation and aggregated behaviour

## Testing
- npm test -- TopologyView.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc314cdcf8832895d918db4db942ca