### PR TITLE
feat: add swarm manager enable fanout

### DIFF
--- a/orchestrator-service/src/main/java/io/pockethive/orchestrator/app/SwarmController.java
+++ b/orchestrator-service/src/main/java/io/pockethive/orchestrator/app/SwarmController.java
@@ -183,13 +183,24 @@ public class SwarmController {
         String path = "/api/swarms/" + swarmId;
         logRestRequest("GET", path, null);
         ResponseEntity<SwarmView> response = registry.find(swarmId)
-            .map(s -> ResponseEntity.ok(new SwarmView(s.getId(), s.getStatus(), s.getHealth(), s.getHeartbeat())))
+            .map(s -> ResponseEntity.ok(new SwarmView(
+                s.getId(),
+                s.getStatus(),
+                s.getHealth(),
+                s.getHeartbeat(),
+                s.isWorkEnabled(),
+                s.isControllerEnabled())))
             .orElse(ResponseEntity.notFound().build());
         logRestResponse("GET", path, response);
         return response;
     }
 
-    public record SwarmView(String id, SwarmStatus status, SwarmHealth health, java.time.Instant heartbeat) {}
+    public record SwarmView(String id,
+                             SwarmStatus status,
+                             SwarmHealth health,
+                             java.time.Instant heartbeat,
+                             boolean workEnabled,
+                             boolean controllerEnabled) {}
 
     private String toJson(ControlSignal signal) {
         try {

--- a/orchestrator-service/src/main/java/io/pockethive/orchestrator/app/SwarmManagerController.java
+++ b/orchestrator-service/src/main/java/io/pockethive/orchestrator/app/SwarmManagerController.java
@@ -1,0 +1,195 @@
+package io.pockethive.orchestrator.app;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.pockethive.Topology;
+import io.pockethive.control.ControlSignal;
+import io.pockethive.orchestrator.domain.IdempotencyStore;
+import io.pockethive.orchestrator.domain.Swarm;
+import io.pockethive.orchestrator.domain.SwarmRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * REST surface for controller-level enable toggles.
+ */
+@RestController
+@RequestMapping("/api/swarm-managers")
+public class SwarmManagerController {
+    private static final Logger log = LoggerFactory.getLogger(SwarmManagerController.class);
+    private static final long CONFIG_UPDATE_TIMEOUT_MS = 60_000L;
+
+    private final SwarmRegistry registry;
+    private final AmqpTemplate rabbit;
+    private final IdempotencyStore idempotency;
+    private final ObjectMapper json;
+
+    public SwarmManagerController(SwarmRegistry registry,
+                                  AmqpTemplate rabbit,
+                                  IdempotencyStore idempotency,
+                                  ObjectMapper json) {
+        this.registry = registry;
+        this.rabbit = rabbit;
+        this.idempotency = idempotency;
+        this.json = json;
+    }
+
+    @PostMapping("/enabled")
+    public ResponseEntity<FanoutControlResponse> updateAll(@RequestBody ToggleRequest request) {
+        String path = "/api/swarm-managers/enabled";
+        logRestRequest("POST", path, request);
+        FanoutControlResponse body = dispatch(registry.all(), request);
+        ResponseEntity<FanoutControlResponse> response = ResponseEntity.accepted().body(body);
+        logRestResponse("POST", path, response);
+        return response;
+    }
+
+    @PostMapping("/{swarmId}/enabled")
+    public ResponseEntity<FanoutControlResponse> updateOne(@PathVariable String swarmId,
+                                                           @RequestBody ToggleRequest request) {
+        String path = "/api/swarm-managers/" + swarmId + "/enabled";
+        logRestRequest("POST", path, request);
+        ResponseEntity<FanoutControlResponse> response = registry.find(swarmId)
+            .map(swarm -> ResponseEntity.accepted().body(dispatch(List.of(swarm), request)))
+            .orElseGet(() -> ResponseEntity.notFound().build());
+        logRestResponse("POST", path, response);
+        return response;
+    }
+
+    private FanoutControlResponse dispatch(Iterable<Swarm> swarms, ToggleRequest request) {
+        List<Dispatch> dispatches = new ArrayList<>();
+        for (Swarm swarm : swarms) {
+            if (swarm == null || swarm.getInstanceId() == null || swarm.getInstanceId().isBlank()) {
+                continue;
+            }
+            String swarmId = swarm.getId();
+            String scope = swarmId;
+            idempotency.findCorrelation(scope, "config-update", request.idempotencyKey())
+                .ifPresentOrElse(correlation -> dispatches.add(new Dispatch(swarmId, swarm.getInstanceId(),
+                        accepted(correlation, request.idempotencyKey(), swarm.getInstanceId()), true)),
+                    () -> {
+                        String correlation = UUID.randomUUID().toString();
+                        ControlSignal payload = ControlSignal.forInstance(
+                            "config-update",
+                            swarmId,
+                            "swarm-controller",
+                            swarm.getInstanceId(),
+                            correlation,
+                            request.idempotencyKey(),
+                            argsFor(request));
+                        sendControl(routingKey(swarm.getInstanceId()), toJson(payload), request.target());
+                        idempotency.record(scope, "config-update", request.idempotencyKey(), correlation);
+                        dispatches.add(new Dispatch(swarmId, swarm.getInstanceId(),
+                            accepted(correlation, request.idempotencyKey(), swarm.getInstanceId()), false));
+                    });
+        }
+        return new FanoutControlResponse(dispatches);
+    }
+
+    private static String routingKey(String instanceId) {
+        return "sig.config-update.swarm-controller." + instanceId;
+    }
+
+    private Map<String, Object> argsFor(ToggleRequest request) {
+        Map<String, Object> args = new LinkedHashMap<>();
+        args.put("target", request.target());
+        args.put("scope", request.target());
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("enabled", request.enabled());
+        args.put("data", data);
+        return args;
+    }
+
+    private ControlResponse accepted(String correlationId, String idempotencyKey, String instanceId) {
+        ControlResponse.Watch watch = new ControlResponse.Watch(
+            "ev.ready.config-update.swarm-controller." + instanceId,
+            "ev.error.config-update.swarm-controller." + instanceId
+        );
+        return new ControlResponse(correlationId, idempotencyKey, watch, CONFIG_UPDATE_TIMEOUT_MS);
+    }
+
+    private void sendControl(String routingKey, String payload, String context) {
+        String label = (context == null || context.isBlank()) ? "SEND" : "SEND " + context;
+        log.info("[CTRL] {} rk={} payload={}", label, routingKey, snippet(payload));
+        rabbit.convertAndSend(Topology.CONTROL_EXCHANGE, routingKey, payload);
+    }
+
+    private String toJson(ControlSignal signal) {
+        try {
+            return json.writeValueAsString(signal);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize control signal %s for swarm %s".formatted(
+                signal.signal(), signal.swarmId()), e);
+        }
+    }
+
+    private void logRestRequest(String method, String path, Object body) {
+        log.info("[REST] {} {} request={}", method, path, toSafeString(body));
+    }
+
+    private void logRestResponse(String method, String path, ResponseEntity<?> response) {
+        if (response == null) {
+            return;
+        }
+        log.info("[REST] {} {} -> status={} body={}", method, path, response.getStatusCode(), toSafeString(response.getBody()));
+    }
+
+    private static String toSafeString(Object value) {
+        if (value == null) {
+            return "";
+        }
+        String text = value.toString();
+        if (text.length() > 300) {
+            return text.substring(0, 300) + "…";
+        }
+        return text;
+    }
+
+    private static String snippet(String payload) {
+        if (payload == null) {
+            return "";
+        }
+        String trimmed = payload.strip();
+        if (trimmed.length() > 300) {
+            return trimmed.substring(0, 300) + "…";
+        }
+        return trimmed;
+    }
+
+    public record ToggleRequest(String idempotencyKey,
+                                 Boolean enabled,
+                                 String target,
+                                 String notes) {
+        public ToggleRequest {
+            if (idempotencyKey == null || idempotencyKey.isBlank()) {
+                throw new IllegalArgumentException("idempotencyKey is required");
+            }
+            if (enabled == null) {
+                throw new IllegalArgumentException("enabled flag is required");
+            }
+            if (target == null || target.isBlank()) {
+                throw new IllegalArgumentException("target is required");
+            }
+            if (!"swarm".equals(target) && !"controller".equals(target)) {
+                throw new IllegalArgumentException("target must be swarm or controller");
+            }
+        }
+    }
+
+    public record FanoutControlResponse(List<Dispatch> dispatches) {}
+
+    public record Dispatch(String swarmId, String instanceId, ControlResponse response, boolean reused) {}
+}

