### PR TITLE
fix(swarm-controller): derive config update routing keys

### DIFF
--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmLifecycleManager.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmLifecycleManager.java
@@ -9,6 +9,7 @@ import io.pockethive.control.ControlSignal;
 import io.pockethive.swarm.model.Bee;
 import io.pockethive.swarm.model.SwarmPlan;
 import io.pockethive.swarm.model.Work;
+import io.pockethive.controlplane.routing.ControlPlaneRouting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -196,9 +197,10 @@ public class SwarmLifecycleManager implements SwarmLifecycle {
         .swarmId(Topology.SWARM_ID)
         .controlIn(controlQueue)
         .controlRoutes(
-            "sig.config-update",
-            "sig.config-update.swarm-controller",
-            "sig.config-update.swarm-controller." + instanceId,
+            ControlPlaneRouting.signal("config-update", Topology.SWARM_ID, null, null),
+            ControlPlaneRouting.signal("config-update", Topology.SWARM_ID, "swarm-controller", null),
+            ControlPlaneRouting.signal("config-update", Topology.SWARM_ID, "swarm-controller", instanceId),
+            ControlPlaneRouting.signal("config-update", "ALL", "swarm-controller", null),
             "sig.status-request",
             "sig.status-request.swarm-controller",
             "sig.status-request.swarm-controller." + instanceId,
@@ -511,8 +513,9 @@ public class SwarmLifecycleManager implements SwarmLifecycle {
         args);
     try {
       String payload = mapper.writeValueAsString(signal);
-      log.info("{} config-update rk=sig.config-update correlation={} payload {}", context, correlationId, snippet(payload));
-      rabbit.convertAndSend(Topology.CONTROL_EXCHANGE, "sig.config-update", payload);
+      String routingKey = ControlPlaneRouting.signal("config-update", swarmId, role, instance);
+      log.info("{} config-update rk={} correlation={} payload {}", context, routingKey, correlationId, snippet(payload));
+      rabbit.convertAndSend(Topology.CONTROL_EXCHANGE, routingKey, payload);
     } catch (JsonProcessingException e) {
       throw new IllegalStateException("Failed to serialize config-update signal", e);
     }


### PR DESCRIPTION
## Summary
- derive config-update routing keys via ControlPlaneRouting so broadcasts and targeted updates follow the segmented pattern
- include the derived routes in status envelopes and extend tests to cover broadcast, role, and instance routing behaviour

## Testing
- ./mvnw -pl swarm-controller-service test *(fails: Network is unreachable while downloading Maven wrapper dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d6832efb0c8328b3155e9c745f9e31