### PR TITLE
fix: align dropdowns with header theme

### DIFF
--- a/ui/assets/css/app.css
+++ b/ui/assets/css/app.css
@@ -10,6 +10,55 @@ body{
   -moz-osx-font-smoothing: grayscale;
 }
 button, input, select, textarea{ font: inherit; }
+
+/* Neon-themed select to match header controls */
+.themed-select{
+  appearance:none;
+  -webkit-appearance:none;
+  -moz-appearance:none;
+  display:inline-block;
+  padding:0.35rem 2.25rem 0.35rem 0.85rem;
+  border-radius:12px;
+  border:1px solid rgba(51,225,255,0.35);
+  background-color:rgba(12,16,22,0.82);
+  background-image:
+    radial-gradient(120% 120% at 10% 10%, rgba(51,225,255,0.25), rgba(51,225,255,0.06) 45%, rgba(255,255,255,0.05) 70%, rgba(0,0,0,0) 100%),
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20' stroke='%2333E1FF' stroke-width='1.6'%3E%3Cpath d='M6 8l4 4 4-4' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-repeat:no-repeat, no-repeat;
+  background-size:100% 100%, 0.75rem;
+  background-position:center, right 0.8rem center;
+  box-shadow:0 0 20px rgba(51,225,255,0.15) inset, 0 0 16px rgba(51,225,255,0.18);
+  color:#e6f9ff;
+  font-weight:600;
+  letter-spacing:0.01em;
+  line-height:1.3;
+  cursor:pointer;
+  transition:border-color 0.15s ease, box-shadow 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+.themed-select:hover{
+  box-shadow:0 0 26px rgba(51,225,255,0.22) inset, 0 0 20px rgba(51,225,255,0.28);
+}
+.themed-select:focus,
+.themed-select:focus-visible{
+  outline:none;
+  border-color:rgba(51,225,255,0.65);
+  box-shadow:0 0 0 2px rgba(51,225,255,0.25), 0 0 28px rgba(51,225,255,0.32) inset;
+}
+.themed-select:disabled{
+  opacity:0.55;
+  cursor:not-allowed;
+  box-shadow:none;
+}
+.themed-select option{
+  background:#0f1116;
+  color:#e6f9ff;
+}
+.themed-select::-ms-expand{ display:none; }
+
+.themed-select--compact{
+  padding:0.25rem 1.75rem 0.25rem 0.65rem;
+  border-radius:10px;
+}
 main{ margin: 24px 0; padding: 0 20px 40px; color:#fff; font-family: Inter, Segoe UI, Arial, sans-serif; }
 h1{ font-weight:800; letter-spacing:.02em; }
 p{ color:#9aa0a6; }

--- a/ui/src/components/BuzzPanel.tsx
+++ b/ui/src/components/BuzzPanel.tsx
@@ -122,7 +122,7 @@ export default function BuzzPanel() {
               <select
                 value={sourceFilter}
                 onChange={(e) => setSourceFilter(e.target.value as 'all' | LogSource)}
-                className="rounded border border-white/20 bg-white/10 px-1 py-0.5"
+                className="themed-select themed-select--compact text-xs"
               >
                 <option value="all">All sources</option>
                 <option value="ui">UI</option>
@@ -131,7 +131,7 @@ export default function BuzzPanel() {
               <select
                 value={channelFilter}
                 onChange={(e) => setChannelFilter(e.target.value as 'all' | LogChannel)}
-                className="rounded border border-white/20 bg-white/10 px-1 py-0.5"
+                className="themed-select themed-select--compact text-xs"
               >
                 <option value="all">All channels</option>
                 <option value="stomp">STOMP</option>
@@ -141,7 +141,7 @@ export default function BuzzPanel() {
               <select
                 value={typeFilter}
                 onChange={(e) => setTypeFilter(e.target.value as 'all' | 'error')}
-                className="rounded border border-white/20 bg-white/10 px-1 py-0.5"
+                className="themed-select themed-select--compact text-xs"
               >
                 <option value="all">All logs</option>
                 <option value="error">Errors only</option>

--- a/ui/src/pages/hive/SwarmCreateModal.tsx
+++ b/ui/src/pages/hive/SwarmCreateModal.tsx
@@ -70,7 +70,7 @@ export default function SwarmCreateModal({ onClose }: Props) {
               id="scenario"
               value={scenarioId}
               onChange={(e) => setScenarioId(e.target.value)}
-              className="w-full rounded border border-white/20 bg-white/10 px-2 py-1 text-sm"
+              className="themed-select w-full text-sm"
             >
               <option value="">Select scenario</option>
               {scenarios.map((s) => (


### PR DESCRIPTION
## Summary
- introduce a reusable neon-themed `.themed-select` style that mirrors the header menu treatment
- apply the themed select styling to Buzz log filters and the swarm creation modal dropdown so the text stays legible

## Testing
- npm run lint *(fails: existing @typescript-eslint/no-explicit-any violations in `src/pages/hive/TopologyView.test.tsx`)*
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68d2f5ded7088328b8de020227a661ac