### PR TITLE
feat: fan out orchestrator start/stop commands

### DIFF
--- a/ui/src/lib/orchestratorApi.ts
+++ b/ui/src/lib/orchestratorApi.ts
@@ -1,6 +1,12 @@
 import { apiFetch } from './api'
 import type { Component } from '../types/hive'
 
+interface SwarmManagersTogglePayload {
+  idempotencyKey: string
+  target: 'swarm'
+  enabled: boolean
+}
+
 export async function createSwarm(id: string, templateId: string) {
   const payload: Record<string, unknown> = {
     templateId,
@@ -31,6 +37,27 @@ export async function stopSwarm(id: string) {
     headers: { 'Content-Type': 'application/json' },
     body,
   })
+}
+
+async function setSwarmManagersEnabled(enabled: boolean) {
+  const payload: SwarmManagersTogglePayload = {
+    idempotencyKey: crypto.randomUUID(),
+    target: 'swarm',
+    enabled,
+  }
+  await apiFetch('/orchestrator/swarm-managers/enabled', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+}
+
+export async function enableSwarmManagers() {
+  await setSwarmManagersEnabled(true)
+}
+
+export async function disableSwarmManagers() {
+  await setSwarmManagersEnabled(false)
 }
 
 export async function sendConfigUpdate(component: Component, config: unknown) {

--- a/ui/src/pages/hive/HivePage.test.tsx
+++ b/ui/src/pages/hive/HivePage.test.tsx
@@ -1,21 +1,22 @@
 /**
  * @vitest-environment jsdom
  */
-import { render, screen, within } from '@testing-library/react'
+import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom/vitest'
 import { vi, test, expect, beforeEach, afterEach } from 'vitest'
 import HivePage from './HivePage'
 import type { Component } from '../../types/hive'
 import { subscribeComponents } from '../../lib/stompClient'
-import { sendConfigUpdate } from '../../lib/orchestratorApi'
+import * as orchestratorApi from '../../lib/orchestratorApi'
+import { apiFetch } from '../../lib/api'
 
 vi.mock('../../lib/stompClient', () => ({
   subscribeComponents: vi.fn(),
 }))
 
-vi.mock('../../lib/orchestratorApi', () => ({
-  sendConfigUpdate: vi.fn(),
+vi.mock('../../lib/api', () => ({
+  apiFetch: vi.fn(),
 }))
 
 vi.mock('./TopologyView', () => ({
@@ -43,6 +44,9 @@ const baseComponents: Component[] = [
 ]
 
 let comps: Component[] = []
+const apiFetchMock = vi.mocked(apiFetch)
+const sendConfigUpdateSpy = vi.spyOn(orchestratorApi, 'sendConfigUpdate')
+
 beforeEach(() => {
   comps = baseComponents.map((c) => ({
     ...c,
@@ -55,7 +59,9 @@ beforeEach(() => {
       return () => {}
     },
   )
-  vi.mocked(sendConfigUpdate).mockResolvedValue(undefined)
+  apiFetchMock.mockClear()
+  apiFetchMock.mockResolvedValue(new Response(null, { status: 202 }))
+  sendConfigUpdateSpy.mockClear()
 })
 
 afterEach(() => {
@@ -118,7 +124,7 @@ test('enables orchestrator controls when orchestrator component is present', asy
     expect(swarmsRow).toHaveTextContent('5')
   }
   await user.click(badge)
-  expect(sendConfigUpdate).toHaveBeenCalledWith(
+  expect(sendConfigUpdateSpy).toHaveBeenCalledWith(
     expect.objectContaining({ id: 'hive-orchestrator' }),
     { enabled: false },
   )
@@ -141,10 +147,92 @@ test('enables orchestrator controls when orchestrator component is present', asy
     }),
   ).toBeInTheDocument()
   await user.click(screen.getByRole('button', { name: 'Send Stop all' }))
-  expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
   await user.click(within(panel).getByText('HAL'))
   expect(await screen.findByText('hive-orchestrator')).toBeInTheDocument()
   expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument()
+})
+
+test('confirming swarm start and stop commands fan out via orchestrator API', async () => {
+  const lastHeartbeat = Date.now() - 3000
+  comps.push({
+    id: 'hive-orchestrator',
+    name: 'HAL',
+    role: 'orchestrator',
+    lastHeartbeat,
+    queues: [],
+    status: 'OK',
+    config: { enabled: true, swarmCount: 2 },
+  })
+  const user = userEvent.setup()
+  render(<HivePage />)
+  const panels = screen.getAllByTestId('orchestrator-panel')
+  const panel = panels[panels.length - 1]!
+  await within(panel).findByText('HAL')
+  const startButton = within(panel).getByRole('button', { name: 'Start all' })
+  let resolveStart: ((response: Response) => void) | undefined
+  apiFetchMock.mockImplementationOnce(
+    () =>
+      new Promise<Response>((resolve) => {
+        resolveStart = resolve
+      }),
+  )
+  await user.click(startButton)
+  const startDialog = await screen.findByRole('dialog', { name: /confirm start command/i })
+  const startConfirm = within(startDialog).getByRole('button', { name: 'Send Start all' })
+  const cancelStart = within(startDialog).getByRole('button', { name: 'Cancel' })
+  await user.click(startConfirm)
+  expect(startConfirm).toBeDisabled()
+  expect(startConfirm).toHaveAttribute('aria-busy', 'true')
+  expect(startConfirm).toHaveTextContent('Sending…')
+  expect(cancelStart).toBeDisabled()
+  expect(resolveStart).toBeDefined()
+  expect(apiFetchMock).toHaveBeenCalledTimes(1)
+  const [startPath, startInit] = apiFetchMock.mock.calls[0]!
+  expect(startPath).toBe('/orchestrator/swarm-managers/enabled')
+  expect(startInit?.method).toBe('POST')
+  expect(startInit?.headers).toMatchObject({ 'Content-Type': 'application/json' })
+  const startPayload = JSON.parse((startInit?.body as string) ?? '{}')
+  expect(startPayload.target).toBe('swarm')
+  expect(startPayload.enabled).toBe(true)
+  expect(typeof startPayload.idempotencyKey).toBe('string')
+  expect(startPayload.idempotencyKey.length).toBeGreaterThan(0)
+  expect(
+    screen.getByRole('dialog', {
+      name: /confirm start command/i,
+    }),
+  ).toBeInTheDocument()
+  resolveStart?.(new Response(null, { status: 202 }))
+  await waitFor(() =>
+    expect(
+      screen.queryByRole('dialog', {
+        name: /confirm start command/i,
+      }),
+    ).not.toBeInTheDocument(),
+  )
+  apiFetchMock.mockClear()
+  apiFetchMock.mockResolvedValue(new Response(null, { status: 202 }))
+  const stopButton = within(panel).getByRole('button', { name: 'Stop all' })
+  await user.click(stopButton)
+  const stopDialog = await screen.findByRole('dialog', { name: /confirm stop command/i })
+  const stopConfirm = within(stopDialog).getByRole('button', { name: 'Send Stop all' })
+  await user.click(stopConfirm)
+  await waitFor(() => expect(apiFetchMock).toHaveBeenCalledTimes(1))
+  const [stopPath, stopInit] = apiFetchMock.mock.calls[0]!
+  expect(stopPath).toBe('/orchestrator/swarm-managers/enabled')
+  expect(stopInit?.method).toBe('POST')
+  const stopPayload = JSON.parse((stopInit?.body as string) ?? '{}')
+  expect(stopPayload.target).toBe('swarm')
+  expect(stopPayload.enabled).toBe(false)
+  expect(typeof stopPayload.idempotencyKey).toBe('string')
+  expect(stopPayload.idempotencyKey.length).toBeGreaterThan(0)
+  await waitFor(() =>
+    expect(
+      screen.queryByRole('dialog', {
+        name: /confirm stop command/i,
+      }),
+    ).not.toBeInTheDocument(),
+  )
 })
 
 test('shows disabled state when orchestrator config disables it', async () => {
@@ -174,7 +262,7 @@ test('shows disabled state when orchestrator config disables it', async () => {
     expect(swarmsRow).toHaveTextContent('1')
   }
   await user.click(badge)
-  expect(sendConfigUpdate).toHaveBeenCalledWith(
+  expect(sendConfigUpdateSpy).toHaveBeenCalledWith(
     expect.objectContaining({ id: 'hive-orchestrator' }),
     { enabled: true },
   )


### PR DESCRIPTION
## Summary
- add REST helper functions that fan out swarm manager enable toggles through the orchestrator
- wire the orchestrator panel start/stop dialogs to the new helpers and show a busy state while awaiting the response
- extend hive page UI tests to assert the fan-out API is called with the expected payload

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2ae6c0adc8328b05ff401a8e29b3e