### PR TITLE
feat: add control-plane payload factories and contract tests

### DIFF
--- a/common/control-plane-core/pom.xml
+++ b/common/control-plane-core/pom.xml
@@ -33,6 +33,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>io.pockethive</groupId>
+      <artifactId>observability</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.amqp</groupId>
       <artifactId>spring-rabbit</artifactId>
       <version>${spring.amqp.version}</version>
@@ -40,6 +45,11 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
       <version>${jackson.version}</version>
     </dependency>
     <dependency>

--- a/common/control-plane-core/src/main/java/io/pockethive/controlplane/payload/ConfirmationPayloadFactory.java
+++ b/common/control-plane-core/src/main/java/io/pockethive/controlplane/payload/ConfirmationPayloadFactory.java
@@ -1,0 +1,241 @@
+package io.pockethive.controlplane.payload;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import io.pockethive.control.CommandState;
+import io.pockethive.control.ErrorConfirmation;
+import io.pockethive.control.ReadyConfirmation;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Factory that materialises ready and error confirmations with shared scope metadata.
+ */
+public final class ConfirmationPayloadFactory {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+        .findAndRegisterModules()
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    private final ScopeContext context;
+    private final Clock clock;
+
+    public ConfirmationPayloadFactory(ScopeContext context) {
+        this(context, Clock.systemUTC());
+    }
+
+    ConfirmationPayloadFactory(ScopeContext context, Clock clock) {
+        this.context = Objects.requireNonNull(context, "context");
+        this.clock = Objects.requireNonNull(clock, "clock");
+    }
+
+    public ReadyBuilder ready(String signal) {
+        return new ReadyBuilder(signal);
+    }
+
+    public ErrorBuilder error(String signal) {
+        return new ErrorBuilder(signal);
+    }
+
+    private abstract class AbstractBuilder<T extends AbstractBuilder<T>> {
+
+        private final String signal;
+        private String correlationId;
+        private String idempotencyKey;
+        private CommandState state;
+        private Instant timestamp;
+
+        private AbstractBuilder(String signal) {
+            this.signal = requireNonBlank("signal", signal);
+        }
+
+        public T correlationId(String correlationId) {
+            this.correlationId = requireNonBlank("correlationId", correlationId);
+            return self();
+        }
+
+        public T idempotencyKey(String idempotencyKey) {
+            this.idempotencyKey = requireNonBlank("idempotencyKey", idempotencyKey);
+            return self();
+        }
+
+        public T state(CommandState state) {
+            this.state = Objects.requireNonNull(state, "state");
+            return self();
+        }
+
+        public T timestamp(Instant timestamp) {
+            this.timestamp = Objects.requireNonNull(timestamp, "timestamp");
+            return self();
+        }
+
+        protected Instant resolveTimestamp() {
+            return timestamp != null ? timestamp : clock.instant();
+        }
+
+        protected String signal() {
+            return signal;
+        }
+
+        protected String correlationId() {
+            if (correlationId == null) {
+                throw new IllegalStateException("correlationId must be provided");
+            }
+            return correlationId;
+        }
+
+        protected String idempotencyKey() {
+            if (idempotencyKey == null) {
+                throw new IllegalStateException("idempotencyKey must be provided");
+            }
+            return idempotencyKey;
+        }
+
+        protected CommandState state() {
+            if (state == null) {
+                throw new IllegalStateException("state must be provided");
+            }
+            return state;
+        }
+
+        protected ScopeContext context() {
+            return context;
+        }
+
+        protected abstract T self();
+    }
+
+    public final class ReadyBuilder extends AbstractBuilder<ReadyBuilder> {
+
+        private String result;
+        private Map<String, Object> details = Collections.emptyMap();
+
+        private ReadyBuilder(String signal) {
+            super(signal);
+        }
+
+        public ReadyBuilder result(String result) {
+            this.result = result;
+            return this;
+        }
+
+        public ReadyBuilder details(Map<String, Object> details) {
+            this.details = Objects.requireNonNull(details, "details");
+            return this;
+        }
+
+        public String build() {
+            ReadyConfirmation confirmation = new ReadyConfirmation(
+                resolveTimestamp(),
+                correlationId(),
+                idempotencyKey(),
+                signal(),
+                context().scope(),
+                result,
+                state(),
+                details.isEmpty() ? null : details
+            );
+            return toJson(confirmation);
+        }
+
+        @Override
+        protected ReadyBuilder self() {
+            return this;
+        }
+    }
+
+    public final class ErrorBuilder extends AbstractBuilder<ErrorBuilder> {
+
+        private String result;
+        private String phase;
+        private String code;
+        private String message;
+        private Boolean retryable;
+        private Map<String, Object> details = Collections.emptyMap();
+
+        private ErrorBuilder(String signal) {
+            super(signal);
+        }
+
+        public ErrorBuilder result(String result) {
+            this.result = result;
+            return this;
+        }
+
+        public ErrorBuilder phase(String phase) {
+            this.phase = requireNonBlank("phase", phase);
+            return this;
+        }
+
+        public ErrorBuilder code(String code) {
+            this.code = requireNonBlank("code", code);
+            return this;
+        }
+
+        public ErrorBuilder message(String message) {
+            this.message = requireNonBlank("message", message);
+            return this;
+        }
+
+        public ErrorBuilder retryable(Boolean retryable) {
+            this.retryable = Objects.requireNonNull(retryable, "retryable");
+            return this;
+        }
+
+        public ErrorBuilder details(Map<String, Object> details) {
+            this.details = Objects.requireNonNull(details, "details");
+            return this;
+        }
+
+        public String build() {
+            if (phase == null) {
+                throw new IllegalStateException("phase must be provided");
+            }
+            if (code == null) {
+                throw new IllegalStateException("code must be provided");
+            }
+            if (message == null) {
+                throw new IllegalStateException("message must be provided");
+            }
+            ErrorConfirmation confirmation = new ErrorConfirmation(
+                resolveTimestamp(),
+                correlationId(),
+                idempotencyKey(),
+                signal(),
+                context().scope(),
+                result,
+                state(),
+                phase,
+                code,
+                message,
+                retryable,
+                details.isEmpty() ? null : details
+            );
+            return toJson(confirmation);
+        }
+
+        @Override
+        protected ErrorBuilder self() {
+            return this;
+        }
+    }
+
+    private static String requireNonBlank(String field, String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return value;
+    }
+
+    private static String toJson(Object value) {
+        try {
+            return MAPPER.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialise confirmation", e);
+        }
+    }
+}

