### PR TITLE
feat(ui): add scenario module federation remote

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -43,6 +43,32 @@ Run the development server with hot reload (default at http://localhost:5173):
 npm run dev
 ```
 
+### Scenario Remote (`@ph/scenario`)
+
+Run the Module Federation remote in isolation. The dev server exposes the remote entry at
+`http://localhost:5173/assets/remoteEntry.js` while also mounting the placeholder UI for quick visual checks.
+
+```bash
+npm run dev:scenario
+```
+
+Build the remote for distribution. Bundled assets are written to `dist/scenario/` so they can be published independently of the
+main console bundle.
+
+```bash
+npm run build:scenario
+```
+
+To consume the remote from a host application, configure Module Federation (or the compatible loader) with the following
+settings:
+
+- **Remote name**: `@ph/scenario`
+- **Remote entry URL**: `<scenario-server>/assets/remoteEntry.js`
+- **Exposed module**: `./ScenarioApp`
+
+Hosts can then import the module with `import('@ph/scenario/ScenarioApp')` and call the exported `mount` helper to render the
+Scenario Builder placeholder into a DOM node.
+
 ### Build
 
 Type‑checks the project and generates production assets in `dist/`:

--- a/ui/index.html
+++ b/ui/index.html
@@ -15,6 +15,12 @@
   </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module">
+      if (import.meta.env.MODE === 'scenario') {
+        await import('/src/scenario/remoteEntry.ts')
+      } else {
+        await import('/src/main.tsx')
+      }
+    </script>
   </body>
 </html>

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -21,6 +21,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
+        "@originjs/vite-plugin-federation": "^1.4.1",
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^16.0.1",
         "@testing-library/user-event": "^14.6.1",
@@ -1283,6 +1284,34 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@originjs/vite-plugin-federation": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@originjs/vite-plugin-federation/-/vite-plugin-federation-1.4.1.tgz",
+      "integrity": "sha512-Uo08jW5pj1t58OUKuZNkmzcfTN2pqeVuAWCCiKf/75/oll4Efq4cHOqSE1FXMlvwZNGDziNdDyBbQ5IANem3CQ==",
+      "dev": true,
+      "license": "MulanPSL-2.0",
+      "dependencies": {
+        "estree-walker": "^3.0.2",
+        "magic-string": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "pnpm": ">=7.0.1"
+      }
+    },
+    "node_modules/@originjs/vite-plugin-federation/node_modules/magic-string": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@pkgjs/parseargs": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -6,7 +6,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:scenario": "vite --mode scenario",
     "build": "tsc -b && vite build",
+    "build:scenario": "tsc -p tsconfig.scenario.json && vite build --mode scenario",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest run"
@@ -24,6 +26,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@originjs/vite-plugin-federation": "^1.4.1",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^16.0.1",
     "@testing-library/user-event": "^14.6.1",

--- a/ui/src/scenario/ScenarioApp.tsx
+++ b/ui/src/scenario/ScenarioApp.tsx
@@ -1,0 +1,42 @@
+import type { FC, ReactNode } from 'react'
+
+const Section: FC<{ title: string; description: ReactNode }> = ({ title, description }) => (
+  <section className="space-y-2 rounded-lg border border-slate-800 bg-slate-900/60 p-6 shadow-sm">
+    <h2 className="text-xl font-semibold text-slate-100">{title}</h2>
+    <p className="text-sm leading-relaxed text-slate-300">{description}</p>
+  </section>
+)
+
+const ScenarioApp: FC = () => (
+  <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-8 text-slate-100">
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-6">
+      <header className="space-y-2 text-center">
+        <p className="text-sm uppercase tracking-[0.35em] text-amber-400">PocketHive Remote</p>
+        <h1 className="text-4xl font-bold">Scenario Builder Placeholder</h1>
+        <p className="text-base text-slate-300">
+          This layout confirms the Module Federation remote is wired correctly. Replace this scaffold with the
+          interactive Scenario Builder once the remote APIs are available.
+        </p>
+      </header>
+
+      <Section
+        title="Getting Started"
+        description='Import the "@ph/scenario/ScenarioApp" module from the remote entry to mount this placeholder in any host UI.'
+      />
+
+      <Section
+        title="Next Steps"
+        description={
+          <>
+            <span>
+              Build out the Scenario Builder screens here. Shared UI elements can be composed from the PocketHive design
+              system to ensure the embedded experience matches the host application.
+            </span>
+          </>
+        }
+      />
+    </div>
+  </div>
+)
+
+export default ScenarioApp

--- a/ui/src/scenario/remoteEntry.ts
+++ b/ui/src/scenario/remoteEntry.ts
@@ -18,7 +18,7 @@ export const mount = (element: HTMLElement): MountReturn => {
 
 export { ScenarioApp }
 
-if (import.meta.env.MODE === 'scenario') {
+if (import.meta.env.MODE === 'scenario' && import.meta.env.DEV) {
   const container = document.getElementById('root')
   if (container) {
     mount(container)

--- a/ui/src/scenario/remoteEntry.ts
+++ b/ui/src/scenario/remoteEntry.ts
@@ -1,0 +1,26 @@
+import { StrictMode, createElement } from 'react'
+import { createRoot } from 'react-dom/client'
+
+import ScenarioApp from './ScenarioApp'
+
+export type MountReturn = {
+  unmount: () => void
+}
+
+export const mount = (element: HTMLElement): MountReturn => {
+  const root = createRoot(element)
+  root.render(createElement(StrictMode, undefined, createElement(ScenarioApp)))
+
+  return {
+    unmount: () => root.unmount()
+  }
+}
+
+export { ScenarioApp }
+
+if (import.meta.env.MODE === 'scenario') {
+  const container = document.getElementById('root')
+  if (container) {
+    mount(container)
+  }
+}

--- a/ui/tsconfig.scenario.json
+++ b/ui/tsconfig.scenario.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.scenario.tsbuildinfo"
+  },
+  "include": ["src"]
+}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,12 +1,39 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
+import federation from '@originjs/vite-plugin-federation'
 
 // https://vite.dev/config/
-export default defineConfig({
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  plugins: [react() as any],
-  publicDir: 'assets',
-  test: {
-    environment: 'jsdom'
+export default defineConfig(({ mode }) => {
+  const isScenario = mode === 'scenario'
+
+  return {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    plugins: [
+      react() as any,
+      federation({
+        name: '@ph/scenario',
+        filename: 'remoteEntry.js',
+        exposes: {
+          './ScenarioApp': './src/scenario/remoteEntry.ts'
+        },
+        shared: ['react', 'react-dom']
+      })
+    ],
+    publicDir: 'assets',
+    build: {
+      target: 'esnext',
+      modulePreload: false,
+      outDir: isScenario ? 'dist/scenario' : 'dist'
+    },
+    ...(isScenario
+      ? {
+          optimizeDeps: {
+            entries: ['src/scenario/remoteEntry.ts']
+          }
+        }
+      : {}),
+    test: {
+      environment: 'jsdom'
+    }
   }
 })


### PR DESCRIPTION
## Summary
- add module federation configuration that exposes the `@ph/scenario` remote
- scaffold a placeholder Scenario Builder app and bootstrap entry for remote consumption
- add scenario-specific build scripts and documentation for running the remote on its own

## Testing
- npm run build
- npm run build:scenario

------
https://chatgpt.com/codex/tasks/task_e_68da97ff82a4832896b1f46a78c81e30