### PR TITLE
feat: add control-plane topology descriptors

### DIFF
--- a/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/AbstractWorkerTopologyDescriptor.java
+++ b/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/AbstractWorkerTopologyDescriptor.java
@@ -1,0 +1,85 @@
+package io.pockethive.controlplane.topology;
+
+import io.pockethive.Topology;
+import io.pockethive.controlplane.routing.ControlPlaneRouting;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+abstract class AbstractWorkerTopologyDescriptor implements ControlPlaneTopologyDescriptor {
+
+    private final String role;
+    private final Optional<QueueDescriptor> trafficQueue;
+
+    protected AbstractWorkerTopologyDescriptor(String role) {
+        this(role, null);
+    }
+
+    protected AbstractWorkerTopologyDescriptor(String role, QueueDescriptor trafficQueue) {
+        this.role = requireRole(role);
+        this.trafficQueue = Optional.ofNullable(trafficQueue);
+    }
+
+    @Override
+    public String role() {
+        return role;
+    }
+
+    @Override
+    public Optional<ControlQueueDescriptor> controlQueue(String instanceId) {
+        String id = requireInstanceId(instanceId);
+        String queueName = Topology.CONTROL_QUEUE + "." + Topology.SWARM_ID + "." + role + "." + id;
+        Set<String> configSignals = Set.of(
+            ControlPlaneRouting.signal("config-update", "ALL", role, "ALL"),
+            ControlPlaneRouting.signal("config-update", Topology.SWARM_ID, role, "ALL"),
+            ControlPlaneRouting.signal("config-update", Topology.SWARM_ID, role, id),
+            ControlPlaneRouting.signal("config-update", Topology.SWARM_ID, "ALL", "ALL")
+        );
+        Set<String> statusSignals = Set.of(
+            ControlPlaneRouting.signal("status-request", "ALL", role, "ALL"),
+            ControlPlaneRouting.signal("status-request", Topology.SWARM_ID, role, "ALL"),
+            ControlPlaneRouting.signal("status-request", Topology.SWARM_ID, role, id)
+        );
+        LinkedHashSet<String> allSignals = new LinkedHashSet<>(configSignals);
+        allSignals.addAll(statusSignals);
+        return Optional.of(new ControlQueueDescriptor(queueName, allSignals, Set.of()));
+    }
+
+    @Override
+    public Collection<QueueDescriptor> additionalQueues(String instanceId) {
+        requireInstanceId(instanceId);
+        return trafficQueue.<Collection<QueueDescriptor>>map(List::of).orElseGet(List::of);
+    }
+
+    @Override
+    public ControlPlaneRouteCatalog routes() {
+        Set<String> configRoutes = Set.of(
+            ControlPlaneRouting.signal("config-update", "ALL", role, "ALL"),
+            ControlPlaneRouting.signal("config-update", Topology.SWARM_ID, role, "ALL"),
+            ControlPlaneRouting.signal("config-update", Topology.SWARM_ID, role, ControlPlaneRouteCatalog.INSTANCE_TOKEN),
+            ControlPlaneRouting.signal("config-update", Topology.SWARM_ID, "ALL", "ALL")
+        );
+        Set<String> statusRoutes = Set.of(
+            ControlPlaneRouting.signal("status-request", "ALL", role, "ALL"),
+            ControlPlaneRouting.signal("status-request", Topology.SWARM_ID, role, "ALL"),
+            ControlPlaneRouting.signal("status-request", Topology.SWARM_ID, role, ControlPlaneRouteCatalog.INSTANCE_TOKEN)
+        );
+        return new ControlPlaneRouteCatalog(configRoutes, statusRoutes, Set.of(), Set.of(), Set.of(), Set.of());
+    }
+
+    private static String requireRole(String role) {
+        if (role == null || role.isBlank()) {
+            throw new IllegalArgumentException("role must not be blank");
+        }
+        return role;
+    }
+
+    private static String requireInstanceId(String instanceId) {
+        if (instanceId == null || instanceId.isBlank()) {
+            throw new IllegalArgumentException("instanceId must not be blank");
+        }
+        return instanceId;
+    }
+}

