### PR TITLE
feat: distinguish controller and swarm enablement

### DIFF
--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmLifecycle.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmLifecycle.java
@@ -38,4 +38,10 @@ public interface SwarmLifecycle {
    * Enable all components and begin scenario execution.
    */
   void enableAll();
+
+  /**
+   * Toggle swarm workloads on or off without affecting the controller runtime.
+   * @param enabled whether workloads should process messages
+   */
+  void setSwarmEnabled(boolean enabled);
 }


### PR DESCRIPTION
## Summary
- add a SwarmLifecycle contract for toggling workloads and delegate in the lifecycle manager
- track controller enabled state separately from swarm workloads when handling config updates
- cover workload and controller toggle flows with updated unit tests

## Testing
- mvn -pl swarm-controller-service test

------
https://chatgpt.com/codex/tasks/task_e_68cd6148ee308328b5d5c3fdfa539d71