### PR TITLE
feat: add scenario remote host route

### DIFF
--- a/ui/src/App.scenario.test.tsx
+++ b/ui/src/App.scenario.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { MemoryRouter } from 'react-router-dom'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { describe, expect, test, vi } from 'vitest'
+
+vi.mock('@stomp/stompjs', () => ({
+  Client: vi.fn().mockImplementation(() => ({
+    activate: vi.fn(),
+    deactivate: vi.fn(),
+    configure: vi.fn(),
+    onConnect: undefined,
+    onStompError: undefined,
+    onWebSocketClose: undefined,
+    onWebSocketError: undefined,
+  })),
+}))
+
+vi.mock('@ph/scenario/ScenarioApp', () => ({
+  default: () => <div>Scenario Builder Placeholder</div>,
+}))
+
+const App = (await import('./App')).default
+
+describe('Scenario route', () => {
+  test('renders the scenario remote placeholder when visiting /scenario', async () => {
+    render(
+      <MemoryRouter initialEntries={['/scenario']}>
+        <App />
+      </MemoryRouter>,
+    )
+
+    expect(
+      await screen.findByText(/Scenario Builder Placeholder/i),
+    ).toBeInTheDocument()
+  })
+})

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,8 +1,24 @@
+import { Suspense, lazy } from 'react'
 import { Routes, Route } from 'react-router-dom'
 import Layout from './layout/Layout'
 import Home from './pages/Home'
 import HivePage from './pages/hive/HivePage'
 import Nectar from './pages/Nectar'
+import ScenarioHost from './pages/scenario/ScenarioHost'
+
+const scenarioRemoteId = '@ph/scenario/ScenarioApp'
+
+const ScenarioApp = lazy(async () =>
+  (await import(/* @vite-ignore */ scenarioRemoteId)) as typeof import('@ph/scenario/ScenarioApp'),
+)
+
+function ScenarioFallback() {
+  return (
+    <div className="flex h-full min-h-[360px] items-center justify-center bg-slate-950 text-sm uppercase tracking-[0.3em] text-amber-300">
+      Loading Scenario…
+    </div>
+  )
+}
 
 export default function App() {
   return (
@@ -11,6 +27,16 @@ export default function App() {
         <Route index element={<Home />} />
         <Route path="hive" element={<HivePage />} />
         <Route path="nectar" element={<Nectar />} />
+        <Route
+          path="scenario/*"
+          element={(
+            <Suspense fallback={<ScenarioFallback />}>
+              <ScenarioHost>
+                <ScenarioApp />
+              </ScenarioHost>
+            </Suspense>
+          )}
+        />
       </Route>
     </Routes>
   )

--- a/ui/src/layout/Layout.tsx
+++ b/ui/src/layout/Layout.tsx
@@ -1,5 +1,5 @@
 import { NavLink, Outlet } from 'react-router-dom'
-import { Hexagon, Radio, Droplet } from 'lucide-react'
+import { Hexagon, Radio, Droplet, Workflow } from 'lucide-react'
 import MonolithIcon from '../icons/Monolith'
 import Health from '../components/Health'
 import Connectivity from '../components/Connectivity'
@@ -54,6 +54,15 @@ export default function Layout() {
           >
             <Hexagon strokeWidth={1.5} className="tab-icon text-white/80" />
             Hive
+          </NavLink>
+          <NavLink
+            to="/scenario"
+            className={({ isActive }) =>
+              `tab-btn flex items-center${isActive ? ' tab-active' : ''}`
+            }
+          >
+            <Workflow strokeWidth={1.5} className="tab-icon text-white/80" />
+            Scenario
           </NavLink>
           <button
             className={`tab-btn flex items-center${buzzVisible ? ' tab-active' : ''}`}

--- a/ui/src/pages/scenario/ScenarioHost.tsx
+++ b/ui/src/pages/scenario/ScenarioHost.tsx
@@ -1,0 +1,64 @@
+import { Component, type ReactNode, Suspense } from 'react'
+
+interface ScenarioHostProps {
+  children: ReactNode
+}
+
+interface ScenarioErrorBoundaryProps {
+  children: ReactNode
+  fallback: ReactNode
+}
+
+interface ScenarioErrorBoundaryState {
+  hasError: boolean
+}
+
+function ScenarioLoading() {
+  return (
+    <div className="flex h-full min-h-[360px] flex-1 items-center justify-center bg-slate-950">
+      <span className="text-sm uppercase tracking-[0.3em] text-amber-300">Loading Scenario…</span>
+    </div>
+  )
+}
+
+function ScenarioError() {
+  return (
+    <div
+      role="alert"
+      className="flex h-full min-h-[360px] flex-1 flex-col items-center justify-center gap-2 bg-slate-950 text-center text-slate-200"
+    >
+      <p className="text-lg font-semibold text-rose-300">Failed to load Scenario Builder</p>
+      <p className="text-sm text-slate-400">Refresh the page or contact the PocketHive team if this persists.</p>
+    </div>
+  )
+}
+
+class ScenarioErrorBoundary extends Component<ScenarioErrorBoundaryProps, ScenarioErrorBoundaryState> {
+  state: ScenarioErrorBoundaryState = { hasError: false }
+
+  static getDerivedStateFromError(): ScenarioErrorBoundaryState {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error) {
+    console.error('Scenario remote failed to render', error)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback
+    }
+
+    return this.props.children
+  }
+}
+
+export default function ScenarioHost({ children }: ScenarioHostProps) {
+  return (
+    <div className="flex h-full min-h-full flex-1 bg-slate-950 text-slate-100">
+      <ScenarioErrorBoundary fallback={<ScenarioError />}>
+        <Suspense fallback={<ScenarioLoading />}>{children}</Suspense>
+      </ScenarioErrorBoundary>
+    </div>
+  )
+}

--- a/ui/src/types/module-federation.d.ts
+++ b/ui/src/types/module-federation.d.ts
@@ -1,0 +1,6 @@
+declare module '@ph/scenario/ScenarioApp' {
+  import type { ComponentType } from 'react'
+
+  const ScenarioApp: ComponentType
+  export default ScenarioApp
+}


### PR DESCRIPTION
## Summary
- add a lazy /scenario route that federates the @ph/scenario/ScenarioApp remote with a suspense fallback
- introduce a ScenarioHost wrapper to surface loading/error states and wire the navigation tab
- provide type declarations and a vitest smoke test covering the scenario entry point

## Testing
- npm run test -- App.scenario.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68daad8ea68883288880a00e64bc0330