--- a/orchestrator-service/src/main/java/io/pockethive/orchestrator/domain/Swarm.java
+++ b/orchestrator-service/src/main/java/io/pockethive/orchestrator/domain/Swarm.java
@@ -10,6 +10,8 @@ public class Swarm {
     private SwarmHealth health;
     private Instant heartbeat;
     private final Instant createdAt;
+    private boolean workEnabled;
+    private boolean controllerEnabled;
 
     public Swarm(String id, String instanceId, String containerId) {
         this.id = id;
@@ -19,6 +21,8 @@ public class Swarm {
         this.health = SwarmHealth.UNKNOWN;
         this.heartbeat = Instant.now();
         this.createdAt = Instant.now();
+        this.workEnabled = true;
+        this.controllerEnabled = true;
     }
 
     public String getId() {
@@ -55,6 +59,22 @@ public class Swarm {
     public void refresh(SwarmHealth health) {
         this.health = health;
         this.heartbeat = Instant.now();
+    }
+
+    public boolean isWorkEnabled() {
+        return workEnabled;
+    }
+
+    public void setWorkEnabled(boolean workEnabled) {
+        this.workEnabled = workEnabled;
+    }
+
+    public boolean isControllerEnabled() {
+        return controllerEnabled;
+    }
+
+    public void setControllerEnabled(boolean controllerEnabled) {
+        this.controllerEnabled = controllerEnabled;
     }
 
     void expire(Instant now, java.time.Duration degradedAfter, java.time.Duration failedAfter) {

--- a/orchestrator-service/src/main/java/io/pockethive/orchestrator/domain/SwarmRegistry.java
+++ b/orchestrator-service/src/main/java/io/pockethive/orchestrator/domain/SwarmRegistry.java
@@ -1,5 +1,7 @@
 package io.pockethive.orchestrator.domain;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -16,6 +18,10 @@ public class SwarmRegistry {
         return Optional.ofNullable(swarms.get(id));
     }
 
+    public Collection<Swarm> all() {
+        return Collections.unmodifiableCollection(swarms.values());
+    }
+
     public void remove(String id) {
         swarms.remove(id);
     }
@@ -24,6 +30,20 @@ public class SwarmRegistry {
         Swarm swarm = swarms.get(id);
         if (swarm != null) {
             swarm.transitionTo(status);
+        }
+    }
+
+    public void updateWorkEnabled(String id, boolean enabled) {
+        Swarm swarm = swarms.get(id);
+        if (swarm != null) {
+            swarm.setWorkEnabled(enabled);
+        }
+    }
+
+    public void updateControllerEnabled(String id, boolean enabled) {
+        Swarm swarm = swarms.get(id);
+        if (swarm != null) {
+            swarm.setControllerEnabled(enabled);
         }
     }
 

--- a/orchestrator-service/src/test/java/io/pockethive/orchestrator/app/ComponentControllerTest.java
+++ b/orchestrator-service/src/test/java/io/pockethive/orchestrator/app/ComponentControllerTest.java
@@ -32,7 +32,7 @@ class ComponentControllerTest {
     void updateConfigPublishesControlSignal() throws Exception {
         ComponentController controller = new ComponentController(rabbit, new InMemoryIdempotencyStore(), mapper);
         ComponentController.ConfigUpdateRequest request =
-            new ComponentController.ConfigUpdateRequest("idem", Map.of("enabled", true), null, "sw1");
+            new ComponentController.ConfigUpdateRequest("idem", Map.of("enabled", true), null, "sw1", "swarm", "swarm");
 
         ResponseEntity<ControlResponse> response = controller.updateConfig("generator", "c1", request);
 
@@ -46,6 +46,8 @@ class ComponentControllerTest {
         assertThat(signal.idempotencyKey()).isEqualTo("idem");
         assertThat(signal.args()).isNotNull();
         assertThat(signal.args()).containsKey("data");
+        assertThat(signal.args()).containsEntry("scope", "swarm");
+        assertThat(signal.args()).containsEntry("target", "swarm");
         @SuppressWarnings("unchecked")
         Map<String, Object> data = (Map<String, Object>) signal.args().get("data");
         assertThat(data).containsEntry("enabled", true);
@@ -57,7 +59,7 @@ class ComponentControllerTest {
     void configUpdateIsIdempotent() {
         ComponentController controller = new ComponentController(rabbit, new InMemoryIdempotencyStore(), mapper);
         ComponentController.ConfigUpdateRequest request =
-            new ComponentController.ConfigUpdateRequest("idem", Map.of(), null, null);
+            new ComponentController.ConfigUpdateRequest("idem", Map.of(), null, null, null, null);
 
         ResponseEntity<ControlResponse> first = controller.updateConfig("processor", "p1", request);
         ResponseEntity<ControlResponse> second = controller.updateConfig("processor", "p1", request);

--- a/orchestrator-service/src/test/java/io/pockethive/orchestrator/app/ControllerStatusListenerTest.java
+++ b/orchestrator-service/src/test/java/io/pockethive/orchestrator/app/ControllerStatusListenerTest.java
@@ -18,8 +18,10 @@ class ControllerStatusListenerTest {
     @Test
     void updatesRegistry() {
         ControllerStatusListener listener = new ControllerStatusListener(registry, new ObjectMapper());
-        String json = "{\"swarmId\":\"sw1\",\"data\":{\"swarmStatus\":\"RUNNING\"}}";
+        String json = "{\"swarmId\":\"sw1\",\"data\":{\"swarmStatus\":\"RUNNING\",\"state\":{\"workloads\":{\"enabled\":true},\"controller\":{\"enabled\":false}}}}";
         listener.handle(json, "ev.status-delta.swarm-controller.inst1");
         verify(registry).refresh("sw1", SwarmHealth.RUNNING);
+        verify(registry).updateWorkEnabled("sw1", true);
+        verify(registry).updateControllerEnabled("sw1", false);
     }
 }

--- a/orchestrator-service/src/test/java/io/pockethive/orchestrator/app/SwarmControllerTest.java
+++ b/orchestrator-service/src/test/java/io/pockethive/orchestrator/app/SwarmControllerTest.java
@@ -153,6 +153,8 @@ class SwarmControllerTest {
 
         ResponseEntity<SwarmController.SwarmView> resp = ctrl.view("sw1");
         assertThat(resp.getBody().id()).isEqualTo("sw1");
+        assertThat(resp.getBody().workEnabled()).isTrue();
+        assertThat(resp.getBody().controllerEnabled()).isTrue();
     }
 
     @Test

--- a/orchestrator-service/src/test/java/io/pockethive/orchestrator/app/SwarmEventFlowIntegrationTest.java
+++ b/orchestrator-service/src/test/java/io/pockethive/orchestrator/app/SwarmEventFlowIntegrationTest.java
@@ -62,8 +62,11 @@ class SwarmEventFlowIntegrationTest {
         signal.handle("", "ev.ready.swarm-start.sw1");
         assertThat(registry.find("sw1").get().getStatus()).isEqualTo(SwarmStatus.RUNNING);
 
-        statusListener.handle("{\"swarmId\":\"sw1\",\"data\":{\"swarmStatus\":\"RUNNING\"}}", "ev.status-delta.swarm-controller.inst1");
+        statusListener.handle("{\"swarmId\":\"sw1\",\"data\":{\"swarmStatus\":\"RUNNING\",\"state\":{\"workloads\":{\"enabled\":false},\"controller\":{\"enabled\":true}}}}",
+            "ev.status-delta.swarm-controller.inst1");
         assertEquals(SwarmHealth.RUNNING, registry.find("sw1").get().getHealth());
+        assertThat(registry.find("sw1").get().isWorkEnabled()).isFalse();
+        assertThat(registry.find("sw1").get().isControllerEnabled()).isTrue();
 
         signal.handle("", "ev.ready.swarm-stop.sw1");
         verify(lifecycle).stopSwarm("sw1");

--- a/orchestrator-service/src/test/java/io/pockethive/orchestrator/app/SwarmManagerControllerTest.java
+++ b/orchestrator-service/src/test/java/io/pockethive/orchestrator/app/SwarmManagerControllerTest.java
@@ -1,0 +1,93 @@
+package io.pockethive.orchestrator.app;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.pockethive.Topology;
+import io.pockethive.control.ControlSignal;
+import io.pockethive.orchestrator.domain.IdempotencyStore;
+import io.pockethive.orchestrator.domain.Swarm;
+import io.pockethive.orchestrator.domain.SwarmRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SwarmManagerControllerTest {
+
+    @Mock
+    AmqpTemplate rabbit;
+    @Mock
+    IdempotencyStore idempotency;
+
+    private final ObjectMapper mapper = new JacksonConfiguration().objectMapper();
+
+    @Test
+    void fanOutToggleToAllControllers() throws Exception {
+        SwarmRegistry registry = new SwarmRegistry();
+        registry.register(new Swarm("sw1", "ctrl-a", "c1"));
+        registry.register(new Swarm("sw2", "ctrl-b", "c2"));
+        when(idempotency.findCorrelation(eq("sw1"), eq("config-update"), eq("idem-1"))).thenReturn(Optional.empty());
+        when(idempotency.findCorrelation(eq("sw2"), eq("config-update"), eq("idem-1"))).thenReturn(Optional.empty());
+        SwarmManagerController controller = new SwarmManagerController(registry, rabbit, idempotency, mapper);
+        SwarmManagerController.ToggleRequest request = new SwarmManagerController.ToggleRequest("idem-1", true, "swarm", null);
+
+        ResponseEntity<SwarmManagerController.FanoutControlResponse> response = controller.updateAll(request);
+
+        ArgumentCaptor<String> payloads = ArgumentCaptor.forClass(String.class);
+        verify(rabbit).convertAndSend(eq(Topology.CONTROL_EXCHANGE), eq("sig.config-update.swarm-controller.ctrl-a"), payloads.capture());
+        verify(rabbit).convertAndSend(eq(Topology.CONTROL_EXCHANGE), eq("sig.config-update.swarm-controller.ctrl-b"), payloads.capture());
+        List<String> sentPayloads = payloads.getAllValues();
+        assertThat(sentPayloads).hasSize(2);
+        java.util.List<String> swarmIds = new java.util.ArrayList<>();
+        for (String json : sentPayloads) {
+            ControlSignal signal = mapper.readValue(json, ControlSignal.class);
+            swarmIds.add(signal.swarmId());
+            assertThat(signal.signal()).isEqualTo("config-update");
+            assertThat(signal.args()).containsEntry("scope", "swarm");
+            assertThat(signal.args()).containsEntry("target", "swarm");
+            @SuppressWarnings("unchecked")
+            var data = (java.util.Map<String, Object>) signal.args().get("data");
+            assertThat(data).containsEntry("enabled", true);
+        }
+        assertThat(swarmIds).containsExactlyInAnyOrder("sw1", "sw2");
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().dispatches()).hasSize(2);
+    }
+
+    @Test
+    void toggleSingleControllerScope() throws Exception {
+        SwarmRegistry registry = new SwarmRegistry();
+        registry.register(new Swarm("sw9", "ctrl-z", "c9"));
+        when(idempotency.findCorrelation(eq("sw9"), eq("config-update"), eq("idem-2"))).thenReturn(Optional.empty());
+        SwarmManagerController controller = new SwarmManagerController(registry, rabbit, idempotency, mapper);
+        SwarmManagerController.ToggleRequest request = new SwarmManagerController.ToggleRequest("idem-2", false, "controller", null);
+
+        ResponseEntity<SwarmManagerController.FanoutControlResponse> response = controller.updateOne("sw9", request);
+
+        ArgumentCaptor<String> payload = ArgumentCaptor.forClass(String.class);
+        verify(rabbit).convertAndSend(eq(Topology.CONTROL_EXCHANGE), eq("sig.config-update.swarm-controller.ctrl-z"), payload.capture());
+        ControlSignal signal = mapper.readValue(payload.getValue(), ControlSignal.class);
+        assertThat(signal.args()).containsEntry("scope", "controller");
+        assertThat(signal.args()).containsEntry("target", "controller");
+        @SuppressWarnings("unchecked")
+        var data = (java.util.Map<String, Object>) signal.args().get("data");
+        assertThat(data).containsEntry("enabled", false);
+        assertThat(response.getStatusCode().value()).isEqualTo(202);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().dispatches()).hasSize(1);
+        SwarmManagerController.Dispatch dispatch = response.getBody().dispatches().getFirst();
+        assertThat(dispatch.response().watch().successTopic()).isEqualTo("ev.ready.config-update.swarm-controller.ctrl-z");
+    }
+}

--- a/orchestrator-service/src/test/java/io/pockethive/orchestrator/domain/SwarmRegistryTest.java
+++ b/orchestrator-service/src/test/java/io/pockethive/orchestrator/domain/SwarmRegistryTest.java
@@ -12,6 +12,20 @@ class SwarmRegistryTest {
         registry.register(swarm);
 
         assertTrue(registry.find("s1").isPresent());
+        assertTrue(registry.all().contains(swarm));
+    }
+
+    @Test
+    void updatesEnableFlags() {
+        SwarmRegistry registry = new SwarmRegistry();
+        Swarm swarm = new Swarm("s1", "inst1", "container");
+        registry.register(swarm);
+
+        registry.updateWorkEnabled("s1", false);
+        registry.updateControllerEnabled("s1", false);
+
+        assertFalse(swarm.isWorkEnabled());
+        assertFalse(swarm.isControllerEnabled());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add swarm manager REST endpoints to fan out controller enable toggles with scope-aware control payloads
- persist controller and workload enable flags on swarms and expose them via the view DTOs
- extend component config wiring and registry helpers to carry target/scope context for control-plane messaging

## Testing
- mvn -pl orchestrator-service test

------
https://chatgpt.com/codex/tasks/task_e_68cd5e74ea2083288868f36f0a43b245