--- a/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/ControlPlaneRouteCatalog.java
+++ b/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/ControlPlaneRouteCatalog.java
@@ -1,0 +1,36 @@
+package io.pockethive.controlplane.topology;
+
+import java.util.Set;
+
+/**
+ * Canonical route templates advertised for a control-plane role.
+ */
+public record ControlPlaneRouteCatalog(Set<String> configSignals,
+                                       Set<String> statusSignals,
+                                       Set<String> lifecycleSignals,
+                                       Set<String> statusEvents,
+                                       Set<String> lifecycleEvents,
+                                       Set<String> otherEvents) {
+
+    public static final String INSTANCE_TOKEN = "{instance}";
+
+    public static ControlPlaneRouteCatalog empty() {
+        return new ControlPlaneRouteCatalog(Set.of(), Set.of(), Set.of(), Set.of(), Set.of(), Set.of());
+    }
+
+    public ControlPlaneRouteCatalog {
+        configSignals = copyOf(configSignals);
+        statusSignals = copyOf(statusSignals);
+        lifecycleSignals = copyOf(lifecycleSignals);
+        statusEvents = copyOf(statusEvents);
+        lifecycleEvents = copyOf(lifecycleEvents);
+        otherEvents = copyOf(otherEvents);
+    }
+
+    private static Set<String> copyOf(Set<String> source) {
+        if (source == null || source.isEmpty()) {
+            return Set.of();
+        }
+        return Set.copyOf(source);
+    }
+}

--- a/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/ControlPlaneTopologyDescriptor.java
+++ b/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/ControlPlaneTopologyDescriptor.java
@@ -1,0 +1,23 @@
+package io.pockethive.controlplane.topology;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Describes the queues and bindings required for a control-plane participant.
+ */
+public interface ControlPlaneTopologyDescriptor {
+
+    String role();
+
+    Optional<ControlQueueDescriptor> controlQueue(String instanceId);
+
+    default Collection<QueueDescriptor> additionalQueues(String instanceId) {
+        Objects.requireNonNull(instanceId, "instanceId");
+        return List.of();
+    }
+
+    ControlPlaneRouteCatalog routes();
+}

--- a/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/ControlQueueDescriptor.java
+++ b/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/ControlQueueDescriptor.java
@@ -1,0 +1,34 @@
+package io.pockethive.controlplane.topology;
+
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Control-queue declaration paired with the signal and event bindings it requires.
+ */
+public record ControlQueueDescriptor(String name,
+                                     Set<String> signalBindings,
+                                     Set<String> eventBindings) {
+
+    public ControlQueueDescriptor {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("name must not be blank");
+        }
+        signalBindings = copyOf(signalBindings);
+        eventBindings = copyOf(eventBindings);
+    }
+
+    public Set<String> allBindings() {
+        LinkedHashSet<String> merged = new LinkedHashSet<>(signalBindings);
+        merged.addAll(eventBindings);
+        return Set.copyOf(merged);
+    }
+
+    private static Set<String> copyOf(Set<String> source) {
+        if (source == null || source.isEmpty()) {
+            return Set.of();
+        }
+        return Set.copyOf(source);
+    }
+}

--- a/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/GeneratorControlPlaneTopologyDescriptor.java
+++ b/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/GeneratorControlPlaneTopologyDescriptor.java
@@ -1,0 +1,8 @@
+package io.pockethive.controlplane.topology;
+
+public final class GeneratorControlPlaneTopologyDescriptor extends AbstractWorkerTopologyDescriptor {
+
+    public GeneratorControlPlaneTopologyDescriptor() {
+        super("generator");
+    }
+}

--- a/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/ModeratorControlPlaneTopologyDescriptor.java
+++ b/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/ModeratorControlPlaneTopologyDescriptor.java
@@ -1,0 +1,11 @@
+package io.pockethive.controlplane.topology;
+
+import io.pockethive.Topology;
+import java.util.Set;
+
+public final class ModeratorControlPlaneTopologyDescriptor extends AbstractWorkerTopologyDescriptor {
+
+    public ModeratorControlPlaneTopologyDescriptor() {
+        super("moderator", new QueueDescriptor(Topology.GEN_QUEUE, Set.of(Topology.GEN_QUEUE)));
+    }
+}