--- a/common/control-plane-core/src/main/java/io/pockethive/controlplane/payload/RoleContext.java
+++ b/common/control-plane-core/src/main/java/io/pockethive/controlplane/payload/RoleContext.java
@@ -1,0 +1,32 @@
+package io.pockethive.controlplane.payload;
+
+import io.pockethive.control.ConfirmationScope;
+import java.util.Objects;
+
+/**
+ * Identifies the control-plane role emitting payloads.
+ */
+public record RoleContext(String swarmId, String role, String instanceId) {
+
+    public RoleContext {
+        swarmId = requireNonBlank("swarmId", swarmId);
+        role = requireNonBlank("role", role);
+        instanceId = requireNonBlank("instanceId", instanceId);
+    }
+
+    private static String requireNonBlank(String field, String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return value;
+    }
+
+    public ConfirmationScope toScope() {
+        return new ConfirmationScope(swarmId, role, instanceId);
+    }
+
+    public static RoleContext fromIdentity(io.pockethive.controlplane.ControlPlaneIdentity identity) {
+        Objects.requireNonNull(identity, "identity");
+        return new RoleContext(identity.swarmId(), identity.role(), identity.instanceId());
+    }
+}

--- a/common/control-plane-core/src/main/java/io/pockethive/controlplane/payload/ScopeContext.java
+++ b/common/control-plane-core/src/main/java/io/pockethive/controlplane/payload/ScopeContext.java
@@ -1,0 +1,23 @@
+package io.pockethive.controlplane.payload;
+
+import io.pockethive.control.ConfirmationScope;
+import java.util.Objects;
+
+/**
+ * Provides the confirmation scope for payload factories.
+ */
+public record ScopeContext(ConfirmationScope scope) {
+
+    public ScopeContext {
+        Objects.requireNonNull(scope, "scope");
+    }
+
+    public static ScopeContext of(ConfirmationScope scope) {
+        return new ScopeContext(scope);
+    }
+
+    public static ScopeContext fromRole(RoleContext role) {
+        Objects.requireNonNull(role, "role");
+        return new ScopeContext(role.toScope());
+    }
+}

