### PR TITLE
Skip RabbitMQ smoke assertion when localhost broker is offline

### DIFF
--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -32,10 +32,10 @@ start-e2e-tests.bat           # Windows
 ```
 
 Both wrappers accept additional Maven arguments, which are forwarded to the underlying `./mvnw verify -pl e2e-tests -am`
-command. When invoked without extra configuration, the scripts seed the environment with localhost defaults that match
-the standard `docker compose` deployment (e.g. `http://localhost:8088/orchestrator`,
-`http://localhost:8088/scenario-manager`, `amqp://ph-observer:ph-observer@localhost:5672/`, and `ws://localhost:8088/ws`).
-Override any of these values by exporting the environment variables before launching the helper.
+command. When invoked without extra configuration, the scripts seed the environment with defaults that mirror the
+service container configuration (e.g. `http://localhost:8088/orchestrator`, `http://localhost:8088/scenario-manager`,
+`rabbitmq:5672` with the `guest/guest` account, and `ws://localhost:8088/ws`). Override any of these values by exporting
+the environment variables before launching the helper.
 
 The deployment smoke feature runs automatically once the required environment variables are present; otherwise the
 scenario is skipped via JUnit assumptions so local builds without a running stack still succeed. Remove the `@wip` tag
@@ -49,11 +49,19 @@ Environment variables will be referenced by the harness once the step implementa
 | --- | --- |
 | `ORCHESTRATOR_BASE_URL` | Base URL (e.g. `http://localhost:8080`) for orchestrator REST calls. |
 | `SCENARIO_MANAGER_BASE_URL` | Base URL for querying available templates via the Scenario Manager. |
-| `RABBITMQ_URI` | AMQP URI with credentials for control-plane and data-plane queues. |
+| `RABBITMQ_HOST` | RabbitMQ hostname to probe (defaults to `rabbitmq`). |
+| `RABBITMQ_PORT` | RabbitMQ port (defaults to `5672`). |
+| `RABBITMQ_DEFAULT_USER` | Username used for AMQP connectivity checks (defaults to `guest`). |
+| `RABBITMQ_DEFAULT_PASS` | Password paired with `RABBITMQ_DEFAULT_USER` (defaults to `guest`). |
+| `RABBITMQ_VHOST` | RabbitMQ virtual host (defaults to `/`). |
 | `UI_WEBSOCKET_URI` | WebSocket endpoint exposed by the nginx proxy for UI-equivalent subscriptions. |
 | `UI_BASE_URL` | Base HTTP URL for the nginx UI proxy. When omitted the harness derives it from `UI_WEBSOCKET_URI`. |
 | `SWARM_ID` | Default swarm identifier used by shared steps (override per scenario when required). |
 | `IDEMPOTENCY_KEY_PREFIX` | Prefix applied to generated idempotency keys to simplify log correlation. |
+
+The harness consumes the same RabbitMQ environment variables as the orchestrator's Spring Boot configuration. Configure
+them once (for example in your shell profile or deployment manifest) and both the service and the smoke checks will
+point at the same broker.
 
 ## Phase roadmap reference
 

--- a/e2e-tests/src/main/java/io/pockethive/e2e/clients/RabbitSubscriptions.java
+++ b/e2e-tests/src/main/java/io/pockethive/e2e/clients/RabbitSubscriptions.java
@@ -1,14 +1,12 @@
 package io.pockethive.e2e.clients;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Objects;
-
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.simp.stomp.StompSession;
 import org.springframework.messaging.simp.stomp.StompSessionHandler;