--- a/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/OrchestratorControlPlaneTopologyDescriptor.java
+++ b/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/OrchestratorControlPlaneTopologyDescriptor.java
@@ -1,0 +1,72 @@
+package io.pockethive.controlplane.topology;
+
+import io.pockethive.Topology;
+import io.pockethive.control.ConfirmationScope;
+import io.pockethive.controlplane.routing.ControlPlaneRouting;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+public final class OrchestratorControlPlaneTopologyDescriptor implements ControlPlaneTopologyDescriptor {
+
+    private static final String ROLE = "orchestrator";
+
+    @Override
+    public String role() {
+        return ROLE;
+    }
+
+    @Override
+    public Optional<ControlQueueDescriptor> controlQueue(String instanceId) {
+        String id = requireInstanceId(instanceId);
+        String queueName = Topology.CONTROL_QUEUE + "." + ROLE + "." + id;
+        Set<String> readyErrorEvents = Set.of(
+            lifecycleEventPattern("ready"),
+            lifecycleEventPattern("error")
+        );
+        return Optional.of(new ControlQueueDescriptor(queueName, Set.of(), readyErrorEvents));
+    }
+
+    @Override
+    public Collection<QueueDescriptor> additionalQueues(String instanceId) {
+        String id = requireInstanceId(instanceId);
+        String queueName = Topology.CONTROL_QUEUE + ".orchestrator-status." + id;
+        Set<String> bindings = Set.of(
+            controllerStatusPattern("status-full"),
+            controllerStatusPattern("status-delta")
+        );
+        return List.of(new QueueDescriptor(queueName, bindings));
+    }
+
+    @Override
+    public ControlPlaneRouteCatalog routes() {
+        Set<String> lifecycleEvents = Set.of(
+            lifecycleEventPattern("ready"),
+            lifecycleEventPattern("error")
+        );
+        Set<String> statusEvents = Set.of(
+            controllerStatusPattern("status-full"),
+            controllerStatusPattern("status-delta")
+        );
+        return new ControlPlaneRouteCatalog(Set.of(), Set.of(), Set.of(), statusEvents, lifecycleEvents, Set.of());
+    }
+
+    private static String lifecycleEventPattern(String type) {
+        String base = ControlPlaneRouting.event(type, ConfirmationScope.EMPTY);
+        return base.replace(".ALL.ALL.ALL", ".#");
+    }
+
+    private static String controllerStatusPattern(String type) {
+        ConfirmationScope scope = new ConfirmationScope(null, "swarm-controller", "*");
+        String base = ControlPlaneRouting.event(type, scope);
+        return base.replace(".ALL.swarm-controller", ".swarm-controller");
+    }
+
+    private static String requireInstanceId(String instanceId) {
+        if (instanceId == null || instanceId.isBlank()) {
+            throw new IllegalArgumentException("instanceId must not be blank");
+        }
+        return instanceId;
+    }
+}

--- a/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/PostProcessorControlPlaneTopologyDescriptor.java
+++ b/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/PostProcessorControlPlaneTopologyDescriptor.java
@@ -1,0 +1,11 @@
+package io.pockethive.controlplane.topology;
+
+import io.pockethive.Topology;
+import java.util.Set;
+
+public final class PostProcessorControlPlaneTopologyDescriptor extends AbstractWorkerTopologyDescriptor {
+
+    public PostProcessorControlPlaneTopologyDescriptor() {
+        super("postprocessor", new QueueDescriptor(Topology.FINAL_QUEUE, Set.of(Topology.FINAL_QUEUE)));
+    }
+}

--- a/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/ProcessorControlPlaneTopologyDescriptor.java
+++ b/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/ProcessorControlPlaneTopologyDescriptor.java
@@ -1,0 +1,11 @@
+package io.pockethive.controlplane.topology;
+
+import io.pockethive.Topology;
+import java.util.Set;
+
+public final class ProcessorControlPlaneTopologyDescriptor extends AbstractWorkerTopologyDescriptor {
+
+    public ProcessorControlPlaneTopologyDescriptor() {
+        super("processor", new QueueDescriptor(Topology.MOD_QUEUE, Set.of(Topology.MOD_QUEUE)));
+    }
+}