--- a/common/control-plane-core/src/main/java/io/pockethive/controlplane/payload/StatusPayloadFactory.java
+++ b/common/control-plane-core/src/main/java/io/pockethive/controlplane/payload/StatusPayloadFactory.java
@@ -1,0 +1,43 @@
+package io.pockethive.controlplane.payload;
+
+import io.pockethive.observability.StatusEnvelopeBuilder;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Factory for producing control-plane status payloads with embedded role context.
+ */
+public final class StatusPayloadFactory {
+
+    private final RoleContext context;
+    private final Supplier<StatusEnvelopeBuilder> builderSupplier;
+
+    public StatusPayloadFactory(RoleContext context) {
+        this(context, StatusEnvelopeBuilder::new);
+    }
+
+    StatusPayloadFactory(RoleContext context, Supplier<StatusEnvelopeBuilder> builderSupplier) {
+        this.context = Objects.requireNonNull(context, "context");
+        this.builderSupplier = Objects.requireNonNull(builderSupplier, "builderSupplier");
+    }
+
+    public String snapshot(Consumer<StatusEnvelopeBuilder> customiser) {
+        return build("status-full", customiser);
+    }
+
+    public String delta(Consumer<StatusEnvelopeBuilder> customiser) {
+        return build("status-delta", customiser);
+    }
+
+    private String build(String kind, Consumer<StatusEnvelopeBuilder> customiser) {
+        Objects.requireNonNull(customiser, "customiser");
+        StatusEnvelopeBuilder builder = Objects.requireNonNull(builderSupplier.get(), "builder");
+        builder.kind(kind)
+            .role(context.role())
+            .instance(context.instanceId())
+            .swarmId(context.swarmId());
+        customiser.accept(builder);
+        return builder.toJson();
+    }
+}

--- a/common/control-plane-core/src/test/java/io/pockethive/controlplane/payload/ConfirmationPayloadFactoryTest.java
+++ b/common/control-plane-core/src/test/java/io/pockethive/controlplane/payload/ConfirmationPayloadFactoryTest.java
@@ -1,0 +1,49 @@
+package io.pockethive.controlplane.payload;
+
+import static io.pockethive.controlplane.payload.JsonFixtureAssertions.assertMatchesFixture;
+
+import io.pockethive.control.CommandState;
+import io.pockethive.control.ConfirmationScope;
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ConfirmationPayloadFactoryTest {
+
+    private static final Clock FIXED_CLOCK = Clock.fixed(Instant.parse("2024-01-02T03:04:05Z"), ZoneOffset.UTC);
+    private final ScopeContext scope = ScopeContext.of(new ConfirmationScope("swarm-1", "processor", "instance-7"));
+
+    @Test
+    void buildsReadyConfirmation() throws IOException {
+        ConfirmationPayloadFactory factory = new ConfirmationPayloadFactory(scope, FIXED_CLOCK);
+        String json = factory.ready("swarm-start")
+            .correlationId("corr-1")
+            .idempotencyKey("idem-1")
+            .state(new CommandState("Running", true, Map.of("tasks", 5)))
+            .result("success")
+            .details(Map.of("durationMs", 123))
+            .build();
+
+        assertMatchesFixture("/io/pockethive/controlplane/payload/ready-confirmation.json", json);
+    }
+
+    @Test
+    void buildsErrorConfirmation() throws IOException {
+        ConfirmationPayloadFactory factory = new ConfirmationPayloadFactory(scope, FIXED_CLOCK);
+        String json = factory.error("swarm-stop")
+            .correlationId("corr-2")
+            .idempotencyKey("idem-2")
+            .state(CommandState.status("Failed"))
+            .phase("shutdown")
+            .code("ERR-42")
+            .message("Something went wrong")
+            .retryable(Boolean.FALSE)
+            .details(Map.of("stack", "trace"))
+            .build();
+
+        assertMatchesFixture("/io/pockethive/controlplane/payload/error-confirmation.json", json);
+    }
+}

