### PR TITLE
chore: remove unused swarm1 exchange from rabbitmq config

### DIFF
--- a/rabbitmq/definitions.json
+++ b/rabbitmq/definitions.json
@@ -43,15 +43,6 @@
       "arguments": {}
     },
     {
-      "name": "ph.swarm1.hive",
-      "vhost": "/",
-      "type": "topic",
-      "durable": true,
-      "auto_delete": false,
-      "internal": false,
-      "arguments": {}
-    },
-    {
       "name": "ph.logs",
       "vhost": "/",
       "type": "topic",


### PR DESCRIPTION
## Summary
- remove the ph.swarm1.hive exchange from the RabbitMQ definitions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cc51336d1883288241ce911594b417