### PR TITLE
fix(ui): split orchestrator controls

### DIFF
--- a/ui/assets/css/app.css
+++ b/ui/assets/css/app.css
@@ -56,6 +56,44 @@ p{ color:#9aa0a6; }
 #status-ui[data-state="connecting"], #status-ws[data-state="connecting"]{ --hal:#00ccff; }
 #status-ui[data-state="connecting"]::after, #status-ws[data-state="connecting"]::after{ animation: hal-core-modem 1.1s linear infinite; }
 
+/* Generic HAL eyes (orchestrator panel) */
+.hal-eye[data-state="ok"]{
+  --hal:#00ff66;
+  box-shadow: 0 0 10px rgba(0,0,0,.35) inset,
+              0 0 18px color-mix(in srgb, var(--hal) 30%, transparent),
+              0 0 34px color-mix(in srgb, var(--hal) 18%, transparent);
+}
+.hal-eye[data-state="ok"]::after{ animation: hal-core-slow 2.4s ease-in-out infinite; }
+
+.hal-eye[data-state="warn"]{
+  --hal:#ff9f1c;
+  box-shadow: 0 0 10px rgba(0,0,0,.35) inset,
+              0 0 16px color-mix(in srgb, var(--hal) 28%, transparent),
+              0 0 30px color-mix(in srgb, var(--hal) 18%, transparent);
+}
+.hal-eye[data-state="warn"]::after{ animation: hal-core-modem 1.1s linear infinite; }
+
+.hal-eye[data-state="alert"],
+.hal-eye[data-state="disabled"]{
+  box-shadow: 0 0 10px rgba(0,0,0,.35) inset,
+              0 0 18px color-mix(in srgb, var(--hal) 36%, transparent),
+              0 0 36px color-mix(in srgb, var(--hal) 22%, transparent);
+}
+.hal-eye[data-state="alert"]{ --hal:#ff0033; }
+.hal-eye[data-state="disabled"]{ --hal:#ff4d6d; }
+.hal-eye[data-state="alert"]::after,
+.hal-eye[data-state="disabled"]::after{ animation: hal-core-fast 0.7s ease-in-out infinite; }
+
+.hal-eye[data-state="missing"]{
+  --hal:#5b6679;
+  box-shadow: 0 0 10px rgba(0,0,0,.35) inset,
+              0 0 12px color-mix(in srgb, var(--hal) 22%, transparent);
+}
+.hal-eye[data-state="missing"]::after{
+  animation: none;
+  opacity: .6;
+}
+
 /* Stronger outer glow per state to increase contrast */
 #status-ui[data-state="healthy"], #status-ws[data-state="connected"]{
   box-shadow: 0 0 10px rgba(0,0,0,.35) inset,
@@ -81,6 +119,42 @@ p{ color:#9aa0a6; }
   box-shadow: 0 0 10px rgba(0,0,0,.35) inset,
               0 0 24px color-mix(in srgb, var(--hal) 40%, transparent),
               0 0 44px color-mix(in srgb, var(--hal) 28%, transparent);
+}
+
+[data-enabled]{
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.125rem 0.55rem;
+  border-radius: 9999px;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.12);
+  color: rgba(226,232,240,0.85);
+  text-transform: uppercase;
+  line-height: 1.1;
+}
+[data-enabled] > svg{ flex-shrink: 0; }
+[data-enabled] > span{ line-height: 1; }
+
+[data-enabled="true"]{
+  background: rgba(16,185,129,0.18);
+  border-color: rgba(16,185,129,0.38);
+  color: #d1fae5;
+}
+
+[data-enabled="false"]{
+  background: rgba(244,63,94,0.18);
+  border-color: rgba(244,63,94,0.38);
+  color: #fecdd3;
+}
+
+[data-enabled="unknown"]{
+  background: rgba(148,163,184,0.18);
+  border-color: rgba(148,163,184,0.28);
+  color: #e2e8f0;
 }
 /* Shared dropdown menu styling */
 .dropdown-panel{

--- a/ui/assets/css/app.css
+++ b/ui/assets/css/app.css
@@ -135,9 +135,17 @@ p{ color:#9aa0a6; }
   color: rgba(226,232,240,0.85);
   text-transform: uppercase;
   line-height: 1.1;
+  cursor: pointer;
+  user-select: none;
+  transition: background-color 0.15s ease, border-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
 }
 [data-enabled] > svg{ flex-shrink: 0; }
 [data-enabled] > span{ line-height: 1; }
+
+[data-enabled]:disabled{
+  cursor: not-allowed;
+  opacity: 0.55;
+}
 
 [data-enabled="true"]{
   background: rgba(16,185,129,0.18);

--- a/ui/src/pages/hive/HivePage.test.tsx
+++ b/ui/src/pages/hive/HivePage.test.tsx
@@ -126,7 +126,7 @@ test('enables orchestrator controls when orchestrator component is present', asy
   expect(eye).toHaveAttribute('data-state', 'ok')
   const title = eye.getAttribute('title') ?? ''
   expect(title).toMatch(/Last status OK received \d+s ago/)
-  expect(title).toContain(new Date(lastHeartbeat).toISOString())
+  expect(title).not.toMatch(/\d{4}-\d{2}-\d{2}T/)
   await user.click(startButton)
   const dialog = await screen.findByRole('dialog', {
     name: /confirm start command/i,
@@ -182,7 +182,7 @@ test('shows disabled state when orchestrator config disables it', async () => {
   expect(eye).toHaveAttribute('data-state', 'disabled')
   const title = eye.getAttribute('title') ?? ''
   expect(title).toMatch(/Last status WARN received \d+s ago/)
-  expect(title).toContain(new Date(lastHeartbeat).toISOString())
+  expect(title).not.toMatch(/\d{4}-\d{2}-\d{2}T/)
 })
 
 test('shows unassigned components when selecting default swarm', async () => {

--- a/ui/src/pages/hive/HivePage.test.tsx
+++ b/ui/src/pages/hive/HivePage.test.tsx
@@ -83,14 +83,16 @@ test('renders orchestrator panel inactive when orchestrator is missing', () => {
   }
   const eye = scope.getByTestId('orchestrator-health')
   expect(eye).toHaveAttribute('data-state', 'missing')
+  expect(eye).toHaveAttribute('title', 'Orchestrator missing')
 })
 
 test('enables orchestrator controls when orchestrator component is present', async () => {
+  const lastHeartbeat = Date.now() - 5000
   comps.push({
     id: 'hive-orchestrator',
     name: 'HAL',
     role: 'orchestrator',
-    lastHeartbeat: Date.now(),
+    lastHeartbeat,
     queues: [],
     status: 'OK',
     config: { enabled: true, swarmCount: 5 },
@@ -122,6 +124,9 @@ test('enables orchestrator controls when orchestrator component is present', asy
   )
   const eye = within(panel).getByTestId('orchestrator-health')
   expect(eye).toHaveAttribute('data-state', 'ok')
+  const title = eye.getAttribute('title') ?? ''
+  expect(title).toMatch(/Last status OK received \d+s ago/)
+  expect(title).toContain(new Date(lastHeartbeat).toISOString())
   await user.click(startButton)
   const dialog = await screen.findByRole('dialog', {
     name: /confirm start command/i,
@@ -137,14 +142,18 @@ test('enables orchestrator controls when orchestrator component is present', asy
   ).toBeInTheDocument()
   await user.click(screen.getByRole('button', { name: 'Send Stop all' }))
   expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  await user.click(within(panel).getByText('HAL'))
+  expect(await screen.findByText('hive-orchestrator')).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument()
 })
 
 test('shows disabled state when orchestrator config disables it', async () => {
+  const lastHeartbeat = Date.now() - 15000
   comps.push({
     id: 'hive-orchestrator',
     name: 'HAL disabled',
     role: 'orchestrator',
-    lastHeartbeat: Date.now(),
+    lastHeartbeat,
     queues: [],
     status: 'WARN',
     config: { enabled: false, swarmCount: 1 },
@@ -171,6 +180,9 @@ test('shows disabled state when orchestrator config disables it', async () => {
   )
   const eye = scope.getByTestId('orchestrator-health')
   expect(eye).toHaveAttribute('data-state', 'disabled')
+  const title = eye.getAttribute('title') ?? ''
+  expect(title).toMatch(/Last status WARN received \d+s ago/)
+  expect(title).toContain(new Date(lastHeartbeat).toISOString())
 })
 
 test('shows unassigned components when selecting default swarm', async () => {

--- a/ui/src/pages/hive/HivePage.test.tsx
+++ b/ui/src/pages/hive/HivePage.test.tsx
@@ -66,6 +66,11 @@ test('renders orchestrator panel inactive when orchestrator is missing', () => {
   expect(scope.getByText('Not detected')).toBeInTheDocument()
   expect(scope.getByRole('button', { name: 'Start all' })).toBeDisabled()
   expect(scope.getByRole('button', { name: 'Stop all' })).toBeDisabled()
+  const badge = scope.getByTestId('orchestrator-enabled')
+  expect(badge).toHaveTextContent('Unknown')
+  expect(badge).toHaveAttribute('data-enabled', 'unknown')
+  const eye = scope.getByTestId('orchestrator-health')
+  expect(eye).toHaveAttribute('data-state', 'missing')
 })
 
 test('enables orchestrator controls when orchestrator component is present', async () => {
@@ -87,6 +92,11 @@ test('enables orchestrator controls when orchestrator component is present', asy
   const stopButton = within(panel).getByRole('button', { name: 'Stop all' })
   expect(startButton).toBeEnabled()
   expect(stopButton).toBeEnabled()
+  const badge = within(panel).getByTestId('orchestrator-enabled')
+  expect(badge).toHaveTextContent('Enabled')
+  expect(badge).toHaveAttribute('data-enabled', 'true')
+  const eye = within(panel).getByTestId('orchestrator-health')
+  expect(eye).toHaveAttribute('data-state', 'ok')
   await user.click(startButton)
   const dialog = await screen.findByRole('dialog', {
     name: /confirm start command/i,
@@ -102,6 +112,27 @@ test('enables orchestrator controls when orchestrator component is present', asy
   ).toBeInTheDocument()
   await user.click(screen.getByRole('button', { name: 'Send Stop all' }))
   expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+})
+
+test('shows disabled state when orchestrator config disables it', async () => {
+  comps.push({
+    id: 'hive-orchestrator',
+    name: 'HAL disabled',
+    role: 'orchestrator',
+    lastHeartbeat: Date.now(),
+    queues: [],
+    config: { enabled: false },
+  })
+  render(<HivePage />)
+  const panels = screen.getAllByTestId('orchestrator-panel')
+  const panel = panels[panels.length - 1]!
+  const scope = within(panel)
+  await scope.findByText('HAL disabled')
+  const badge = scope.getByTestId('orchestrator-enabled')
+  expect(badge).toHaveTextContent('Disabled')
+  expect(badge).toHaveAttribute('data-enabled', 'false')
+  const eye = scope.getByTestId('orchestrator-health')
+  expect(eye).toHaveAttribute('data-state', 'disabled')
 })
 
 test('shows unassigned components when selecting default swarm', async () => {

--- a/ui/src/pages/hive/HivePage.tsx
+++ b/ui/src/pages/hive/HivePage.tsx
@@ -5,6 +5,7 @@ import TopologyView from './TopologyView'
 import SwarmCreateModal from './SwarmCreateModal'
 import { subscribeComponents } from '../../lib/stompClient'
 import type { Component } from '../../types/hive'
+import OrchestratorPanel from './OrchestratorPanel'
 
 export default function HivePage() {
   const [components, setComponents] = useState<Component[]>([])
@@ -31,7 +32,13 @@ export default function HivePage() {
     setSelected(null)
   }, [activeSwarm])
 
+  const isOrchestrator = (comp: Component) =>
+    comp.role.trim().toLowerCase() === 'orchestrator'
+
+  const orchestrator = components.find((c) => isOrchestrator(c)) ?? null
+
   const filtered = components.filter((c) => {
+    if (isOrchestrator(c)) return false
     const haystack = search.toLowerCase()
     const matchesSearch =
       c.name.toLowerCase().includes(haystack) ||
@@ -68,42 +75,45 @@ export default function HivePage() {
           </button>
         </div>
         <div className="mt-4 flex-1 overflow-y-auto">
-          {activeSwarm && (
-            <button
-              className="mb-2 text-xs underline"
-              onClick={() => setActiveSwarm(null)}
-            >
-              Back to all swarms
-            </button>
-          )}
-          {Object.entries(grouped)
-            .sort(([a], [b]) => a.localeCompare(b))
-            .filter(([id]) => !activeSwarm || id === activeSwarm)
-            .map(([id, comps]) => {
-              return (
-                <div
-                  key={id}
-                  className="mb-4 border border-white/20 rounded p-2"
-                >
-                  <div className="flex items-center mb-1">
-                    <div
-                      className="font-medium cursor-pointer"
-                      onClick={() =>
-                        !activeSwarm &&
-                        setActiveSwarm(id === 'default' ? 'default' : id)
-                      }
-                    >
-                      {id}
+          <div className="space-y-4">
+            <OrchestratorPanel orchestrator={orchestrator} />
+            {activeSwarm && (
+              <button
+                className="text-xs underline"
+                onClick={() => setActiveSwarm(null)}
+              >
+                Back to all swarms
+              </button>
+            )}
+            {Object.entries(grouped)
+              .sort(([a], [b]) => a.localeCompare(b))
+              .filter(([id]) => !activeSwarm || id === activeSwarm)
+              .map(([id, comps]) => {
+                return (
+                  <div
+                    key={id}
+                    className="border border-white/20 rounded p-2"
+                  >
+                    <div className="flex items-center mb-1">
+                      <div
+                        className="font-medium cursor-pointer"
+                        onClick={() =>
+                          !activeSwarm &&
+                          setActiveSwarm(id === 'default' ? 'default' : id)
+                        }
+                      >
+                        {id}
+                      </div>
                     </div>
+                    <ComponentList
+                      components={comps}
+                      onSelect={(c) => setSelected(c)}
+                      selectedId={selected?.id}
+                    />
                   </div>
-                  <ComponentList
-                    components={comps}
-                    onSelect={(c) => setSelected(c)}
-                    selectedId={selected?.id}
-                  />
-                </div>
-              )
-            })}
+                )
+              })}
+          </div>
         </div>
       </div>
       <div className="hidden md:flex flex-1 overflow-auto">

--- a/ui/src/pages/hive/HivePage.tsx
+++ b/ui/src/pages/hive/HivePage.tsx
@@ -76,7 +76,11 @@ export default function HivePage() {
         </div>
         <div className="mt-4 flex-1 overflow-y-auto">
           <div className="space-y-4">
-            <OrchestratorPanel orchestrator={orchestrator} />
+            <OrchestratorPanel
+              orchestrator={orchestrator}
+              onSelect={(component) => setSelected(component)}
+              selectedId={selected?.id}
+            />
             {activeSwarm && (
               <button
                 className="text-xs underline"

--- a/ui/src/pages/hive/OrchestratorPanel.tsx
+++ b/ui/src/pages/hive/OrchestratorPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { Play, Square } from 'lucide-react'
 import type { Component } from '../../types/hive'
 import { heartbeatHealth } from '../../lib/health'
+import { sendConfigUpdate } from '../../lib/orchestratorApi'
 
 interface Props {
   orchestrator?: Component | null
@@ -45,20 +46,23 @@ export default function OrchestratorPanel({ orchestrator }: Props) {
   const [heartbeatKey, setHeartbeatKey] = useState(0)
   const [now, setNow] = useState(() => Date.now())
   const [pendingAction, setPendingAction] = useState<OrchestratorAction | null>(null)
+  const [updatingEnabled, setUpdatingEnabled] = useState(false)
   const isDetected = Boolean(orchestrator)
-  const rawEnabled = orchestrator?.config
-    ? (orchestrator.config as { enabled?: unknown }).enabled
-    : undefined
+  const rawConfig = orchestrator?.config as Record<string, unknown> | undefined
+  const rawEnabled = rawConfig ? (rawConfig as { enabled?: unknown }).enabled : undefined
   const enabledState: 'true' | 'false' | 'unknown' = !isDetected
     ? 'unknown'
     : typeof rawEnabled === 'boolean'
     ? (rawEnabled ? 'true' : 'false')
     : 'unknown'
+  const isEnabled = enabledState === 'true'
 
   const name = useMemo(() => displayNameFor(orchestrator), [orchestrator])
   const healthState: HealthVisualState = useMemo(() => {
     if (!isDetected || !orchestrator) return 'missing'
     if (enabledState === 'false') return 'disabled'
+    const statusDerived = mapStatusToVisualState(orchestrator.status)
+    if (statusDerived) return statusDerived
     const health = heartbeatHealth(orchestrator.lastHeartbeat, now)
     switch (health) {
       case 'WARN':
@@ -70,21 +74,11 @@ export default function OrchestratorPanel({ orchestrator }: Props) {
     }
   }, [enabledState, isDetected, orchestrator, now])
 
-  const secondsSince = useMemo(() => {
-    if (!isDetected || !orchestrator) return null
-    if (orchestrator.lastHeartbeat <= 0) return null
-    const age = Math.floor((now - orchestrator.lastHeartbeat) / 1000)
-    return age < 0 ? 0 : age
-  }, [isDetected, orchestrator, now])
-
-  const statusLabel = useMemo(() => {
-    if (!isDetected) return 'Not detected'
-    if (!orchestrator || orchestrator.lastHeartbeat <= 0) return 'Awaiting status'
-    if (secondsSince === null) return 'Status received just now'
-    if (secondsSince <= 1) return 'Status received just now'
-    const suffix = healthState === 'warn' ? ' (late)' : healthState === 'alert' ? ' (stale)' : ''
-    return `Status received ${secondsSince}s ago${suffix}`
-  }, [healthState, isDetected, orchestrator, secondsSince])
+  const activeSwarmDisplay = useMemo(() => {
+    if (!rawConfig) return '—'
+    const formatted = extractActiveSwarmCount(rawConfig)
+    return formatted ?? '—'
+  }, [rawConfig])
 
   const enabledLabel =
     enabledState === 'true' ? 'Enabled' : enabledState === 'false' ? 'Disabled' : 'Unknown'
@@ -117,7 +111,26 @@ export default function OrchestratorPanel({ orchestrator }: Props) {
     }
     setHeartbeatKey((key) => key + 1)
     setNow(Date.now())
-  }, [orchestrator, orchestrator?.lastHeartbeat])
+  }, [orchestrator, orchestrator?.lastHeartbeat, orchestrator?.status])
+
+  const toggleEnabled = async () => {
+    if (!isDetected || !orchestrator || updatingEnabled) return
+    const next = !isEnabled
+    try {
+      setUpdatingEnabled(true)
+      await sendConfigUpdate(orchestrator, { enabled: next })
+    } catch (error) {
+      console.error('Failed to update orchestrator config:', error)
+    } finally {
+      setUpdatingEnabled(false)
+    }
+  }
+
+  const halTitle = !isDetected
+    ? 'Orchestrator missing'
+    : orchestrator?.status
+    ? `Orchestrator status: ${orchestrator.status}`
+    : 'Orchestrator status unavailable'
 
   return (
     <div data-testid="orchestrator-panel" className={cardClasses}>
@@ -126,31 +139,39 @@ export default function OrchestratorPanel({ orchestrator }: Props) {
           <div className="text-xs uppercase tracking-wide text-white/50">Orchestrator</div>
           <div className="mt-1 flex flex-wrap items-center gap-2">
             <div className={`text-lg font-semibold ${isDetected ? '' : 'text-white/70'}`}>{name}</div>
-            <span
-              data-enabled={enabledState}
-              data-testid="orchestrator-enabled"
-              className="shrink-0"
-            >
-              {enabledState === 'true' ? (
-                <Square className="h-3.5 w-3.5" aria-hidden="true" />
-              ) : (
-                <Play className="h-3.5 w-3.5" aria-hidden="true" />
-              )}
-              <span>{enabledLabel}</span>
-            </span>
           </div>
-          <div className="mt-1 text-xs text-white/60">{statusLabel}</div>
+          <div className="mt-1 flex items-baseline gap-2 text-xs text-white/60">
+            <span className="uppercase tracking-wide text-white/40">Active swarms</span>
+            <span className="font-semibold text-white/80">{activeSwarmDisplay}</span>
+          </div>
         </div>
         <span
           key={heartbeatKey}
           className="hal-eye shrink-0"
           data-state={healthState}
           data-testid="orchestrator-health"
-          title={`Orchestrator status: ${statusLabel}`}
+          title={halTitle}
           aria-hidden="true"
         />
       </div>
-      <div className="mt-3 flex justify-end gap-2">
+      <div className="mt-3 flex flex-wrap items-center justify-end gap-2">
+        <button
+          type="button"
+          data-enabled={enabledState}
+          data-testid="orchestrator-enabled"
+          className="shrink-0"
+          disabled={!isDetected || updatingEnabled}
+          onClick={toggleEnabled}
+          aria-pressed={isEnabled}
+          aria-busy={updatingEnabled}
+        >
+          {isEnabled ? (
+            <Square className="h-3.5 w-3.5" aria-hidden="true" />
+          ) : (
+            <Play className="h-3.5 w-3.5" aria-hidden="true" />
+          )}
+          <span>{enabledLabel}</span>
+        </button>
         <button
           type="button"
           className={buttonClasses(isDetected, 'start')}
@@ -203,4 +224,51 @@ export default function OrchestratorPanel({ orchestrator }: Props) {
       )}
     </div>
   )
+}
+
+function mapStatusToVisualState(status: unknown): HealthVisualState | null {
+  if (typeof status !== 'string') return null
+  const normalized = status.trim().toUpperCase()
+  if (!normalized) return null
+  if (['OK', 'HEALTHY', 'RUNNING', 'READY', 'STARTING'].includes(normalized)) return 'ok'
+  if (['WARN', 'WARNING', 'DEGRADED', 'LATE'].includes(normalized)) return 'warn'
+  if (['ALERT', 'ERROR', 'FAILED', 'STOPPED', 'DOWN', 'CRITICAL'].includes(normalized)) return 'alert'
+  return null
+}
+
+function extractActiveSwarmCount(config: Record<string, unknown>): string | null {
+  const candidateKeys = [
+    'swarmCount',
+    'activeSwarmCount',
+    'activeSwarms',
+    'swarm-count',
+    'active-swarms',
+  ]
+  for (const key of candidateKeys) {
+    if (!(key in config)) continue
+    const formatted = formatSwarmCountValue(config[key as keyof typeof config])
+    if (formatted !== null) return formatted
+  }
+  return null
+}
+
+function formatSwarmCountValue(value: unknown): string | null {
+  if (value == null) return null
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value.toString()
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    return trimmed ? trimmed : null
+  }
+  if (Array.isArray(value)) {
+    return value.length.toString()
+  }
+  if (typeof value === 'object' && 'count' in (value as Record<string, unknown>)) {
+    const countValue = (value as { count?: unknown }).count
+    if (typeof countValue === 'number' && Number.isFinite(countValue)) {
+      return countValue.toString()
+    }
+  }
+  return null
 }

--- a/ui/src/pages/hive/OrchestratorPanel.tsx
+++ b/ui/src/pages/hive/OrchestratorPanel.tsx
@@ -1,0 +1,140 @@
+import { useMemo, useState } from 'react'
+import type { Component } from '../../types/hive'
+
+interface Props {
+  orchestrator?: Component | null
+}
+
+type OrchestratorAction = 'start' | 'stop'
+
+function displayNameFor(orchestrator?: Component | null) {
+  if (!orchestrator) return 'Orchestrator'
+  const trimmed = typeof orchestrator.name === 'string' ? orchestrator.name.trim() : ''
+  if (trimmed) return trimmed
+  return orchestrator.id
+}
+
+function halState(isDetected: boolean, isEnabled: boolean) {
+  if (!isDetected) return 'down'
+  return isEnabled ? 'healthy' : 'unhealthy'
+}
+
+function buttonClasses(isDetected: boolean, variant: OrchestratorAction) {
+  const base = [
+    'rounded',
+    'px-3',
+    'py-1',
+    'text-sm',
+    'font-medium',
+    'transition',
+    'disabled:cursor-not-allowed',
+    'disabled:opacity-60',
+  ]
+
+  if (!isDetected) {
+    base.push('border border-white/10 bg-white/5 text-white/60')
+  } else if (variant === 'start') {
+    base.push('border border-emerald-400/40 bg-emerald-400/20 hover:bg-emerald-400/30 text-emerald-100')
+  } else {
+    base.push('border border-rose-400/40 bg-rose-400/20 hover:bg-rose-400/30 text-rose-100')
+  }
+
+  return base.join(' ')
+}
+
+export default function OrchestratorPanel({ orchestrator }: Props) {
+  const [pendingAction, setPendingAction] = useState<OrchestratorAction | null>(null)
+  const isDetected = Boolean(orchestrator)
+  const isEnabled =
+    orchestrator?.config &&
+    typeof (orchestrator.config as { enabled?: unknown }).enabled === 'boolean'
+      ? (orchestrator.config as { enabled?: boolean }).enabled !== false
+      : true
+
+  const name = useMemo(() => displayNameFor(orchestrator), [orchestrator])
+  const statusLabel = isDetected ? (isEnabled ? 'Active' : 'Disabled') : 'Not detected'
+  const cardClasses = [
+    'rounded',
+    'border',
+    'p-3',
+    'text-white',
+    'transition-colors',
+    isDetected ? 'border-white/20 bg-white/10' : 'border-white/10 bg-white/5 opacity-60',
+  ].join(' ')
+
+  const actionCopy = pendingAction
+    ? {
+        label: pendingAction === 'start' ? 'Start all' : 'Stop all',
+        verb: pendingAction,
+      }
+    : null
+
+  return (
+    <div data-testid="orchestrator-panel" className={cardClasses}>
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <div className="text-xs uppercase tracking-wide text-white/50">Orchestrator</div>
+          <div className={`text-lg font-semibold ${isDetected ? '' : 'text-white/70'}`}>{name}</div>
+          <div className="text-xs text-white/60">{statusLabel}</div>
+        </div>
+        <span
+          className="hal-eye shrink-0"
+          data-state={halState(isDetected, isEnabled)}
+          title={`Orchestrator status: ${statusLabel}`}
+          aria-hidden="true"
+        />
+      </div>
+      <div className="mt-3 flex justify-end gap-2">
+        <button
+          type="button"
+          className={buttonClasses(isDetected, 'start')}
+          disabled={!isDetected}
+          onClick={() => setPendingAction('start')}
+        >
+          Start all
+        </button>
+        <button
+          type="button"
+          className={buttonClasses(isDetected, 'stop')}
+          disabled={!isDetected}
+          onClick={() => setPendingAction('stop')}
+        >
+          Stop all
+        </button>
+      </div>
+      {actionCopy && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="orchestrator-confirm-title"
+            className="w-80 rounded border border-white/10 bg-[#1a1d24] p-4 shadow-lg"
+          >
+            <h3 id="orchestrator-confirm-title" className="text-lg font-semibold">
+              Confirm {actionCopy.verb} command
+            </h3>
+            <p className="mt-2 text-sm text-white/70">
+              Are you sure you want to send a {actionCopy.verb} command to all swarms via {name}?
+            </p>
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setPendingAction(null)}
+                className="rounded bg-white/10 px-3 py-1 text-sm hover:bg-white/20"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => setPendingAction(null)}
+                className="rounded bg-white/20 px-3 py-1 text-sm font-medium hover:bg-white/30"
+              >
+                Send {actionCopy.label}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/src/pages/hive/OrchestratorPanel.tsx
+++ b/ui/src/pages/hive/OrchestratorPanel.tsx
@@ -341,9 +341,8 @@ function formatLastStatusTooltip(
 
   if (typeof orchestrator.lastHeartbeat === 'number' && Number.isFinite(orchestrator.lastHeartbeat)) {
     const diffSeconds = Math.max(0, Math.floor((now - orchestrator.lastHeartbeat) / 1000))
-    const iso = new Date(orchestrator.lastHeartbeat).toISOString()
-    return `Last status ${statusText} received ${diffSeconds}s ago (${iso})`
+    return `Last status ${statusText} received ${diffSeconds}s ago`
   }
 
-  return `Last status ${statusText} timestamp unavailable`
+  return `Last status ${statusText} timing unavailable`
 }


### PR DESCRIPTION
## Summary
- add a dedicated orchestrator panel with HAL indicator and Start all / Stop all confirmation modals in the hive sidebar
- keep the orchestrator entry visible while excluding it from hive group listings
- cover orchestrator panel states with new HivePage tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd28076b8083288f699857934b40e1