### PR TITLE
feat(e2e-tests): cover swarm lifecycle golden path

### DIFF
--- a/e2e-tests/pom.xml
+++ b/e2e-tests/pom.xml
@@ -35,10 +35,12 @@
     <dependency>
       <groupId>io.pockethive</groupId>
       <artifactId>topology-core</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>io.pockethive</groupId>
       <artifactId>swarm-model</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/e2e-tests/pom.xml
+++ b/e2e-tests/pom.xml
@@ -33,6 +33,14 @@
       <artifactId>spring-boot-starter-amqp</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.pockethive</groupId>
+      <artifactId>topology-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.pockethive</groupId>
+      <artifactId>swarm-model</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-websocket</artifactId>
     </dependency>

--- a/e2e-tests/src/main/java/io/pockethive/e2e/clients/OrchestratorClient.java
+++ b/e2e-tests/src/main/java/io/pockethive/e2e/clients/OrchestratorClient.java
@@ -1,14 +1,21 @@
 package io.pockethive.e2e.clients;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.Objects;
+import java.util.Optional;
 
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 /**
  * Thin wrapper around {@link WebClient} to access the Orchestrator REST API.
  */
 public final class OrchestratorClient {
+
+  private static final Duration HTTP_TIMEOUT = Duration.ofSeconds(30);
 
   private final WebClient webClient;
 
@@ -23,5 +30,88 @@ public final class OrchestratorClient {
 
   public WebClient webClient() {
     return webClient;
+  }
+
+  public ControlResponse createSwarm(String swarmId, SwarmCreateRequest request) {
+    Objects.requireNonNull(swarmId, "swarmId");
+    Objects.requireNonNull(request, "request");
+    return postControlRequest(path("/api/swarms/{swarmId}/create", swarmId), request, ControlResponse.class);
+  }
+
+  public ControlResponse startSwarm(String swarmId, ControlRequest request) {
+    Objects.requireNonNull(swarmId, "swarmId");
+    Objects.requireNonNull(request, "request");
+    return postControlRequest(path("/api/swarms/{swarmId}/start", swarmId), request, ControlResponse.class);
+  }
+
+  public ControlResponse stopSwarm(String swarmId, ControlRequest request) {
+    Objects.requireNonNull(swarmId, "swarmId");
+    Objects.requireNonNull(request, "request");
+    return postControlRequest(path("/api/swarms/{swarmId}/stop", swarmId), request, ControlResponse.class);
+  }
+
+  public ControlResponse removeSwarm(String swarmId, ControlRequest request) {
+    Objects.requireNonNull(swarmId, "swarmId");
+    Objects.requireNonNull(request, "request");
+    return postControlRequest(path("/api/swarms/{swarmId}/remove", swarmId), request, ControlResponse.class);
+  }
+
+  public Optional<SwarmView> findSwarm(String swarmId) {
+    Objects.requireNonNull(swarmId, "swarmId");
+    try {
+      ResponseEntity<SwarmView> entity = webClient.get()
+          .uri(path("/api/swarms/{swarmId}", swarmId))
+          .accept(MediaType.APPLICATION_JSON)
+          .retrieve()
+          .toEntity(SwarmView.class)
+          .timeout(HTTP_TIMEOUT)
+          .block(HTTP_TIMEOUT);
+      return Optional.ofNullable(entity.getBody());
+    } catch (WebClientResponseException.NotFound notFound) {
+      return Optional.empty();
+    }
+  }
+
+  private <T> T postControlRequest(String path, Object body, Class<T> responseType) {
+    ResponseEntity<T> entity = webClient.post()
+        .uri(path)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(body)
+        .retrieve()
+        .toEntity(responseType)
+        .timeout(HTTP_TIMEOUT)
+        .block(HTTP_TIMEOUT);
+    if (entity == null || entity.getBody() == null) {
+      throw new IllegalStateException("No response received from orchestrator at " + path);
+    }
+    return entity.getBody();
+  }
+
+  private static String path(String template, String swarmId) {
+    return template.replace("{swarmId}", swarmId);
+  }
+
+  public record ControlResponse(String correlationId, String idempotencyKey, Watch watch, long timeoutMs) {
+
+    public Watch watch() {
+      return watch == null ? new Watch(null, null) : watch;
+    }
+  }
+
+  public record Watch(String successTopic, String errorTopic) {
+  }
+
+  public record ControlRequest(String idempotencyKey, String notes) {
+  }
+
+  public record SwarmCreateRequest(String templateId, String idempotencyKey, String notes) {
+  }
+
+  public record SwarmView(String id,
+                          String status,
+                          String health,
+                          String heartbeat,
+                          boolean workEnabled,
+                          boolean controllerEnabled) {
   }
 }

--- a/e2e-tests/src/main/java/io/pockethive/e2e/clients/RabbitSubscriptions.java
+++ b/e2e-tests/src/main/java/io/pockethive/e2e/clients/RabbitSubscriptions.java
@@ -7,6 +7,7 @@ import org.springframework.messaging.simp.stomp.StompSession;
 import org.springframework.messaging.simp.stomp.StompSessionHandler;
 
 import io.pockethive.e2e.config.EnvironmentConfig.RabbitMqSettings;
+import io.pockethive.e2e.support.ControlPlaneEvents;
 
 /**
  * Placeholder messaging client. Actual subscription helpers will be introduced in later phases.
@@ -31,6 +32,10 @@ public final class RabbitSubscriptions {
 
   public ConnectionFactory connectionFactory() {
     return connectionFactory;
+  }
+
+  public ControlPlaneEvents controlPlaneEvents() {
+    return new ControlPlaneEvents(connectionFactory);
   }
 
   /**

--- a/e2e-tests/src/main/java/io/pockethive/e2e/clients/ScenarioManagerClient.java
+++ b/e2e-tests/src/main/java/io/pockethive/e2e/clients/ScenarioManagerClient.java
@@ -1,14 +1,23 @@
 package io.pockethive.e2e.clients;
 
 import java.net.URI;
+import java.time.Duration;
+import java.util.List;
 import java.util.Objects;
 
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.reactive.function.client.WebClient;
+
+import io.pockethive.swarm.model.SwarmTemplate;
 
 /**
  * Simple client used to browse the Scenario Manager catalogue in acceptance tests.
  */
 public final class ScenarioManagerClient {
+
+  private static final Duration HTTP_TIMEOUT = Duration.ofSeconds(20);
 
   private final WebClient webClient;
 
@@ -23,5 +32,40 @@ public final class ScenarioManagerClient {
 
   public WebClient webClient() {
     return webClient;
+  }
+
+  public List<ScenarioSummary> listScenarios() {
+    ResponseEntity<List<ScenarioSummary>> entity = webClient.get()
+        .uri("/scenarios")
+        .accept(MediaType.APPLICATION_JSON)
+        .retrieve()
+        .toEntity(new ParameterizedTypeReference<List<ScenarioSummary>>() {})
+        .timeout(HTTP_TIMEOUT)
+        .block(HTTP_TIMEOUT);
+    if (entity == null || entity.getBody() == null) {
+      throw new IllegalStateException("Scenario Manager /scenarios returned no body");
+    }
+    return entity.getBody();
+  }
+
+  public ScenarioDetails fetchScenario(String scenarioId) {
+    Objects.requireNonNull(scenarioId, "scenarioId");
+    ResponseEntity<ScenarioDetails> entity = webClient.get()
+        .uri(uriBuilder -> uriBuilder.path("/scenarios/{id}").build(scenarioId))
+        .accept(MediaType.APPLICATION_JSON)
+        .retrieve()
+        .toEntity(ScenarioDetails.class)
+        .timeout(HTTP_TIMEOUT)
+        .block(HTTP_TIMEOUT);
+    if (entity == null || entity.getBody() == null) {
+      throw new IllegalStateException("Scenario Manager /scenarios/" + scenarioId + " returned no body");
+    }
+    return entity.getBody();
+  }
+
+  public record ScenarioSummary(String id, String name) {
+  }
+
+  public record ScenarioDetails(String id, String name, String description, SwarmTemplate template) {
   }
 }

--- a/e2e-tests/src/main/java/io/pockethive/e2e/support/ControlPlaneEventParser.java
+++ b/e2e-tests/src/main/java/io/pockethive/e2e/support/ControlPlaneEventParser.java
@@ -1,0 +1,49 @@
+package io.pockethive.e2e.support;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import io.pockethive.control.Confirmation;
+import io.pockethive.control.ErrorConfirmation;
+import io.pockethive.control.ReadyConfirmation;
+
+/**
+ * Utility responsible for decoding control-plane confirmation payloads based on their routing keys.
+ */
+public final class ControlPlaneEventParser {
+
+  private final ObjectMapper objectMapper;
+
+  public ControlPlaneEventParser() {
+    this(createDefaultMapper());
+  }
+
+  public ControlPlaneEventParser(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  public Confirmation parse(String routingKey, byte[] body) throws IOException {
+    if (routingKey == null || body == null) {
+      return null;
+    }
+    Class<? extends Confirmation> type;
+    if (routingKey.startsWith("ev.ready.")) {
+      type = ReadyConfirmation.class;
+    } else if (routingKey.startsWith("ev.error.")) {
+      type = ErrorConfirmation.class;
+    } else {
+      return null;
+    }
+    return objectMapper.readValue(body, type);
+  }
+
+  private static ObjectMapper createDefaultMapper() {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new JavaTimeModule());
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    return mapper;
+  }
+}

--- a/e2e-tests/src/main/java/io/pockethive/e2e/support/ControlPlaneEvents.java
+++ b/e2e-tests/src/main/java/io/pockethive/e2e/support/ControlPlaneEvents.java
@@ -1,0 +1,158 @@
+package io.pockethive.e2e.support;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.DeliverCallback;
+import com.rabbitmq.client.Delivery;
+
+import io.pockethive.Topology;
+import io.pockethive.control.Confirmation;
+import io.pockethive.control.ErrorConfirmation;
+import io.pockethive.control.ReadyConfirmation;
+
+/**
+ * Collects control-plane confirmations from RabbitMQ for later assertions.
+ */
+public final class ControlPlaneEvents implements AutoCloseable {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ControlPlaneEvents.class);
+
+  private final org.springframework.amqp.rabbit.connection.Connection connection;
+  private final Channel channel;
+  private final String queueName;
+  private final String consumerTag;
+  private final ControlPlaneEventParser parser;
+  private final List<ConfirmationEnvelope> confirmations = new CopyOnWriteArrayList<>();
+
+  public ControlPlaneEvents(ConnectionFactory connectionFactory) {
+    Objects.requireNonNull(connectionFactory, "connectionFactory");
+    try {
+      this.connection = connectionFactory.createConnection();
+      this.channel = connection.createChannel(false);
+      this.parser = new ControlPlaneEventParser();
+      this.queueName = channel.queueDeclare("", false, true, true, Collections.emptyMap()).getQueue();
+      channel.queueBind(queueName, Topology.CONTROL_EXCHANGE, "ev.ready.#");
+      channel.queueBind(queueName, Topology.CONTROL_EXCHANGE, "ev.error.#");
+      DeliverCallback callback = this::handleDelivery;
+      this.consumerTag = channel.basicConsume(queueName, true, callback, consumerTag -> { });
+    } catch (Exception ex) {
+      throw new IllegalStateException("Failed to initialise control-plane event consumer", ex);
+    }
+  }
+
+  private void handleDelivery(String tag, Delivery delivery) {
+    String routingKey = delivery.getEnvelope().getRoutingKey();
+    byte[] body = delivery.getBody();
+    try {
+      Confirmation confirmation = parser.parse(routingKey, body);
+      if (confirmation != null) {
+        confirmations.add(new ConfirmationEnvelope(routingKey, confirmation, Instant.now()));
+      } else {
+        LOGGER.debug("Ignoring non-confirmation message on {}", routingKey);
+      }
+    } catch (IOException ex) {
+      LOGGER.warn("Failed to parse confirmation payload on {}", routingKey, ex);
+    }
+  }
+
+  public List<ConfirmationEnvelope> confirmations() {
+    return new ArrayList<>(confirmations);
+  }
+
+  public Optional<ConfirmationEnvelope> findReady(String signal, String correlationId) {
+    return confirmations.stream()
+        .filter(env -> env.confirmation() instanceof ReadyConfirmation ready && matches(ready, signal, correlationId))
+        .findFirst();
+  }
+
+  public Optional<ReadyConfirmation> readyConfirmation(String signal, String correlationId) {
+    return findReady(signal, correlationId)
+        .map(env -> (ReadyConfirmation) env.confirmation());
+  }
+
+  public List<ReadyConfirmation> readyConfirmations(String signal) {
+    return confirmations.stream()
+        .filter(env -> env.confirmation() instanceof ReadyConfirmation ready && matchesSignal(ready, signal))
+        .map(env -> (ReadyConfirmation) env.confirmation())
+        .toList();
+  }
+
+  public List<ErrorConfirmation> errors() {
+    return confirmations.stream()
+        .filter(env -> env.confirmation() instanceof ErrorConfirmation)
+        .map(env -> (ErrorConfirmation) env.confirmation())
+        .toList();
+  }
+
+  public List<ErrorConfirmation> errorsForCorrelation(String correlationId) {
+    return confirmations.stream()
+        .filter(env -> env.confirmation() instanceof ErrorConfirmation error
+            && matchesCorrelation(error, correlationId))
+        .map(env -> (ErrorConfirmation) env.confirmation())
+        .toList();
+  }
+
+  public boolean hasEventOnRoutingKey(String routingKey) {
+    return confirmations.stream().anyMatch(env -> Objects.equals(env.routingKey(), routingKey));
+  }
+
+  public long readyCount(String signal) {
+    return confirmations.stream()
+        .filter(env -> env.confirmation() instanceof ReadyConfirmation ready && matchesSignal(ready, signal))
+        .count();
+  }
+
+  @Override
+  public void close() {
+    try {
+      if (channel != null && channel.isOpen()) {
+        if (consumerTag != null) {
+          channel.basicCancel(consumerTag);
+        }
+        channel.close();
+      }
+    } catch (Exception ex) {
+      LOGGER.debug("Failed to close control-plane channel", ex);
+    }
+    try {
+      if (connection != null) {
+        connection.close();
+      }
+    } catch (Exception ex) {
+      LOGGER.debug("Failed to close control-plane connection", ex);
+    }
+  }
+
+  private boolean matches(ReadyConfirmation ready, String signal, String correlationId) {
+    return matchesSignal(ready, signal) && matchesCorrelation(ready, correlationId);
+  }
+
+  private boolean matchesSignal(ReadyConfirmation ready, String signal) {
+    if (ready == null || signal == null) {
+      return false;
+    }
+    return signal.equalsIgnoreCase(ready.signal());
+  }
+
+  private boolean matchesCorrelation(Confirmation confirmation, String correlationId) {
+    if (confirmation == null || correlationId == null) {
+      return false;
+    }
+    return correlationId.equals(confirmation.correlationId());
+  }
+
+  public record ConfirmationEnvelope(String routingKey, Confirmation confirmation, Instant receivedAt) {
+  }
+}

--- a/e2e-tests/src/main/java/io/pockethive/e2e/support/QueueProbe.java
+++ b/e2e-tests/src/main/java/io/pockethive/e2e/support/QueueProbe.java
@@ -1,7 +1,7 @@
 package io.pockethive.e2e.support;
 
-import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
 
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
@@ -20,7 +20,7 @@ public final class QueueProbe {
 
   public boolean exists(String queueName) {
     Objects.requireNonNull(queueName, "queueName");
-    Map<String, Object> properties = rabbitAdmin.getQueueProperties(queueName);
+    Properties properties = rabbitAdmin.getQueueProperties(queueName);
     return properties != null;
   }
 }

--- a/e2e-tests/src/main/java/io/pockethive/e2e/support/QueueProbe.java
+++ b/e2e-tests/src/main/java/io/pockethive/e2e/support/QueueProbe.java
@@ -1,0 +1,26 @@
+package io.pockethive.e2e.support;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+
+/**
+ * Lightweight helper to inspect queue existence without mutating broker state.
+ */
+public final class QueueProbe {
+
+  private final RabbitAdmin rabbitAdmin;
+
+  public QueueProbe(ConnectionFactory connectionFactory) {
+    Objects.requireNonNull(connectionFactory, "connectionFactory");
+    this.rabbitAdmin = new RabbitAdmin(connectionFactory);
+  }
+
+  public boolean exists(String queueName) {
+    Objects.requireNonNull(queueName, "queueName");
+    Map<String, Object> properties = rabbitAdmin.getQueueProperties(queueName);
+    return properties != null;
+  }
+}

--- a/e2e-tests/src/test/java/io/pockethive/e2e/steps/SwarmLifecycleSteps.java
+++ b/e2e-tests/src/test/java/io/pockethive/e2e/steps/SwarmLifecycleSteps.java
@@ -1,0 +1,321 @@
+package io.pockethive.e2e.steps;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Assumptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.cucumber.java.After;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import io.pockethive.control.ErrorConfirmation;
+import io.pockethive.control.ReadyConfirmation;
+import io.pockethive.e2e.clients.OrchestratorClient;
+import io.pockethive.e2e.clients.OrchestratorClient.ControlRequest;
+import io.pockethive.e2e.clients.OrchestratorClient.ControlResponse;
+import io.pockethive.e2e.clients.OrchestratorClient.SwarmCreateRequest;
+import io.pockethive.e2e.clients.OrchestratorClient.SwarmView;
+import io.pockethive.e2e.clients.RabbitSubscriptions;
+import io.pockethive.e2e.clients.ScenarioManagerClient;
+import io.pockethive.e2e.clients.ScenarioManagerClient.ScenarioDetails;
+import io.pockethive.e2e.clients.ScenarioManagerClient.ScenarioSummary;
+import io.pockethive.e2e.config.EnvironmentConfig;
+import io.pockethive.e2e.config.EnvironmentConfig.ServiceEndpoints;
+import io.pockethive.e2e.support.ControlPlaneEvents;
+import io.pockethive.e2e.support.QueueProbe;
+import io.pockethive.e2e.support.SwarmAssertions;
+import io.pockethive.swarm.model.Bee;
+import io.pockethive.swarm.model.SwarmTemplate;
+import io.pockethive.swarm.model.Work;
+
+/**
+ * Step definitions for the Phase 2 swarm lifecycle golden path scenario.
+ */
+public class SwarmLifecycleSteps {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SwarmLifecycleSteps.class);
+  private ServiceEndpoints endpoints;
+  private OrchestratorClient orchestratorClient;
+  private ScenarioManagerClient scenarioManagerClient;
+  private RabbitSubscriptions rabbitSubscriptions;
+  private ControlPlaneEvents controlPlaneEvents;
+  private ScenarioDetails scenarioDetails;
+  private SwarmTemplate template;
+  private String swarmId;
+  private String idempotencyPrefix;
+  private boolean swarmRemoved;
+
+  private ControlResponse createResponse;
+  private ControlResponse startResponse;
+  private ControlResponse stopResponse;
+  private ControlResponse removeResponse;
+
+  @Given("the swarm lifecycle harness is initialised")
+  public void theSwarmLifecycleHarnessIsInitialised() {
+    try {
+      endpoints = EnvironmentConfig.loadServiceEndpoints();
+    } catch (IllegalStateException ex) {
+      Assumptions.assumeTrue(false, () -> "Skipping lifecycle scenario: " + ex.getMessage());
+    }
+
+    orchestratorClient = OrchestratorClient.create(endpoints.orchestratorBaseUrl());
+    scenarioManagerClient = ScenarioManagerClient.create(endpoints.scenarioManagerBaseUrl());
+    rabbitSubscriptions = RabbitSubscriptions.from(endpoints.rabbitMq());
+    controlPlaneEvents = rabbitSubscriptions.controlPlaneEvents();
+
+    String baseSwarmId = endpoints.defaultSwarmId();
+    String suffix = Long.toHexString(System.nanoTime());
+    swarmId = baseSwarmId + "-gp-" + suffix;
+    idempotencyPrefix = endpoints.idempotencyKeyPrefix();
+
+    LOGGER.info("Lifecycle harness initialised with swarmId={} endpoints={} ", swarmId, endpoints.asMap());
+  }
+
+  @And("a default scenario template is available")
+  public void aDefaultScenarioTemplateIsAvailable() {
+    ensureHarness();
+    List<ScenarioSummary> summaries;
+    try {
+      summaries = scenarioManagerClient.listScenarios();
+    } catch (Exception ex) {
+      Assumptions.assumeTrue(false, () -> "Skipping lifecycle scenario: failed to query Scenario Manager: " + ex.getMessage());
+      return;
+    }
+    Assumptions.assumeTrue(!summaries.isEmpty(), "Skipping lifecycle scenario: no scenarios available");
+
+    ScenarioSummary summary = summaries.getFirst();
+    LOGGER.info("Using scenario {} - {}", summary.id(), summary.name());
+    scenarioDetails = scenarioManagerClient.fetchScenario(summary.id());
+    template = Objects.requireNonNull(scenarioDetails.template(), "scenario template");
+  }
+
+  @When("I create the swarm from that template")
+  public void iCreateTheSwarmFromThatTemplate() {
+    ensureTemplate();
+    String idempotencyKey = idKey("create");
+    SwarmCreateRequest request = new SwarmCreateRequest(scenarioDetails.id(), idempotencyKey, "e2e lifecycle create");
+    createResponse = orchestratorClient.createSwarm(swarmId, request);
+    LOGGER.info("Create request accepted correlation={} watch={}", createResponse.correlationId(), createResponse.watch());
+  }
+
+  @Then("the swarm is registered and queues are declared")
+  public void theSwarmIsRegisteredAndQueuesAreDeclared() {
+    ensureCreateResponse();
+
+    awaitReady("swarm-create", createResponse);
+    awaitReady("swarm-template", createResponse);
+    assertNoErrors(createResponse.correlationId(), "swarm-create");
+    assertWatchMatched(createResponse);
+
+    SwarmAssertions.await("swarm registered", () -> {
+      Optional<SwarmView> view = orchestratorClient.findSwarm(swarmId);
+      assertTrue(view.isPresent(), "Swarm should be registered after create");
+      assertEquals("READY", view.get().status(), "Swarm status should be READY after template applied");
+    });
+
+    QueueProbe probe = new QueueProbe(rabbitSubscriptions.connectionFactory());
+    for (String suffix : expectedQueueSuffixes(template)) {
+      String queueName = "ph." + swarmId + "." + suffix;
+      assertTrue(probe.exists(queueName), () -> "Expected workload queue to exist: " + queueName);
+    }
+  }
+
+  @When("I start the swarm")
+  public void iStartTheSwarm() {
+    ensureCreateResponse();
+    String idempotencyKey = idKey("start");
+    startResponse = orchestratorClient.startSwarm(swarmId, new ControlRequest(idempotencyKey, "e2e lifecycle start"));
+    LOGGER.info("Start request correlation={} watch={}", startResponse.correlationId(), startResponse.watch());
+  }
+
+  @Then("the swarm reports running")
+  public void theSwarmReportsRunning() {
+    ensureStartResponse();
+    awaitReady("swarm-start", startResponse);
+    assertNoErrors(startResponse.correlationId(), "swarm-start");
+    assertWatchMatched(startResponse);
+
+    SwarmAssertions.await("swarm running", () -> {
+      Optional<SwarmView> view = orchestratorClient.findSwarm(swarmId);
+      assertTrue(view.isPresent(), "Swarm should be available when running");
+      assertEquals("RUNNING", view.get().status(), "Swarm status should be RUNNING after start");
+      assertTrue(view.get().workEnabled(), "Workloads should be enabled after start");
+    });
+  }
+
+  @When("I stop the swarm")
+  public void iStopTheSwarm() {
+    ensureStartResponse();
+    String idempotencyKey = idKey("stop");
+    stopResponse = orchestratorClient.stopSwarm(swarmId, new ControlRequest(idempotencyKey, "e2e lifecycle stop"));
+    LOGGER.info("Stop request correlation={} watch={}", stopResponse.correlationId(), stopResponse.watch());
+  }
+
+  @Then("the swarm reports stopped")
+  public void theSwarmReportsStopped() {
+    ensureStopResponse();
+    awaitReady("swarm-stop", stopResponse);
+    assertNoErrors(stopResponse.correlationId(), "swarm-stop");
+    assertWatchMatched(stopResponse);
+
+    SwarmAssertions.await("swarm stopped", () -> {
+      Optional<SwarmView> view = orchestratorClient.findSwarm(swarmId);
+      assertTrue(view.isPresent(), "Swarm should still be registered when stopped");
+      assertEquals("STOPPED", view.get().status(), "Swarm status should be STOPPED after stop");
+      assertFalse(view.get().workEnabled(), "Workloads should be disabled after stop");
+    });
+  }
+
+  @When("I remove the swarm")
+  public void iRemoveTheSwarm() {
+    ensureStopResponse();
+    String idempotencyKey = idKey("remove");
+    removeResponse = orchestratorClient.removeSwarm(swarmId, new ControlRequest(idempotencyKey, "e2e lifecycle remove"));
+    LOGGER.info("Remove request correlation={} watch={}", removeResponse.correlationId(), removeResponse.watch());
+  }
+
+  @Then("the swarm is removed and lifecycle confirmations are recorded")
+  public void theSwarmIsRemovedAndLifecycleConfirmationsAreRecorded() {
+    ensureRemoveResponse();
+    awaitReady("swarm-remove", removeResponse);
+    assertNoErrors(removeResponse.correlationId(), "swarm-remove");
+    assertWatchMatched(removeResponse);
+    swarmRemoved = true;
+
+    SwarmAssertions.await("swarm removed", () -> {
+      Optional<SwarmView> view = orchestratorClient.findSwarm(swarmId);
+      assertTrue(view.isEmpty(), "Swarm should no longer be present after removal");
+    });
+
+    assertEquals(1, controlPlaneEvents.readyCount("swarm-create"), "Expected exactly one swarm-create ready event");
+    assertEquals(1, controlPlaneEvents.readyCount("swarm-template"), "Expected exactly one swarm-template ready event");
+    assertEquals(1, controlPlaneEvents.readyCount("swarm-start"), "Expected exactly one swarm-start ready event");
+    assertEquals(1, controlPlaneEvents.readyCount("swarm-stop"), "Expected exactly one swarm-stop ready event");
+    assertEquals(1, controlPlaneEvents.readyCount("swarm-remove"), "Expected exactly one swarm-remove ready event");
+    assertTrue(controlPlaneEvents.errors().isEmpty(), "No error confirmations should be emitted during the golden path");
+  }
+
+  @After
+  public void tearDownLifecycle() {
+    if (controlPlaneEvents != null) {
+      controlPlaneEvents.close();
+    }
+    if (!swarmRemoved && orchestratorClient != null && swarmId != null) {
+      try {
+        LOGGER.info("Attempting to remove swarm {} during cleanup", swarmId);
+        orchestratorClient.removeSwarm(swarmId, new ControlRequest(idKey("cleanup"), "cleanup"));
+      } catch (Exception ex) {
+        LOGGER.warn("Cleanup remove failed for swarm {}", swarmId, ex);
+      }
+    }
+  }
+
+  private void ensureHarness() {
+    Assumptions.assumeTrue(endpoints != null, "Harness not initialised");
+  }
+
+  private void ensureTemplate() {
+    ensureHarness();
+    Assumptions.assumeTrue(template != null, "Scenario template not loaded");
+  }
+
+  private void ensureCreateResponse() {
+    Assumptions.assumeTrue(createResponse != null, "Create request was not issued");
+  }
+
+  private void ensureStartResponse() {
+    ensureCreateResponse();
+    Assumptions.assumeTrue(startResponse != null, "Start request was not issued");
+  }
+
+  private void ensureStopResponse() {
+    ensureStartResponse();
+    Assumptions.assumeTrue(stopResponse != null, "Stop request was not issued");
+  }
+
+  private void ensureRemoveResponse() {
+    ensureStopResponse();
+    Assumptions.assumeTrue(removeResponse != null, "Remove request was not issued");
+  }
+
+  private void awaitReady(String signal, ControlResponse response) {
+    String correlationId = response.correlationId();
+    SwarmAssertions.await(signal + " confirmation", () -> {
+      Optional<ReadyConfirmation> ready = controlPlaneEvents.readyConfirmation(signal, correlationId);
+      assertTrue(ready.isPresent(), () -> "Missing ready confirmation for " + signal + " correlation=" + correlationId);
+    });
+  }
+
+  private void assertNoErrors(String correlationId, String context) {
+    List<ErrorConfirmation> errors = controlPlaneEvents.errorsForCorrelation(correlationId);
+    assertTrue(errors.isEmpty(), () -> "Unexpected error confirmations for " + context + ": " + errors);
+  }
+
+  private void assertWatchMatched(ControlResponse response) {
+    String signal = signalFromWatch(response);
+    if (signal.isEmpty()) {
+      return;
+    }
+    controlPlaneEvents.findReady(signal, response.correlationId())
+        .ifPresent(env -> {
+          String expected = response.watch().successTopic();
+          if (expected != null && !expected.isBlank()) {
+            assertEquals(expected, env.routingKey(), "Watch success topic should match emitted event");
+          }
+        });
+    String errorTopic = response.watch().errorTopic();
+    if (errorTopic != null && !errorTopic.isBlank()) {
+      assertFalse(controlPlaneEvents.hasEventOnRoutingKey(errorTopic),
+          () -> "Unexpected error event detected on " + errorTopic);
+    }
+  }
+
+  private String signalFromWatch(ControlResponse response) {
+    // success topic format: ev.ready.<signal>.<swarm>... -> extract <signal>
+    String topic = response.watch().successTopic();
+    if (topic == null || topic.isBlank()) {
+      return "";
+    }
+    String[] parts = topic.split("\\.");
+    if (parts.length < 3) {
+      return "";
+    }
+    String raw = parts[2];
+    return raw.toLowerCase(Locale.ROOT);
+  }
+
+  private Set<String> expectedQueueSuffixes(SwarmTemplate template) {
+    Set<String> suffixes = new LinkedHashSet<>();
+    if (template.bees() != null) {
+      for (Bee bee : template.bees()) {
+        Work work = bee.work();
+        if (work != null) {
+          if (work.in() != null && !work.in().isBlank()) {
+            suffixes.add(work.in());
+          }
+          if (work.out() != null && !work.out().isBlank()) {
+            suffixes.add(work.out());
+          }
+        }
+      }
+    }
+    return suffixes;
+  }
+
+  private String idKey(String action) {
+    return idempotencyPrefix + "-" + action + "-" + UUID.randomUUID();
+  }
+}

