### PR TITLE
feat: share shell providers and hooks with scenario remote

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -69,6 +69,17 @@ settings:
 Hosts can then import the module with `import('@ph/scenario/ScenarioApp')` and call the exported `mount` helper to render the
 Scenario Builder placeholder into a DOM node.
 
+### Shell integration and shared hooks
+
+PocketHive's host shell now centralises cross-cutting providers—such as UI configuration and shared state—in the
+`ShellProviders` component. Wrap both the host router and any remote mount points with this component to ensure the remote
+consumes the same React Query client, configuration context and future theme/auth providers as the host.
+
+Remote modules should import hooks and context accessors from the `@ph/shell` barrel. This guarantees a single instance of
+shared utilities like `useConfig` and `useUIStore` across host and remote bundles when Module Federation loads the remote at
+runtime. See `src/scenario/ScenarioApp.integration.test.tsx` for an example that asserts the remote receives the host-provided
+RabbitMQ/Prometheus endpoints and store state when rendered through the shell.
+
 ### Build
 
 Type‑checks the project and generates production assets in `dist/`:

--- a/ui/src/components/BuzzPanel.tsx
+++ b/ui/src/components/BuzzPanel.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
 import { PanelLeft, PanelRight, PanelBottom } from 'lucide-react'
+import { useConfig, useUIStore } from '@ph/shell'
+
 import { subscribeLogs, type LogEntry, type LogChannel, type LogSource } from '../lib/logs'