--- a/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/QueueDescriptor.java
+++ b/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/QueueDescriptor.java
@@ -1,0 +1,16 @@
+package io.pockethive.controlplane.topology;
+
+import java.util.Set;
+
+/**
+ * Describes a queue and the binding keys required to attach it to an exchange.
+ */
+public record QueueDescriptor(String name, Set<String> bindings) {
+
+    public QueueDescriptor {
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("name must not be blank");
+        }
+        bindings = bindings == null || bindings.isEmpty() ? Set.of() : Set.copyOf(bindings);
+    }
+}

--- a/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/ScenarioManagerTopologyDescriptor.java
+++ b/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/ScenarioManagerTopologyDescriptor.java
@@ -1,0 +1,25 @@
+package io.pockethive.controlplane.topology;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public final class ScenarioManagerTopologyDescriptor implements ControlPlaneTopologyDescriptor {
+
+    private static final String ROLE = "scenario-manager";
+
+    @Override
+    public String role() {
+        return ROLE;
+    }
+
+    @Override
+    public Optional<ControlQueueDescriptor> controlQueue(String instanceId) {
+        Objects.requireNonNull(instanceId, "instanceId");
+        return Optional.empty();
+    }
+
+    @Override
+    public ControlPlaneRouteCatalog routes() {
+        return ControlPlaneRouteCatalog.empty();
+    }
+}