--- a/e2e-tests/src/test/java/io/pockethive/e2e/support/ControlPlaneEventParserTest.java
+++ b/e2e-tests/src/test/java/io/pockethive/e2e/support/ControlPlaneEventParserTest.java
@@ -1,0 +1,70 @@
+package io.pockethive.e2e.support;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.time.Instant;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.pockethive.control.CommandState;
+import io.pockethive.control.Confirmation;
+import io.pockethive.control.ConfirmationScope;
+import io.pockethive.control.ErrorConfirmation;
+import io.pockethive.control.ReadyConfirmation;
+
+class ControlPlaneEventParserTest {
+
+  private final ObjectMapper mapper = new ObjectMapper().findAndRegisterModules();
+
+  @Test
+  void parsesReadyConfirmations() throws Exception {
+    ReadyConfirmation confirmation = new ReadyConfirmation(
+        Instant.now(),
+        "corr-1",
+        "idem-1",
+        "swarm-start",
+        ConfirmationScope.forSwarm("swarm-test"),
+        new CommandState("Running", true, Map.of("workloads", Map.of("enabled", true)))
+    );
+    byte[] body = mapper.writeValueAsBytes(confirmation);
+
+    ControlPlaneEventParser parser = new ControlPlaneEventParser(mapper);
+    Confirmation parsed = parser.parse("ev.ready.swarm-start.swarm-test.swarm-controller.alpha", body);
+
+    ReadyConfirmation ready = assertInstanceOf(ReadyConfirmation.class, parsed);
+    assertEquals("corr-1", ready.correlationId());
+    assertEquals("swarm-start", ready.signal());
+    assertNotNull(ready.state());
+  }
+
+  @Test
+  void parsesErrorConfirmations() throws Exception {
+    ErrorConfirmation confirmation = new ErrorConfirmation(
+        Instant.now(),
+        "corr-2",
+        "idem-2",
+        "swarm-stop",
+        ConfirmationScope.forSwarm("swarm-test"),
+        new CommandState("Stopped", false, null),
+        "stop",
+        "IllegalStateException",
+        "boom",
+        Boolean.FALSE,
+        null
+    );
+    byte[] body = mapper.writeValueAsBytes(confirmation);
+
+    ControlPlaneEventParser parser = new ControlPlaneEventParser(mapper);
+    Confirmation parsed = parser.parse("ev.error.swarm-stop.swarm-test.swarm-controller.alpha", body);
+
+    ErrorConfirmation error = assertInstanceOf(ErrorConfirmation.class, parsed);
+    assertEquals("corr-2", error.correlationId());
+    assertEquals("swarm-stop", error.signal());
+    assertEquals("boom", error.message());
+  }
+}

--- a/e2e-tests/src/test/resources/features/swarm-lifecycle.feature
+++ b/e2e-tests/src/test/resources/features/swarm-lifecycle.feature
@@ -1,0 +1,15 @@
+Feature: Swarm lifecycle golden path
+
+  Background:
+    Given the swarm lifecycle harness is initialised
+    And a default scenario template is available
+
+  Scenario: Operators can drive the swarm lifecycle via REST and confirmations
+    When I create the swarm from that template
+    Then the swarm is registered and queues are declared
+    When I start the swarm
+    Then the swarm reports running
+    When I stop the swarm
+    Then the swarm reports stopped
+    When I remove the swarm
+    Then the swarm is removed and lifecycle confirmations are recorded


### PR DESCRIPTION
## Summary
- extend orchestrator and scenario manager clients to drive swarm lifecycle controls
- add RabbitMQ control-plane event collector, queue probe, and confirmation parser utilities
- implement Cucumber lifecycle scenario with supporting steps plus parser unit tests

## Testing
- ./mvnw -pl e2e-tests test *(fails: Network is unreachable when downloading Maven wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68d97ab29fdc8328bad497814a8f6050