### PR TITLE
fix(ui): align nginx proxies with smoke checks

### DIFF
--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -75,9 +75,44 @@ server {
     add_header Access-Control-Allow-Methods "GET,POST,PUT,DELETE,OPTIONS" always;
   }
 
+  # Proxy Orchestrator actuator endpoints without the /api prefix so health checks resolve
+  location /orchestrator/actuator/ {
+    set $orchestrator orchestrator;
+    rewrite ^/orchestrator/(.*)$ /$1 break;
+    if ($request_method = OPTIONS) {
+      add_header Access-Control-Allow-Origin "*";
+      add_header Access-Control-Allow-Headers "Authorization,Content-Type";
+      add_header Access-Control-Allow-Methods "GET,POST,PUT,DELETE,OPTIONS";
+      return 204;
+    }
+    proxy_pass http://$orchestrator:8080;
+    proxy_set_header Host $host;
+    add_header Access-Control-Allow-Origin "*" always;
+    add_header Access-Control-Allow-Headers "Authorization,Content-Type" always;
+    add_header Access-Control-Allow-Methods "GET,POST,PUT,DELETE,OPTIONS" always;
+  }
+
+  # Proxy Scenario Manager actuator endpoints for smoke checks via UI ingress
+  location /scenario-manager/actuator/ {
+    set $scenario_manager scenario-manager;
+    rewrite ^/scenario-manager/(.*)$ /$1 break;
+    if ($request_method = OPTIONS) {
+      add_header Access-Control-Allow-Origin "*";
+      add_header Access-Control-Allow-Headers "Authorization,Content-Type";
+      add_header Access-Control-Allow-Methods "GET,POST,PUT,DELETE,OPTIONS";
+      return 204;
+    }
+    proxy_pass http://$scenario_manager:8080;
+    proxy_set_header Host $host;
+    add_header Access-Control-Allow-Origin "*" always;
+    add_header Access-Control-Allow-Headers "Authorization,Content-Type" always;
+    add_header Access-Control-Allow-Methods "GET,POST,PUT,DELETE,OPTIONS" always;
+  }
+
   # Proxy Orchestrator API to avoid browser CORS
   location /orchestrator/ {
     set $orchestrator orchestrator;
+    rewrite ^/orchestrator/api/(.*)$ /api/$1 break;
     rewrite ^/orchestrator/(.*)$ /api/$1 break;
     if ($request_method = OPTIONS) {
       add_header Access-Control-Allow-Origin "*";


### PR DESCRIPTION
## Summary
- ensure the orchestrator actuator endpoints are proxied without the /api prefix so platform health checks resolve
- expose the scenario manager actuator path via nginx so smoke tests can probe it through the UI ingress
- prevent double /api rewrites when the smoke tests request /orchestrator/api/... resources by aligning the rewrite rules with their paths

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d41099c71483289bc76f6bf0672578