-import { useConfig } from '../lib/config'
-import { useUIStore } from '../store'
 
 function LogView({
   sourceFilter,

--- a/ui/src/components/Connectivity.tsx
+++ b/ui/src/components/Connectivity.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useRef, useState } from 'react'
 import { Plug, Square } from 'lucide-react'
 import { Client } from '@stomp/stompjs'
+import { getConfig, setConfig } from '@ph/shell'
+
 import { setClient as setStompClient } from '../lib/stompClient'
 import { logOther } from '../lib/logs'
-import { getConfig, setConfig } from '../lib/config'
 
 export default function Connectivity() {
   const [state, setState] = useState<'connected' | 'connecting' | 'disconnected'>('disconnected')

--- a/ui/src/layout/Layout.tsx
+++ b/ui/src/layout/Layout.tsx
@@ -1,13 +1,13 @@
 import { NavLink, Outlet } from 'react-router-dom'
 import { Hexagon, Radio, Droplet, Workflow } from 'lucide-react'
+import { useEffect } from 'react'
+import { PanelGroup, Panel, PanelResizeHandle } from 'react-resizable-panels'
+import { useConfig, useUIStore } from '@ph/shell'
+
 import MonolithIcon from '../icons/Monolith'
 import Health from '../components/Health'
 import Connectivity from '../components/Connectivity'
-import { useUIStore } from '../store'
-import { useEffect } from 'react'
-import { useConfig } from '../lib/config'
 import BuzzPanel from '../components/BuzzPanel'
-import { PanelGroup, Panel, PanelResizeHandle } from 'react-resizable-panels'
 
 export default function Layout() {
   const {

--- a/ui/src/lib/config.tsx
+++ b/ui/src/lib/config.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
 
 export type UIConfig = {
   rabbitmq: string
@@ -26,7 +26,7 @@ const config: UIConfig = {
   stompUrl: `/ws`,
   stompUser: readOnlyUser,
   stompPasscode: readOnlyPasscode,
-  stompSubscription: '/exchange/ph.control/ev.#',
+  stompSubscription: '/exchange/ph.control/ev.#'
 }
 
 type Listener = (cfg: UIConfig) => void
@@ -49,8 +49,16 @@ export function subscribeConfig(fn: Listener) {
   }
 }
 
-export function useConfig(): UIConfig {
+const ConfigContext = createContext<UIConfig>(config)
+
+export function ConfigProvider({ children }: { children: ReactNode }): JSX.Element {
   const [cfg, setCfg] = useState(config)
+
   useEffect(() => subscribeConfig(setCfg), [])
-  return cfg
+
+  return <ConfigContext.Provider value={cfg}>{children}</ConfigContext.Provider>
+}
+
+export function useConfig(): UIConfig {
+  return useContext(ConfigContext)
 }

--- a/ui/src/lib/logs.ts
+++ b/ui/src/lib/logs.ts
@@ -1,4 +1,4 @@
-import { useUIStore } from '../store'
+import { useUIStore } from '@ph/shell'
 
 export type LogSource = 'hive' | 'ui'
 export type LogChannel = 'stomp' | 'rest' | 'internal'

--- a/ui/src/lib/stompClient.test.ts
+++ b/ui/src/lib/stompClient.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { Client } from '@stomp/stompjs'
 import { setClient } from './stompClient'
 import { subscribeLogs, type LogEntry, resetLogs } from './logs'
-import { useUIStore } from '../store'
+import { useUIStore } from '@ph/shell'
 
 /**
  * @vitest-environment jsdom

--- a/ui/src/lib/stompClient.ts
+++ b/ui/src/lib/stompClient.ts
@@ -1,8 +1,9 @@
 import { Client, type StompSubscription } from '@stomp/stompjs'
 import type { Component } from '../types/hive'
 import { isControlEvent, type ControlEvent } from '../types/control'
+import { useUIStore } from '@ph/shell'
+
 import { logIn, logError } from './logs'
-import { useUIStore } from '../store'
 
 export type ComponentListener = (components: Component[]) => void
 export interface TopologyNode {

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,18 +1,19 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { QueryClient } from '@tanstack/react-query'
 import { BrowserRouter } from 'react-router-dom'
 import './styles/globals.css'
 import App from './App.tsx'
+import { ShellProviders } from '@ph/shell'
 
 const queryClient = new QueryClient()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
+    <BrowserRouter>
+      <ShellProviders queryClient={queryClient}>
         <App />
-      </BrowserRouter>
-    </QueryClientProvider>
-  </StrictMode>,
+      </ShellProviders>
+    </BrowserRouter>
+  </StrictMode>
 )

--- a/ui/src/scenario/ScenarioApp.integration.test.tsx
+++ b/ui/src/scenario/ScenarioApp.integration.test.tsx
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+
+import ScenarioApp from './ScenarioApp'
+import { ShellProviders, getConfig, setConfig, useUIStore } from '@ph/shell'
+
+describe('ScenarioApp shell integration', () => {
+  const snapshotConfig = () => ({ ...getConfig() })
+  let baselineConfig = snapshotConfig()
+
+  beforeEach(() => {
+    baselineConfig = snapshotConfig()
+    setConfig(baselineConfig)
+    useUIStore.setState({ messageLimit: 100 })
+  })
+
+  afterEach(() => {
+    cleanup()
+    setConfig(baselineConfig)
+    useUIStore.setState({ messageLimit: 100 })
+  })
+
+  it('reads configuration and store values from the host shell', () => {
+    setConfig({
+      rabbitmq: 'https://host.example/rabbitmq',
+      prometheus: 'https://host.example/prometheus',
+    })
+    useUIStore.setState({ messageLimit: 256 })
+
+    render(
+      <ShellProviders>
+        <ScenarioApp />
+      </ShellProviders>
+    )
+
+    expect(screen.getByTestId('config-rabbitmq')).toHaveTextContent('https://host.example/rabbitmq')
+    expect(screen.getByTestId('config-prometheus')).toHaveTextContent('https://host.example/prometheus')
+    expect(screen.getByTestId('ui-message-limit')).toHaveTextContent('256')
+  })
+})

--- a/ui/src/scenario/ScenarioApp.tsx
+++ b/ui/src/scenario/ScenarioApp.tsx
@@ -1,11 +1,45 @@
 import type { FC, ReactNode } from 'react'
+import { useConfig, useUIStore } from '@ph/shell'
 
 const Section: FC<{ title: string; description: ReactNode }> = ({ title, description }) => (
   <section className="space-y-2 rounded-lg border border-slate-800 bg-slate-900/60 p-6 shadow-sm">
     <h2 className="text-xl font-semibold text-slate-100">{title}</h2>
-    <p className="text-sm leading-relaxed text-slate-300">{description}</p>
+    <div className="text-sm leading-relaxed text-slate-300">{description}</div>
   </section>
 )
+
+const HostIntegration: FC = () => {
+  const config = useConfig()
+  const messageLimit = useUIStore((state) => state.messageLimit)
+
+  return (
+    <Section
+      title="Host Integration"
+      description={
+        <dl className="grid gap-2 text-left">
+          <div>
+            <dt className="font-medium text-slate-200">RabbitMQ endpoint</dt>
+            <dd data-testid="config-rabbitmq" className="font-mono text-xs text-amber-300">
+              {config.rabbitmq}
+            </dd>
+          </div>
+          <div>
+            <dt className="font-medium text-slate-200">Prometheus endpoint</dt>
+            <dd data-testid="config-prometheus" className="font-mono text-xs text-amber-300">
+              {config.prometheus}
+            </dd>
+          </div>
+          <div>
+            <dt className="font-medium text-slate-200">Active message limit</dt>
+            <dd data-testid="ui-message-limit" className="font-mono text-xs text-amber-300">
+              {messageLimit}
+            </dd>
+          </div>
+        </dl>
+      }
+    />
+  )
+}
 
 const ScenarioApp: FC = () => (
   <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-8 text-slate-100">
@@ -14,8 +48,8 @@ const ScenarioApp: FC = () => (
         <p className="text-sm uppercase tracking-[0.35em] text-amber-400">PocketHive Remote</p>
         <h1 className="text-4xl font-bold">Scenario Builder Placeholder</h1>
         <p className="text-base text-slate-300">
-          This layout confirms the Module Federation remote is wired correctly. Replace this scaffold with the
-          interactive Scenario Builder once the remote APIs are available.
+          This layout confirms the Module Federation remote is wired correctly. Replace this scaffold with the interactive
+          Scenario Builder once the remote APIs are available.
         </p>
       </header>
 
@@ -29,12 +63,14 @@ const ScenarioApp: FC = () => (
         description={
           <>
             <span>
-              Build out the Scenario Builder screens here. Shared UI elements can be composed from the PocketHive design
-              system to ensure the embedded experience matches the host application.
+              Build out the Scenario Builder screens here. Shared UI elements can be composed from the PocketHive design system
+              to ensure the embedded experience matches the host application.
             </span>
           </>
         }
       />
+
+      <HostIntegration />
     </div>
   </div>
 )

--- a/ui/src/scenario/remoteEntry.ts
+++ b/ui/src/scenario/remoteEntry.ts
@@ -1,15 +1,23 @@
 import { StrictMode, createElement } from 'react'
 import { createRoot } from 'react-dom/client'
 
+import { ShellProviders } from '@ph/shell'
 import ScenarioApp from './ScenarioApp'
 
 export type MountReturn = {
   unmount: () => void
 }
 
+const renderScenarioApp = () =>
+  createElement(
+    StrictMode,
+    undefined,
+    createElement(ShellProviders, undefined, createElement(ScenarioApp))
+  )
+
 export const mount = (element: HTMLElement): MountReturn => {
   const root = createRoot(element)
-  root.render(createElement(StrictMode, undefined, createElement(ScenarioApp)))
+  root.render(renderScenarioApp())
 
   return {
     unmount: () => root.unmount()

--- a/ui/src/shell/ShellProviders.tsx
+++ b/ui/src/shell/ShellProviders.tsx
@@ -1,0 +1,25 @@
+import type { PropsWithChildren } from 'react'
+import { useState } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import { ConfigProvider } from '../lib/config'
+
+function ThemeProvider({ children }: PropsWithChildren): JSX.Element {
+  return <>{children}</>
+}
+
+export interface ShellProvidersProps extends PropsWithChildren {
+  queryClient?: QueryClient
+}
+
+export function ShellProviders({ children, queryClient }: ShellProvidersProps): JSX.Element {
+  const [client] = useState(() => queryClient ?? new QueryClient())
+
+  return (
+    <ThemeProvider>
+      <ConfigProvider>
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      </ConfigProvider>
+    </ThemeProvider>
+  )
+}

--- a/ui/src/shell/index.ts
+++ b/ui/src/shell/index.ts
@@ -1,0 +1,4 @@
+export { ShellProviders } from './ShellProviders'
+export type { ShellProvidersProps } from './ShellProviders'
+export { useConfig, getConfig, setConfig, subscribeConfig, ConfigProvider } from '../lib/config'
+export { useUIStore } from '../store'

--- a/ui/src/store.test.ts
+++ b/ui/src/store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach } from 'vitest'
-import { useUIStore } from './store'
+import { useUIStore } from '@ph/shell'
 
 describe('useUIStore messageLimit', () => {
   beforeEach(() => {

--- a/ui/tsconfig.app.json
+++ b/ui/tsconfig.app.json
@@ -15,6 +15,11 @@
     "noEmit": true,
     "resolveJsonModule": true,
     "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@ph/shell": ["./src/shell/index.ts"],
+      "@ph/shell/*": ["./src/shell/*"]
+    },
 
     /* Linting */
     "strict": true,

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath, URL } from 'node:url'
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import federation from '@originjs/vite-plugin-federation'
@@ -16,7 +17,14 @@ export default defineConfig(({ mode }) => {
         exposes: {
           './ScenarioApp': './src/scenario/remoteEntry.ts'
         },
-        shared: ['react', 'react-dom']
+        shared: {
+          react: { singleton: true, eager: true, requiredVersion: '^19.1.1' },
+          'react-dom': { singleton: true, eager: true, requiredVersion: '^19.1.1' },
+          zustand: { singleton: true, requiredVersion: '^5.0.8' },
+          '@ph/shell': { import: './src/shell/index.ts', singleton: true },
+          './src/lib/config': { import: './src/lib/config', singleton: true },
+          './src/store': { import: './src/store', singleton: true }
+        }
       })
     ],
     publicDir: 'assets',
@@ -34,6 +42,11 @@ export default defineConfig(({ mode }) => {
       : {}),
     test: {
       environment: 'jsdom'
+    },
+    resolve: {
+      alias: {
+        '@ph/shell': fileURLToPath(new URL('./src/shell/index.ts', import.meta.url))
+      }
     }
   }
 })


### PR DESCRIPTION
## Summary
- centralize shared shell providers and expose hooks through the `@ph/shell` barrel so host and remote use the same instances
- configure Module Federation sharing for React, Zustand, and config utilities while wiring the scenario remote through the shell
- document the shared shell contract and add an integration test that proves the remote reads host-provided configuration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68daba562894832895fc0dd5e8a6c550