--- a/common/control-plane-core/src/test/java/io/pockethive/controlplane/payload/JsonFixtureAssertions.java
+++ b/common/control-plane-core/src/test/java/io/pockethive/controlplane/payload/JsonFixtureAssertions.java
@@ -1,0 +1,60 @@
+package io.pockethive.controlplane.payload;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.Map.Entry;
+
+final class JsonFixtureAssertions {
+
+    static final String ANY_VALUE = "<<ANY>>";
+    private static final ObjectMapper MAPPER = new ObjectMapper().findAndRegisterModules();
+
+    private JsonFixtureAssertions() {
+    }
+
+    static void assertMatchesFixture(String fixtureName, String json) throws IOException {
+        try (InputStream input = JsonFixtureAssertions.class.getResourceAsStream(fixtureName)) {
+            assertNotNull(input, () -> "Missing fixture " + fixtureName);
+            JsonNode expected = MAPPER.readTree(input);
+            JsonNode actual = MAPPER.readTree(json);
+            assertNode(expected, actual, fixtureName);
+        }
+    }
+
+    private static void assertNode(JsonNode expected, JsonNode actual, String path) {
+        if (expected.isTextual() && ANY_VALUE.equals(expected.textValue())) {
+            return;
+        }
+        assertEquals(expected.getNodeType(), actual.getNodeType(), () -> "Type mismatch at " + path);
+        switch (expected.getNodeType()) {
+            case OBJECT -> assertObject(expected, actual, path);
+            case ARRAY -> assertArray(expected, actual, path);
+            default -> assertEquals(expected, actual, () -> "Value mismatch at " + path);
+        }
+    }
+
+    private static void assertObject(JsonNode expected, JsonNode actual, String path) {
+        assertEquals(expected.size(), actual.size(), () -> "Field count mismatch at " + path + ": " + actual);
+        Iterator<Entry<String, JsonNode>> fields = expected.fields();
+        while (fields.hasNext()) {
+            Entry<String, JsonNode> entry = fields.next();
+            String childPath = path + "." + entry.getKey();
+            JsonNode actualChild = actual.get(entry.getKey());
+            assertNotNull(actualChild, () -> "Missing field " + childPath);
+            assertNode(entry.getValue(), actualChild, childPath);
+        }
+    }
+
+    private static void assertArray(JsonNode expected, JsonNode actual, String path) {
+        assertEquals(expected.size(), actual.size(), () -> "Array length mismatch at " + path);
+        for (int i = 0; i < expected.size(); i++) {
+            assertNode(expected.get(i), actual.get(i), path + "[" + i + "]");
+        }
+    }
+}

--- a/common/control-plane-core/src/test/java/io/pockethive/controlplane/payload/StatusPayloadFactoryTest.java
+++ b/common/control-plane-core/src/test/java/io/pockethive/controlplane/payload/StatusPayloadFactoryTest.java
@@ -1,0 +1,55 @@
+package io.pockethive.controlplane.payload;
+
+import static io.pockethive.controlplane.payload.JsonFixtureAssertions.ANY_VALUE;
+import static io.pockethive.controlplane.payload.JsonFixtureAssertions.assertMatchesFixture;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class StatusPayloadFactoryTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper().findAndRegisterModules();
+    private final RoleContext context = new RoleContext("swarm-1", "processor", "instance-7");
+
+    @Test
+    void buildsSnapshotPayload() throws IOException {
+        StatusPayloadFactory factory = new StatusPayloadFactory(context);
+        String json = factory.snapshot(builder -> builder
+            .traffic("ph.traffic")
+            .workIn("work.in")
+            .workRoutes("rk.work")
+            .workOut("rk.out")
+            .controlIn("ctrl.queue")
+            .controlRoutes("rk.ctrl")
+            .controlOut("rk.status")
+            .enabled(true)
+            .tps(42)
+            .watermark(Instant.parse("2024-01-01T00:00:00Z"))
+            .totals(3, 2, 2, 3)
+            .data("baseUrl", "https://example"));
+
+        assertMatchesFixture("/io/pockethive/controlplane/payload/status-snapshot.json", normalise(json));
+    }
+
+    @Test
+    void buildsDeltaPayload() throws IOException {
+        StatusPayloadFactory factory = new StatusPayloadFactory(context);
+        String json = factory.delta(builder -> builder
+            .controlOut("rk.status")
+            .enabled(false)
+            .tps(7));
+
+        assertMatchesFixture("/io/pockethive/controlplane/payload/status-delta.json", normalise(json));
+    }
+
+    private static String normalise(String json) throws IOException {
+        ObjectNode node = (ObjectNode) MAPPER.readTree(json);
+        node.put("messageId", ANY_VALUE);
+        node.put("timestamp", ANY_VALUE);
+        node.put("location", ANY_VALUE);
+        return MAPPER.writeValueAsString(node);
+    }
+}