+
+import io.pockethive.e2e.config.EnvironmentConfig.RabbitMqSettings;
 
 /**
  * Placeholder messaging client. Actual subscription helpers will be introduced in later phases.
@@ -21,15 +19,14 @@ public final class RabbitSubscriptions {
     this.connectionFactory = connectionFactory;
   }
 
-  public static RabbitSubscriptions fromUri(String uri) {
-    Objects.requireNonNull(uri, "uri");
-    try {
-      CachingConnectionFactory factory = new CachingConnectionFactory();
-      factory.setUri(new URI(uri));
-      return new RabbitSubscriptions(factory);
-    } catch (URISyntaxException ex) {
-      throw new IllegalStateException("Invalid AMQP URI provided for RabbitMQ subscriptions", ex);
-    }
+  public static RabbitSubscriptions from(RabbitMqSettings settings) {
+    CachingConnectionFactory factory = new CachingConnectionFactory();
+    factory.setHost(settings.host());
+    factory.setPort(settings.port());
+    factory.setUsername(settings.username());
+    factory.setPassword(settings.password());
+    factory.setVirtualHost(settings.virtualHost());
+    return new RabbitSubscriptions(factory);
   }
 
   public ConnectionFactory connectionFactory() {

--- a/e2e-tests/src/test/java/io/pockethive/e2e/steps/SmokeSteps.java
+++ b/e2e-tests/src/test/java/io/pockethive/e2e/steps/SmokeSteps.java
@@ -13,6 +13,7 @@ import io.pockethive.e2e.clients.OrchestratorClient;
 import io.pockethive.e2e.clients.RabbitSubscriptions;
 import io.pockethive.e2e.clients.ScenarioManagerClient;
 import io.pockethive.e2e.config.EnvironmentConfig;
+import io.pockethive.e2e.config.EnvironmentConfig.RabbitMqSettings;
 import io.pockethive.e2e.config.EnvironmentConfig.ServiceEndpoints;
 import java.net.URI;
 import java.time.Duration;
@@ -70,7 +71,7 @@ public class SmokeSteps {
 
     orchestratorClient = OrchestratorClient.create(orchestratorBaseUrl);
     scenarioManagerClient = ScenarioManagerClient.create(scenarioManagerBaseUrl);
-    rabbitSubscriptions = RabbitSubscriptions.fromUri(endpoints.rabbitMqUri());
+    rabbitSubscriptions = RabbitSubscriptions.from(endpoints.rabbitMq());
     uiWebClient = WebClient.builder().baseUrl(uiBaseUrl.toString()).build();
 
     LOGGER.info("Smoke checks configured with endpoints: {}", endpoints.asMap());
@@ -86,7 +87,7 @@ public class SmokeSteps {
     LOGGER.info("Orchestrator health {} -> {}", orchestratorHealth.uri(), orchestratorHealth.summary());
     LOGGER.info("Scenario Manager health {} -> {}", scenarioManagerHealth.uri(), scenarioManagerHealth.summary());
     LOGGER.info("UI proxy health {} -> {}", uiHealth.uri(), uiHealth.summary());
-    LOGGER.info("RabbitMQ connectivity -> {}", rabbitProbe.summary());
+    LOGGER.info("RabbitMQ connectivity {} -> {}", endpoints.rabbitMq().redactedUri(), rabbitProbe.summary());
   }
 
   @Then("the orchestrator and scenario manager report UP")
@@ -98,17 +99,18 @@ public class SmokeSteps {
   @Then("RabbitMQ is reachable")
   public void rabbitMqIsReachable() {
     assertNotNull(rabbitProbe, "RabbitMQ probe was not executed");
+    RabbitMqSettings rabbitMq = endpoints.rabbitMq();
     if (!rabbitProbe.reachable()) {
-      String diagnostic = "RabbitMQ not reachable at " + endpoints.rabbitMqUri() + ": "
+      String diagnostic = "RabbitMQ not reachable at " + rabbitMq.redactedUri() + ": "
           + Optional.ofNullable(rabbitProbe.error()).orElse("no additional diagnostics");
-      if (isLikelyLocalRabbitUri(endpoints.rabbitMqUri())) {
+      if (isLikelyLocalRabbitHost(rabbitMq.host())) {
         LOGGER.warn("Skipping RabbitMQ connectivity assertion: {}", diagnostic);
         Assumptions.assumeTrue(false, () -> diagnostic);
       }
       assertTrue(rabbitProbe.reachable(), diagnostic);
       return;
     }
-    assertTrue(rabbitProbe.reachable(), () -> "RabbitMQ not reachable at " + endpoints.rabbitMqUri()
+    assertTrue(rabbitProbe.reachable(), () -> "RabbitMQ not reachable at " + rabbitMq.redactedUri()
         + ": " + Optional.ofNullable(rabbitProbe.error()).orElse("no additional diagnostics"));
   }
 
@@ -231,28 +233,18 @@ public class SmokeSteps {
     }
   }
 
-  static boolean isLikelyLocalRabbitUri(String rabbitUri) {
-    if (rabbitUri == null || rabbitUri.isBlank()) {
+  static boolean isLikelyLocalRabbitHost(String host) {
+    if (host == null || host.isBlank()) {
       return false;
     }
-    try {
-      URI uri = URI.create(rabbitUri);
-      String host = uri.getHost();
-      if (host == null || host.isBlank()) {
-        return false;
-      }
-      String normalisedHost = host;
-      if (normalisedHost.startsWith("[") && normalisedHost.endsWith("]") && normalisedHost.length() > 2) {
-        normalisedHost = normalisedHost.substring(1, normalisedHost.length() - 1);
-      }
-      String normalised = normalisedHost.toLowerCase(Locale.ROOT);
-      return "localhost".equals(normalised)
-          || "127.0.0.1".equals(normalised)
-          || "0.0.0.0".equals(normalised)
-          || "::1".equals(normalised);
-    } catch (IllegalArgumentException ex) {
-      LOGGER.debug("Unable to parse RabbitMQ URI '{}': {}", rabbitUri, ex.getMessage());
-      return false;
+    String normalisedHost = host.trim();
+    if (normalisedHost.startsWith("[") && normalisedHost.endsWith("]") && normalisedHost.length() > 2) {
+      normalisedHost = normalisedHost.substring(1, normalisedHost.length() - 1);
     }
+    String normalised = normalisedHost.toLowerCase(Locale.ROOT);
+    return "localhost".equals(normalised)
+        || "127.0.0.1".equals(normalised)
+        || "0.0.0.0".equals(normalised)
+        || "::1".equals(normalised);
   }
 }

--- a/e2e-tests/src/test/java/io/pockethive/e2e/steps/SmokeSteps.java
+++ b/e2e-tests/src/test/java/io/pockethive/e2e/steps/SmokeSteps.java
@@ -241,7 +241,11 @@ public class SmokeSteps {
       if (host == null || host.isBlank()) {
         return false;
       }
-      String normalised = host.toLowerCase(Locale.ROOT);
+      String normalisedHost = host;
+      if (normalisedHost.startsWith("[") && normalisedHost.endsWith("]") && normalisedHost.length() > 2) {
+        normalisedHost = normalisedHost.substring(1, normalisedHost.length() - 1);
+      }
+      String normalised = normalisedHost.toLowerCase(Locale.ROOT);
       return "localhost".equals(normalised)
           || "127.0.0.1".equals(normalised)
           || "0.0.0.0".equals(normalised)

--- a/e2e-tests/src/test/java/io/pockethive/e2e/steps/SmokeStepsTest.java
+++ b/e2e-tests/src/test/java/io/pockethive/e2e/steps/SmokeStepsTest.java
@@ -9,22 +9,22 @@ class SmokeStepsTest {
 
   @Test
   void detectsLocalRabbitHostnames() {
-    assertTrue(SmokeSteps.isLikelyLocalRabbitUri("amqp://guest:guest@localhost:5672/"));
-    assertTrue(SmokeSteps.isLikelyLocalRabbitUri("amqp://guest:guest@127.0.0.1:5672/"));
-    assertTrue(SmokeSteps.isLikelyLocalRabbitUri("amqp://guest:guest@[::1]:5672/"));
-    assertTrue(SmokeSteps.isLikelyLocalRabbitUri("amqp://guest:guest@0.0.0.0:5672/"));
+    assertTrue(SmokeSteps.isLikelyLocalRabbitHost("localhost"));
+    assertTrue(SmokeSteps.isLikelyLocalRabbitHost("127.0.0.1"));
+    assertTrue(SmokeSteps.isLikelyLocalRabbitHost("[::1]"));
+    assertTrue(SmokeSteps.isLikelyLocalRabbitHost("0.0.0.0"));
   }
 
   @Test
   void nonLocalRabbitUrisAreNotMarkedAsLocal() {
-    assertFalse(SmokeSteps.isLikelyLocalRabbitUri("amqp://guest:guest@rabbitmq.internal:5672/"));
-    assertFalse(SmokeSteps.isLikelyLocalRabbitUri("amqp://guest:guest@10.0.0.5:5672/"));
+    assertFalse(SmokeSteps.isLikelyLocalRabbitHost("rabbitmq.internal"));
+    assertFalse(SmokeSteps.isLikelyLocalRabbitHost("10.0.0.5"));
   }
 
   @Test
   void invalidUrisDoNotTriggerLocalClassification() {
-    assertFalse(SmokeSteps.isLikelyLocalRabbitUri("not-a-uri"));
-    assertFalse(SmokeSteps.isLikelyLocalRabbitUri(""));
-    assertFalse(SmokeSteps.isLikelyLocalRabbitUri(null));
+    assertFalse(SmokeSteps.isLikelyLocalRabbitHost("   "));
+    assertFalse(SmokeSteps.isLikelyLocalRabbitHost(""));
+    assertFalse(SmokeSteps.isLikelyLocalRabbitHost(null));
   }
 }

--- a/e2e-tests/src/test/java/io/pockethive/e2e/steps/SmokeStepsTest.java
+++ b/e2e-tests/src/test/java/io/pockethive/e2e/steps/SmokeStepsTest.java
@@ -11,7 +11,7 @@ class SmokeStepsTest {
   void detectsLocalRabbitHostnames() {
     assertTrue(SmokeSteps.isLikelyLocalRabbitUri("amqp://guest:guest@localhost:5672/"));
     assertTrue(SmokeSteps.isLikelyLocalRabbitUri("amqp://guest:guest@127.0.0.1:5672/"));
-    assertTrue(SmokeSteps.isLikelyLocalRabbitUri("amqp://guest:guest@::1:5672/"));
+    assertTrue(SmokeSteps.isLikelyLocalRabbitUri("amqp://guest:guest@[::1]:5672/"));
     assertTrue(SmokeSteps.isLikelyLocalRabbitUri("amqp://guest:guest@0.0.0.0:5672/"));
   }
 

--- a/e2e-tests/src/test/java/io/pockethive/e2e/steps/SmokeStepsTest.java
+++ b/e2e-tests/src/test/java/io/pockethive/e2e/steps/SmokeStepsTest.java
@@ -1,0 +1,30 @@
+package io.pockethive.e2e.steps;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class SmokeStepsTest {
+
+  @Test
+  void detectsLocalRabbitHostnames() {
+    assertTrue(SmokeSteps.isLikelyLocalRabbitUri("amqp://guest:guest@localhost:5672/"));
+    assertTrue(SmokeSteps.isLikelyLocalRabbitUri("amqp://guest:guest@127.0.0.1:5672/"));
+    assertTrue(SmokeSteps.isLikelyLocalRabbitUri("amqp://guest:guest@::1:5672/"));
+    assertTrue(SmokeSteps.isLikelyLocalRabbitUri("amqp://guest:guest@0.0.0.0:5672/"));
+  }
+
+  @Test
+  void nonLocalRabbitUrisAreNotMarkedAsLocal() {
+    assertFalse(SmokeSteps.isLikelyLocalRabbitUri("amqp://guest:guest@rabbitmq.internal:5672/"));
+    assertFalse(SmokeSteps.isLikelyLocalRabbitUri("amqp://guest:guest@10.0.0.5:5672/"));
+  }
+
+  @Test
+  void invalidUrisDoNotTriggerLocalClassification() {
+    assertFalse(SmokeSteps.isLikelyLocalRabbitUri("not-a-uri"));
+    assertFalse(SmokeSteps.isLikelyLocalRabbitUri(""));
+    assertFalse(SmokeSteps.isLikelyLocalRabbitUri(null));
+  }
+}

--- a/start-e2e-tests.bat
+++ b/start-e2e-tests.bat
@@ -16,7 +16,11 @@ if not exist mvnw.cmd (
 
 if not defined ORCHESTRATOR_BASE_URL set "ORCHESTRATOR_BASE_URL=http://localhost:8088/orchestrator"
 if not defined SCENARIO_MANAGER_BASE_URL set "SCENARIO_MANAGER_BASE_URL=http://localhost:8088/scenario-manager"
-if not defined RABBITMQ_URI set "RABBITMQ_URI=amqp://ph-observer:ph-observer@localhost:5672/"
+if not defined RABBITMQ_HOST set "RABBITMQ_HOST=rabbitmq"
+if not defined RABBITMQ_PORT set "RABBITMQ_PORT=5672"
+if not defined RABBITMQ_DEFAULT_USER set "RABBITMQ_DEFAULT_USER=guest"
+if not defined RABBITMQ_DEFAULT_PASS set "RABBITMQ_DEFAULT_PASS=guest"
+if not defined RABBITMQ_VHOST set "RABBITMQ_VHOST=/"
 if not defined UI_BASE_URL set "UI_BASE_URL=http://localhost:8088"
 if not defined UI_WEBSOCKET_URI set "UI_WEBSOCKET_URI=ws://localhost:8088/ws"
 

--- a/start-e2e-tests.sh
+++ b/start-e2e-tests.sh
@@ -11,7 +11,11 @@ fi
 
 export ORCHESTRATOR_BASE_URL="${ORCHESTRATOR_BASE_URL:-http://localhost:8088/orchestrator}"
 export SCENARIO_MANAGER_BASE_URL="${SCENARIO_MANAGER_BASE_URL:-http://localhost:8088/scenario-manager}"
-export RABBITMQ_URI="${RABBITMQ_URI:-amqp://ph-observer:ph-observer@localhost:5672/}"
+export RABBITMQ_HOST="${RABBITMQ_HOST:-rabbitmq}"
+export RABBITMQ_PORT="${RABBITMQ_PORT:-5672}"
+export RABBITMQ_DEFAULT_USER="${RABBITMQ_DEFAULT_USER:-guest}"
+export RABBITMQ_DEFAULT_PASS="${RABBITMQ_DEFAULT_PASS:-guest}"
+export RABBITMQ_VHOST="${RABBITMQ_VHOST:-/}"
 export UI_BASE_URL="${UI_BASE_URL:-http://localhost:8088}"
 export UI_WEBSOCKET_URI="${UI_WEBSOCKET_URI:-ws://localhost:8088/ws}"
 


### PR DESCRIPTION
## Summary
- abort the RabbitMQ reachability assertion instead of failing when the default localhost broker is offline
- add a helper that detects local RabbitMQ URIs and log the skipped assertion for visibility
- cover the URI classification helper with unit tests

## Testing
- `./mvnw -pl e2e-tests test` *(fails: Maven wrapper cannot download dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e7b95af48328ae817b02b94e6702