--- a/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/SwarmControllerControlPlaneTopologyDescriptor.java
+++ b/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/SwarmControllerControlPlaneTopologyDescriptor.java
@@ -1,0 +1,81 @@
+package io.pockethive.controlplane.topology;
+
+import io.pockethive.Topology;
+import io.pockethive.control.ConfirmationScope;
+import io.pockethive.controlplane.routing.ControlPlaneRouting;
+import java.util.LinkedHashSet;
+import java.util.Optional;
+import java.util.Set;
+
+public final class SwarmControllerControlPlaneTopologyDescriptor implements ControlPlaneTopologyDescriptor {
+
+    private static final String ROLE = "swarm-controller";
+
+    @Override
+    public String role() {
+        return ROLE;
+    }
+
+    @Override
+    public Optional<ControlQueueDescriptor> controlQueue(String instanceId) {
+        String id = requireInstanceId(instanceId);
+        String queueName = Topology.CONTROL_QUEUE + "." + ROLE + "." + id;
+        LinkedHashSet<String> signals = new LinkedHashSet<>();
+        signals.add(ControlPlaneRouting.signal("swarm-start", Topology.SWARM_ID, ROLE, "ALL"));
+        signals.add(ControlPlaneRouting.signal("swarm-template", Topology.SWARM_ID, ROLE, "ALL"));
+        signals.add(ControlPlaneRouting.signal("swarm-stop", Topology.SWARM_ID, ROLE, "ALL"));
+        signals.add(ControlPlaneRouting.signal("swarm-remove", Topology.SWARM_ID, ROLE, "ALL"));
+        signals.add(ControlPlaneRouting.signal("config-update", Topology.SWARM_ID, ROLE, "ALL"));
+        signals.add(ControlPlaneRouting.signal("config-update", Topology.SWARM_ID, ROLE, id));
+        signals.add(ControlPlaneRouting.signal("config-update", Topology.SWARM_ID, "ALL", "ALL"));
+        signals.add(ControlPlaneRouting.signal("config-update", "ALL", ROLE, "ALL"));
+        signals.add(ControlPlaneRouting.signal("status-request", Topology.SWARM_ID, ROLE, "ALL"));
+        signals.add(ControlPlaneRouting.signal("status-request", Topology.SWARM_ID, "ALL", "ALL"));
+        signals.add(ControlPlaneRouting.signal("status-request", Topology.SWARM_ID, ROLE, id));
+        signals.add(ControlPlaneRouting.signal("status-request", "ALL", ROLE, "ALL"));
+        Set<String> events = Set.of(
+            statusEventPattern("status-full"),
+            statusEventPattern("status-delta")
+        );
+        return Optional.of(new ControlQueueDescriptor(queueName, signals, events));
+    }
+
+    @Override
+    public ControlPlaneRouteCatalog routes() {
+        Set<String> configRoutes = Set.of(
+            ControlPlaneRouting.signal("config-update", "ALL", ROLE, "ALL"),
+            ControlPlaneRouting.signal("config-update", Topology.SWARM_ID, ROLE, "ALL"),
+            ControlPlaneRouting.signal("config-update", Topology.SWARM_ID, ROLE, ControlPlaneRouteCatalog.INSTANCE_TOKEN),
+            ControlPlaneRouting.signal("config-update", Topology.SWARM_ID, "ALL", "ALL")
+        );
+        Set<String> statusRoutes = Set.of(
+            ControlPlaneRouting.signal("status-request", "ALL", ROLE, "ALL"),
+            ControlPlaneRouting.signal("status-request", Topology.SWARM_ID, ROLE, "ALL"),
+            ControlPlaneRouting.signal("status-request", Topology.SWARM_ID, ROLE, ControlPlaneRouteCatalog.INSTANCE_TOKEN),
+            ControlPlaneRouting.signal("status-request", Topology.SWARM_ID, "ALL", "ALL")
+        );
+        Set<String> lifecycleRoutes = Set.of(
+            ControlPlaneRouting.signal("swarm-start", Topology.SWARM_ID, ROLE, "ALL"),
+            ControlPlaneRouting.signal("swarm-template", Topology.SWARM_ID, ROLE, "ALL"),
+            ControlPlaneRouting.signal("swarm-stop", Topology.SWARM_ID, ROLE, "ALL"),
+            ControlPlaneRouting.signal("swarm-remove", Topology.SWARM_ID, ROLE, "ALL")
+        );
+        Set<String> statusEvents = Set.of(
+            statusEventPattern("status-full"),
+            statusEventPattern("status-delta")
+        );
+        return new ControlPlaneRouteCatalog(configRoutes, statusRoutes, lifecycleRoutes, statusEvents, Set.of(), Set.of());
+    }
+
+    private static String statusEventPattern(String type) {
+        String base = ControlPlaneRouting.event(type, ConfirmationScope.forSwarm(Topology.SWARM_ID));
+        return base.replace(".ALL.ALL", ".#");
+    }
+
+    private static String requireInstanceId(String instanceId) {
+        if (instanceId == null || instanceId.isBlank()) {
+            throw new IllegalArgumentException("instanceId must not be blank");
+        }
+        return instanceId;
+    }
+}

--- a/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/TriggerControlPlaneTopologyDescriptor.java
+++ b/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/TriggerControlPlaneTopologyDescriptor.java
@@ -1,0 +1,8 @@
+package io.pockethive.controlplane.topology;
+
+public final class TriggerControlPlaneTopologyDescriptor extends AbstractWorkerTopologyDescriptor {
+
+    public TriggerControlPlaneTopologyDescriptor() {
+        super("trigger");
+    }
+}