--- a/common/control-plane-core/src/test/resources/io/pockethive/controlplane/payload/error-confirmation.json
+++ b/common/control-plane-core/src/test/resources/io/pockethive/controlplane/payload/error-confirmation.json
@@ -1,0 +1,24 @@
+{
+  "ts": "2024-01-02T03:04:05Z",
+  "correlationId": "corr-2",
+  "idempotencyKey": "idem-2",
+  "signal": "swarm-stop",
+  "scope": {
+    "swarmId": "swarm-1",
+    "role": "processor",
+    "instance": "instance-7"
+  },
+  "result": "error",
+  "state": {
+    "status": "Failed",
+    "enabled": null,
+    "details": null
+  },
+  "phase": "shutdown",
+  "code": "ERR-42",
+  "message": "Something went wrong",
+  "retryable": false,
+  "details": {
+    "stack": "trace"
+  }
+}

--- a/common/control-plane-core/src/test/resources/io/pockethive/controlplane/payload/ready-confirmation.json
+++ b/common/control-plane-core/src/test/resources/io/pockethive/controlplane/payload/ready-confirmation.json
@@ -1,0 +1,22 @@
+{
+  "ts": "2024-01-02T03:04:05Z",
+  "correlationId": "corr-1",
+  "idempotencyKey": "idem-1",
+  "signal": "swarm-start",
+  "scope": {
+    "swarmId": "swarm-1",
+    "role": "processor",
+    "instance": "instance-7"
+  },
+  "result": "success",
+  "state": {
+    "status": "Running",
+    "enabled": true,
+    "details": {
+      "tasks": 5
+    }
+  },
+  "details": {
+    "durationMs": 123
+  }
+}

--- a/common/control-plane-core/src/test/resources/io/pockethive/controlplane/payload/status-delta.json
+++ b/common/control-plane-core/src/test/resources/io/pockethive/controlplane/payload/status-delta.json
@@ -1,0 +1,22 @@
+{
+  "event": "status",
+  "version": "1.0",
+  "messageId": "<<ANY>>",
+  "timestamp": "<<ANY>>",
+  "location": "<<ANY>>",
+  "kind": "status-delta",
+  "role": "processor",
+  "instance": "instance-7",
+  "swarmId": "swarm-1",
+  "enabled": false,
+  "queues": {
+    "control": {
+      "out": [
+        "rk.status"
+      ]
+    }
+  },
+  "data": {
+    "tps": 7
+  }
+}

--- a/common/control-plane-core/src/test/resources/io/pockethive/controlplane/payload/status-snapshot.json
+++ b/common/control-plane-core/src/test/resources/io/pockethive/controlplane/payload/status-snapshot.json
@@ -1,0 +1,48 @@
+{
+  "event": "status",
+  "version": "1.0",
+  "messageId": "<<ANY>>",
+  "timestamp": "<<ANY>>",
+  "location": "<<ANY>>",
+  "kind": "status-full",
+  "role": "processor",
+  "instance": "instance-7",
+  "swarmId": "swarm-1",
+  "traffic": "ph.traffic",
+  "watermark": "2024-01-01T00:00:00Z",
+  "enabled": true,
+  "totals": {
+    "desired": 3,
+    "healthy": 2,
+    "running": 2,
+    "enabled": 3
+  },
+  "queues": {
+    "work": {
+      "in": [
+        "work.in"
+      ],
+      "routes": [
+        "rk.work"
+      ],
+      "out": [
+        "rk.out"
+      ]
+    },
+    "control": {
+      "in": [
+        "ctrl.queue"
+      ],
+      "routes": [
+        "rk.ctrl"
+      ],
+      "out": [
+        "rk.status"
+      ]
+    }
+  },
+  "data": {
+    "tps": 42,
+    "baseUrl": "https://example"
+  }
+}


### PR DESCRIPTION
## Summary
- add role/scope context records and factories for ready, error and status payloads in control-plane-core
- integrate the observability status envelope builder and Jackson time module support
- add JSON contract fixtures to lock down ready/error/status payload shapes

## Testing
- mvn -pl common/control-plane-core test

------
https://chatgpt.com/codex/tasks/task_e_68dab5c768ac83288531d17bddaf8c7d