--- a/common/control-plane-core/src/test/java/io/pockethive/controlplane/topology/ControlPlaneTopologyDescriptorsTest.java
+++ b/common/control-plane-core/src/test/java/io/pockethive/controlplane/topology/ControlPlaneTopologyDescriptorsTest.java
@@ -1,0 +1,204 @@
+package io.pockethive.controlplane.topology;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.pockethive.Topology;
+import io.pockethive.controlplane.routing.ControlPlaneRouting;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ControlPlaneTopologyDescriptorsTest {
+
+    private static final String INSTANCE = "inst";
+
+    @Test
+    void processorDescriptorMatchesRabbitConfig() {
+        ProcessorControlPlaneTopologyDescriptor descriptor = new ProcessorControlPlaneTopologyDescriptor();
+
+        ControlQueueDescriptor queue = requireQueue(descriptor);
+        assertThat(queue.name())
+            .isEqualTo(Topology.CONTROL_QUEUE + "." + Topology.SWARM_ID + ".processor." + INSTANCE);
+        assertThat(queue.signalBindings())
+            .containsExactlyInAnyOrderElementsOf(expectedWorkerSignals("processor", INSTANCE));
+        assertThat(queue.eventBindings()).isEmpty();
+        assertThat(descriptor.additionalQueues(INSTANCE))
+            .containsExactly(new QueueDescriptor(Topology.MOD_QUEUE, Set.of(Topology.MOD_QUEUE)));
+
+        ControlPlaneRouteCatalog routes = descriptor.routes();
+        assertThat(routes.configSignals())
+            .containsExactlyInAnyOrderElementsOf(expectedWorkerConfigSignals("processor", ControlPlaneRouteCatalog.INSTANCE_TOKEN));
+        assertThat(routes.statusSignals())
+            .containsExactlyInAnyOrderElementsOf(expectedWorkerStatusSignals("processor", ControlPlaneRouteCatalog.INSTANCE_TOKEN));
+    }
+
+    @Test
+    void generatorDescriptorMatchesRabbitConfig() {
+        GeneratorControlPlaneTopologyDescriptor descriptor = new GeneratorControlPlaneTopologyDescriptor();
+
+        ControlQueueDescriptor queue = requireQueue(descriptor);
+        assertThat(queue.name())
+            .isEqualTo(Topology.CONTROL_QUEUE + "." + Topology.SWARM_ID + ".generator." + INSTANCE);
+        assertThat(queue.signalBindings())
+            .containsExactlyInAnyOrderElementsOf(expectedWorkerSignals("generator", INSTANCE));
+        assertThat(queue.eventBindings()).isEmpty();
+        assertThat(descriptor.additionalQueues(INSTANCE)).isEmpty();
+    }
+
+    @Test
+    void triggerDescriptorMatchesRabbitConfig() {
+        TriggerControlPlaneTopologyDescriptor descriptor = new TriggerControlPlaneTopologyDescriptor();
+
+        ControlQueueDescriptor queue = requireQueue(descriptor);
+        assertThat(queue.name())
+            .isEqualTo(Topology.CONTROL_QUEUE + "." + Topology.SWARM_ID + ".trigger." + INSTANCE);
+        assertThat(queue.signalBindings())
+            .containsExactlyInAnyOrderElementsOf(expectedWorkerSignals("trigger", INSTANCE));
+        assertThat(queue.eventBindings()).isEmpty();
+        assertThat(descriptor.additionalQueues(INSTANCE)).isEmpty();
+    }
+
+    @Test
+    void moderatorDescriptorMatchesRabbitConfig() {
+        ModeratorControlPlaneTopologyDescriptor descriptor = new ModeratorControlPlaneTopologyDescriptor();
+
+        ControlQueueDescriptor queue = requireQueue(descriptor);
+        assertThat(queue.name())
+            .isEqualTo(Topology.CONTROL_QUEUE + "." + Topology.SWARM_ID + ".moderator." + INSTANCE);
+        assertThat(queue.signalBindings())
+            .containsExactlyInAnyOrderElementsOf(expectedWorkerSignals("moderator", INSTANCE));
+        assertThat(queue.eventBindings()).isEmpty();
+        assertThat(descriptor.additionalQueues(INSTANCE))
+            .containsExactly(new QueueDescriptor(Topology.GEN_QUEUE, Set.of(Topology.GEN_QUEUE)));
+    }
+
+    @Test
+    void postProcessorDescriptorMatchesRabbitConfig() {
+        PostProcessorControlPlaneTopologyDescriptor descriptor = new PostProcessorControlPlaneTopologyDescriptor();
+
+        ControlQueueDescriptor queue = requireQueue(descriptor);
+        assertThat(queue.name())
+            .isEqualTo(Topology.CONTROL_QUEUE + "." + Topology.SWARM_ID + ".postprocessor." + INSTANCE);
+        assertThat(queue.signalBindings())
+            .containsExactlyInAnyOrderElementsOf(expectedWorkerSignals("postprocessor", INSTANCE));
+        assertThat(queue.eventBindings()).isEmpty();
+        assertThat(descriptor.additionalQueues(INSTANCE))
+            .containsExactly(new QueueDescriptor(Topology.FINAL_QUEUE, Set.of(Topology.FINAL_QUEUE)));
+    }
+
+    @Test
+    void swarmControllerDescriptorMatchesRabbitConfig() {
+        SwarmControllerControlPlaneTopologyDescriptor descriptor = new SwarmControllerControlPlaneTopologyDescriptor();
+
+        ControlQueueDescriptor queue = requireQueue(descriptor);
+        assertThat(queue.name())
+            .isEqualTo(Topology.CONTROL_QUEUE + ".swarm-controller." + INSTANCE);
+        assertThat(queue.signalBindings())
+            .containsExactlyInAnyOrderElementsOf(expectedSwarmControllerSignals(INSTANCE));
+        assertThat(queue.eventBindings())
+            .containsExactlyInAnyOrder("ev.status-full." + Topology.SWARM_ID + ".#", "ev.status-delta." + Topology.SWARM_ID + ".#");
+
+        ControlPlaneRouteCatalog routes = descriptor.routes();
+        assertThat(routes.configSignals())
+            .containsExactlyInAnyOrderElementsOf(expectedSwarmControllerConfigSignals(ControlPlaneRouteCatalog.INSTANCE_TOKEN));
+        assertThat(routes.statusSignals())
+            .containsExactlyInAnyOrderElementsOf(expectedSwarmControllerStatusSignals(ControlPlaneRouteCatalog.INSTANCE_TOKEN));
+        assertThat(routes.lifecycleSignals())
+            .containsExactlyInAnyOrder(
+                ControlPlaneRouting.signal("swarm-start", Topology.SWARM_ID, "swarm-controller", "ALL"),
+                ControlPlaneRouting.signal("swarm-template", Topology.SWARM_ID, "swarm-controller", "ALL"),
+                ControlPlaneRouting.signal("swarm-stop", Topology.SWARM_ID, "swarm-controller", "ALL"),
+                ControlPlaneRouting.signal("swarm-remove", Topology.SWARM_ID, "swarm-controller", "ALL"));
+        assertThat(routes.statusEvents())
+            .containsExactlyInAnyOrder("ev.status-full." + Topology.SWARM_ID + ".#", "ev.status-delta." + Topology.SWARM_ID + ".#");
+    }
+
+    @Test
+    void orchestratorDescriptorMatchesRabbitConfig() {
+        OrchestratorControlPlaneTopologyDescriptor descriptor = new OrchestratorControlPlaneTopologyDescriptor();
+
+        ControlQueueDescriptor queue = requireQueue(descriptor);
+        assertThat(queue.name())
+            .isEqualTo(Topology.CONTROL_QUEUE + ".orchestrator." + INSTANCE);
+        assertThat(queue.signalBindings()).isEmpty();
+        assertThat(queue.eventBindings())
+            .containsExactlyInAnyOrder("ev.ready.#", "ev.error.#");
+
+        Collection<QueueDescriptor> additional = descriptor.additionalQueues(INSTANCE);
+        assertThat(additional)
+            .containsExactly(new QueueDescriptor(
+                Topology.CONTROL_QUEUE + ".orchestrator-status." + INSTANCE,
+                Set.of("ev.status-full.swarm-controller.*", "ev.status-delta.swarm-controller.*")));
+
+        ControlPlaneRouteCatalog routes = descriptor.routes();
+        assertThat(routes.lifecycleEvents())
+            .containsExactlyInAnyOrder("ev.ready.#", "ev.error.#");
+        assertThat(routes.statusEvents())
+            .containsExactlyInAnyOrder("ev.status-full.swarm-controller.*", "ev.status-delta.swarm-controller.*");
+    }
+
+    @Test
+    void scenarioManagerDescriptorDeclaresNoTopology() {
+        ScenarioManagerTopologyDescriptor descriptor = new ScenarioManagerTopologyDescriptor();
+
+        assertThat(descriptor.controlQueue(INSTANCE)).isEmpty();
+        assertThat(descriptor.additionalQueues(INSTANCE)).isEmpty();
+        assertThat(descriptor.routes()).isEqualTo(ControlPlaneRouteCatalog.empty());
+    }
+
+    private static ControlQueueDescriptor requireQueue(ControlPlaneTopologyDescriptor descriptor) {
+        return descriptor.controlQueue(INSTANCE).orElseThrow();
+    }
+
+    private static Set<String> expectedWorkerSignals(String role, String instanceSegment) {
+        LinkedHashSet<String> merged = new LinkedHashSet<>(expectedWorkerConfigSignals(role, instanceSegment));
+        merged.addAll(expectedWorkerStatusSignals(role, instanceSegment));
+        return Set.copyOf(merged);
+    }
+
+    private static Set<String> expectedWorkerConfigSignals(String role, String instanceSegment) {
+        return Set.of(
+            ControlPlaneRouting.signal("config-update", "ALL", role, "ALL"),
+            ControlPlaneRouting.signal("config-update", Topology.SWARM_ID, role, "ALL"),
+            ControlPlaneRouting.signal("config-update", Topology.SWARM_ID, role, instanceSegment),
+            ControlPlaneRouting.signal("config-update", Topology.SWARM_ID, "ALL", "ALL")
+        );
+    }
+
+    private static Set<String> expectedWorkerStatusSignals(String role, String instanceSegment) {
+        return Set.of(
+            ControlPlaneRouting.signal("status-request", "ALL", role, "ALL"),
+            ControlPlaneRouting.signal("status-request", Topology.SWARM_ID, role, "ALL"),
+            ControlPlaneRouting.signal("status-request", Topology.SWARM_ID, role, instanceSegment)
+        );
+    }
+
+    private static Set<String> expectedSwarmControllerSignals(String instanceSegment) {
+        LinkedHashSet<String> merged = new LinkedHashSet<>(expectedSwarmControllerConfigSignals(instanceSegment));
+        merged.addAll(expectedSwarmControllerStatusSignals(instanceSegment));
+        merged.add(ControlPlaneRouting.signal("swarm-start", Topology.SWARM_ID, "swarm-controller", "ALL"));
+        merged.add(ControlPlaneRouting.signal("swarm-template", Topology.SWARM_ID, "swarm-controller", "ALL"));
+        merged.add(ControlPlaneRouting.signal("swarm-stop", Topology.SWARM_ID, "swarm-controller", "ALL"));
+        merged.add(ControlPlaneRouting.signal("swarm-remove", Topology.SWARM_ID, "swarm-controller", "ALL"));
+        return Set.copyOf(merged);
+    }
+
+    private static Set<String> expectedSwarmControllerConfigSignals(String instanceSegment) {
+        return Set.of(
+            ControlPlaneRouting.signal("config-update", "ALL", "swarm-controller", "ALL"),
+            ControlPlaneRouting.signal("config-update", Topology.SWARM_ID, "swarm-controller", "ALL"),
+            ControlPlaneRouting.signal("config-update", Topology.SWARM_ID, "swarm-controller", instanceSegment),
+            ControlPlaneRouting.signal("config-update", Topology.SWARM_ID, "ALL", "ALL")
+        );
+    }
+
+    private static Set<String> expectedSwarmControllerStatusSignals(String instanceSegment) {
+        return Set.of(
+            ControlPlaneRouting.signal("status-request", "ALL", "swarm-controller", "ALL"),
+            ControlPlaneRouting.signal("status-request", Topology.SWARM_ID, "swarm-controller", "ALL"),
+            ControlPlaneRouting.signal("status-request", Topology.SWARM_ID, "swarm-controller", instanceSegment),
+            ControlPlaneRouting.signal("status-request", Topology.SWARM_ID, "ALL", "ALL")
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add control-plane topology descriptor interfaces with route catalogs
- provide worker and manager descriptor implementations reproducing existing queues and bindings
- add contract tests locking descriptor output to legacy RabbitConfig bindings

## Testing
- mvn -pl common/control-plane-core test

------
https://chatgpt.com/codex/tasks/task_e_68dab260f8348328b98af724ce4eb264