### PR TITLE
feat(ui): add scenario asset management

### DIFF
--- a/ui/src/scenario/Inspector/index.tsx
+++ b/ui/src/scenario/Inspector/index.tsx
@@ -1,0 +1,115 @@
+import type { FC } from 'react'
+
+import AssetList from '../assets/AssetList'
+import type {
+  AssetKind,
+  DatasetAsset,
+  SwarmTemplateAsset,
+  SutAsset,
+} from '../assets/assets'
+
+interface InspectorProps {
+  active: AssetKind
+  sutAssets: SutAsset[]
+  datasetAssets: DatasetAsset[]
+  swarmTemplates: SwarmTemplateAsset[]
+  onCreate: (kind: AssetKind) => void
+  onEdit: (kind: AssetKind, asset: SutAsset | DatasetAsset | SwarmTemplateAsset) => void
+  onDelete: (kind: AssetKind, asset: SutAsset | DatasetAsset | SwarmTemplateAsset) => void
+}
+
+const Inspector: FC<InspectorProps> = ({
+  active,
+  sutAssets,
+  datasetAssets,
+  swarmTemplates,
+  onCreate,
+  onEdit,
+  onDelete,
+}) => {
+  if (active === 'sut') {
+    return (
+      <AssetList
+        title="Systems under test"
+        assets={sutAssets}
+        createLabel="New system"
+        emptyLabel="No systems registered yet. Add a system under test to reuse across scenarios."
+        onCreate={() => onCreate('sut')}
+        onEdit={(asset) => onEdit('sut', asset)}
+        onDelete={(asset) => onDelete('sut', asset)}
+        renderMetadata={(asset) => (
+          <dl className="grid gap-1 md:grid-cols-2">
+            <div>
+              <dt className="text-slate-400">Entry point</dt>
+              <dd className="font-mono text-[11px] text-amber-300">{asset.entrypoint}</dd>
+            </div>
+            <div>
+              <dt className="text-slate-400">Version</dt>
+              <dd className="font-mono text-[11px] text-amber-300">{asset.version}</dd>
+            </div>
+          </dl>
+        )}
+      />
+    )
+  }
+
+  if (active === 'dataset') {
+    return (
+      <AssetList
+        title="Datasets"
+        assets={datasetAssets}
+        createLabel="New dataset"
+        emptyLabel="No datasets registered yet. Bring datasets into PocketHive before linking them to templates."
+        onCreate={() => onCreate('dataset')}
+        onEdit={(asset) => onEdit('dataset', asset)}
+        onDelete={(asset) => onDelete('dataset', asset)}
+        renderMetadata={(asset) => (
+          <dl className="grid gap-1 md:grid-cols-2">
+            <div>
+              <dt className="text-slate-400">Source</dt>
+              <dd className="font-mono text-[11px] text-amber-300">{asset.uri}</dd>
+            </div>
+            <div>
+              <dt className="text-slate-400">Format</dt>
+              <dd className="font-mono text-[11px] text-amber-300">{asset.format}</dd>
+            </div>
+          </dl>
+        )}
+      />
+    )
+  }
+
+  return (
+    <AssetList
+      title="Swarm templates"
+      assets={swarmTemplates}
+      createLabel="New template"
+      emptyLabel="No templates exist yet. Combine a system and dataset to describe a swarm."
+      onCreate={() => onCreate('template')}
+      onEdit={(asset) => onEdit('template', asset)}
+      onDelete={(asset) => onDelete('template', asset)}
+      renderMetadata={(asset) => {
+        const sut = sutAssets.find((candidate) => candidate.id === asset.sutId)
+        const dataset = datasetAssets.find((candidate) => candidate.id === asset.datasetId)
+        return (
+          <dl className="grid gap-1 md:grid-cols-3">
+            <div>
+              <dt className="text-slate-400">System</dt>
+              <dd className="font-mono text-[11px] text-amber-300">{sut?.name ?? asset.sutId}</dd>
+            </div>
+            <div>
+              <dt className="text-slate-400">Dataset</dt>
+              <dd className="font-mono text-[11px] text-amber-300">{dataset?.name ?? asset.datasetId}</dd>
+            </div>
+            <div>
+              <dt className="text-slate-400">Swarm size</dt>
+              <dd className="font-mono text-[11px] text-amber-300">{asset.swarmSize}</dd>
+            </div>
+          </dl>
+        )
+      }}
+    />
+  )
+}
+
+export default Inspector

--- a/ui/src/scenario/LeftNav.tsx
+++ b/ui/src/scenario/LeftNav.tsx
@@ -1,0 +1,55 @@
+import type { FC } from 'react'
+
+import type { AssetKind } from './assets/assets'
+
+interface SectionSummary {
+  id: AssetKind
+  label: string
+  description: string
+  count: number
+}
+
+interface LeftNavProps {
+  active: AssetKind
+  sections: SectionSummary[]
+  onSelect: (id: AssetKind) => void
+}
+
+const LeftNav: FC<LeftNavProps> = ({ active, sections, onSelect }) => (
+  <nav className="flex w-72 flex-col gap-4 rounded-xl border border-slate-800 bg-slate-950/70 p-4">
+    <header className="space-y-1">
+      <p className="text-xs uppercase tracking-[0.35em] text-amber-400">Scenario builder</p>
+      <h1 className="text-lg font-semibold text-slate-50">Assets</h1>
+      <p className="text-xs leading-relaxed text-slate-400">
+        Prepare systems, datasets, and swarm templates before assembling a scenario.
+      </p>
+    </header>
+
+    <ul className="flex flex-col gap-2">
+      {sections.map((section) => {
+        const isActive = section.id === active
+        return (
+          <li key={section.id}>
+            <button
+              type="button"
+              onClick={() => onSelect(section.id)}
+              className={`flex w-full flex-col gap-1 rounded-lg border px-3 py-2 text-left text-sm transition ${
+                isActive
+                  ? 'border-amber-400 bg-amber-400/10 text-amber-200'
+                  : 'border-slate-800 bg-slate-900/70 text-slate-300 hover:border-amber-400/70 hover:text-amber-200'
+              }`}
+            >
+              <span className="flex items-center justify-between">
+                <span className="font-semibold">{section.label}</span>
+                <span className="rounded bg-slate-800 px-2 py-0.5 text-xs font-mono">{section.count}</span>
+              </span>
+              <span className="text-xs text-slate-400">{section.description}</span>
+            </button>
+          </li>
+        )
+      })}
+    </ul>
+  </nav>
+)
+
+export default LeftNav

--- a/ui/src/scenario/ScenarioApp.assets.test.tsx
+++ b/ui/src/scenario/ScenarioApp.assets.test.tsx
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import * as matchers from '@testing-library/jest-dom/matchers'
+
+expect.extend(matchers)
+
+import ScenarioApp from './ScenarioApp'
+import { ShellProviders } from '@ph/shell'
+import { useAssetStore } from './assets/assetStore'
+
+const resetAssets = () => {
+  useAssetStore.getState().reset()
+  if (typeof window !== 'undefined' && window.localStorage) {
+    window.localStorage.removeItem('ph.scenario.assets')
+  }
+}
+
+describe('ScenarioApp asset workflows', () => {
+  beforeEach(() => {
+    resetAssets()
+  })
+
+  afterEach(() => {
+    cleanup()
+    resetAssets()
+  })
+
+  it('disables submission until required fields are populated', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ShellProviders>
+        <ScenarioApp />
+      </ShellProviders>,
+    )
+
+    await user.click(screen.getByRole('button', { name: /new system/i }))
+    const systemSubmit = screen.getByRole('button', { name: /create system/i })
+    expect(systemSubmit).toBeDisabled()
+
+    await user.type(screen.getByLabelText(/Identifier/i), 'sut-1')
+    await user.type(screen.getByLabelText(/Name/i), 'Primary system')
+    await user.type(screen.getByLabelText(/Entry point/i), 'image:latest')
+    await user.type(screen.getByLabelText(/Version/i), 'v1')
+    expect(systemSubmit).toBeEnabled()
+    await user.click(screen.getByRole('button', { name: /cancel/i }))
+
+    await user.click(screen.getByRole('button', { name: /datasets/i }))
+    await user.click(screen.getByRole('button', { name: /new dataset/i }))
+    const datasetSubmit = screen.getByRole('button', { name: /create dataset/i })
+    expect(datasetSubmit).toBeDisabled()
+
+    await user.type(screen.getByLabelText(/Identifier/i), 'dataset-1')
+    await user.type(screen.getByLabelText(/Name/i), 'Dataset')
+    await user.type(screen.getByLabelText(/Source URI/i), 's3://bucket/data.json')
+    await user.type(screen.getByLabelText(/Format/i), 'json')
+    expect(datasetSubmit).toBeEnabled()
+    await user.click(screen.getByRole('button', { name: /cancel/i }))
+
+    useAssetStore.getState().upsertSut({
+      id: 'sut-1',
+      name: 'Primary',
+      entrypoint: 'image:latest',
+      version: 'v1',
+    })
+    useAssetStore.getState().upsertDataset({
+      id: 'dataset-1',
+      name: 'Dataset',
+      uri: 's3://bucket/data.json',
+      format: 'json',
+    })
+
+    await user.click(screen.getByRole('button', { name: /swarm templates/i }))
+    await user.click(screen.getByRole('button', { name: /new template/i }))
+    const templateSubmit = screen.getByRole('button', { name: /create template/i })
+    expect(templateSubmit).toBeDisabled()
+
+    await user.type(screen.getByLabelText(/Identifier/i), 'template-1')
+    await user.type(screen.getByLabelText(/Name/i), 'Template')
+    expect(templateSubmit).toBeEnabled()
+  })
+
+  it('supports create, edit, and delete flows for assets', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <ShellProviders>
+        <ScenarioApp />
+      </ShellProviders>,
+    )
+
+    await user.click(screen.getByRole('button', { name: /new system/i }))
+    await user.type(screen.getByLabelText(/Identifier/i), 'sut-1')
+    await user.type(screen.getByLabelText(/Name/i), 'Primary system')
+    await user.type(screen.getByLabelText(/Entry point/i), 'image:latest')
+    await user.type(screen.getByLabelText(/Version/i), 'v1')
+    await user.click(screen.getByRole('button', { name: /create system/i }))
+
+    expect(screen.getByText('Primary system')).toBeInTheDocument()
+    expect(screen.getByText('sut-1')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /datasets/i }))
+    await user.click(screen.getByRole('button', { name: /new dataset/i }))
+    await user.type(screen.getByLabelText(/Identifier/i), 'dataset-1')
+    await user.type(screen.getByLabelText(/Name/i), 'Main dataset')
+    await user.type(screen.getByLabelText(/Source URI/i), 's3://bucket/data.json')
+    await user.type(screen.getByLabelText(/Format/i), 'json')
+    await user.click(screen.getByRole('button', { name: /create dataset/i }))
+
+    expect(screen.getByText('Main dataset')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /swarm templates/i }))
+    await user.click(screen.getByRole('button', { name: /new template/i }))
+    await user.type(screen.getByLabelText(/Identifier/i), 'template-1')
+    await user.type(screen.getByLabelText(/Name/i), 'Load test template')
+    await user.click(screen.getByRole('button', { name: /create template/i }))
+
+    expect(screen.getByText('Load test template')).toBeInTheDocument()
+    expect(screen.getByText('Swarm size')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /systems/i }))
+    await user.click(screen.getByRole('button', { name: /^edit$/i }))
+    const nameField = screen.getByLabelText(/Name/i)
+    await user.clear(nameField)
+    await user.type(nameField, 'Primary system updated')
+    await user.click(screen.getByRole('button', { name: /save changes/i }))
+
+    expect(screen.getByText('Primary system updated')).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /datasets/i }))
+    await user.click(screen.getAllByRole('button', { name: /^delete$/i })[0]!)
+
+    expect(screen.queryByText('Main dataset')).not.toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: /swarm templates/i }))
+    expect(screen.queryByText('Load test template')).not.toBeInTheDocument()
+  })
+})

--- a/ui/src/scenario/ScenarioApp.integration.test.tsx
+++ b/ui/src/scenario/ScenarioApp.integration.test.tsx
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { cleanup, render, screen } from '@testing-library/react'
-import '@testing-library/jest-dom/vitest'
+import * as matchers from '@testing-library/jest-dom/matchers'
+
+expect.extend(matchers)
 
 import ScenarioApp from './ScenarioApp'
 import { ShellProviders, getConfig, setConfig, useUIStore } from '@ph/shell'

--- a/ui/src/scenario/ScenarioApp.tsx
+++ b/ui/src/scenario/ScenarioApp.tsx
@@ -1,78 +1,209 @@
-import type { FC, ReactNode } from 'react'
+import { useMemo, useState } from 'react'
 import { useConfig, useUIStore } from '@ph/shell'
 
-const Section: FC<{ title: string; description: ReactNode }> = ({ title, description }) => (
-  <section className="space-y-2 rounded-lg border border-slate-800 bg-slate-900/60 p-6 shadow-sm">
-    <h2 className="text-xl font-semibold text-slate-100">{title}</h2>
-    <div className="text-sm leading-relaxed text-slate-300">{description}</div>
-  </section>
-)
+import LeftNav from './LeftNav'
+import Inspector from './Inspector'
+import DatasetForm from './assets/DatasetForm'
+import SwarmTemplateForm from './assets/SwarmTemplateForm'
+import SutForm from './assets/SutForm'
+import type { AssetKind, DatasetAsset, SwarmTemplateAsset, SutAsset } from './assets/assets'
+import { useAssetStore } from './assets/assetStore'
 
-const HostIntegration: FC = () => {
+type ModalState =
+  | { kind: 'sut'; mode: 'create' }
+  | { kind: 'sut'; mode: 'edit'; asset: SutAsset }
+  | { kind: 'dataset'; mode: 'create' }
+  | { kind: 'dataset'; mode: 'edit'; asset: DatasetAsset }
+  | { kind: 'template'; mode: 'create' }
+  | { kind: 'template'; mode: 'edit'; asset: SwarmTemplateAsset }
+
+const ScenarioApp = () => {
   const config = useConfig()
   const messageLimit = useUIStore((state) => state.messageLimit)
+  const [activeSection, setActiveSection] = useState<AssetKind>('sut')
+  const [modal, setModal] = useState<ModalState | null>(null)
+
+  const {
+    sutAssets,
+    datasetAssets,
+    swarmTemplates,
+    upsertSut,
+    upsertDataset,
+    upsertSwarmTemplate,
+    removeSut,
+    removeDataset,
+    removeSwarmTemplate,
+  } = useAssetStore((state) => state)
+
+  const sections = useMemo(
+    () => [
+      {
+        id: 'sut' as const,
+        label: 'Systems',
+        description: 'Containers, binaries, or services PocketHive exercises.',
+        count: sutAssets.length,
+      },
+      {
+        id: 'dataset' as const,
+        label: 'Datasets',
+        description: 'Input corpora and fixtures for swarm members.',
+        count: datasetAssets.length,
+      },
+      {
+        id: 'template' as const,
+        label: 'Swarm templates',
+        description: 'Composed assets that scale a workload.',
+        count: swarmTemplates.length,
+      },
+    ],
+    [datasetAssets.length, sutAssets.length, swarmTemplates.length],
+  )
+
+  const closeModal = () => setModal(null)
+
+  const handleCreate = (kind: AssetKind) => {
+    if (kind === 'sut') {
+      setModal({ kind: 'sut', mode: 'create' })
+    } else if (kind === 'dataset') {
+      setModal({ kind: 'dataset', mode: 'create' })
+    } else {
+      setModal({ kind: 'template', mode: 'create' })
+    }
+  }
+
+  const handleEdit = (kind: AssetKind, asset: SutAsset | DatasetAsset | SwarmTemplateAsset) => {
+    if (kind === 'sut') {
+      setModal({ kind: 'sut', mode: 'edit', asset: asset as SutAsset })
+    } else if (kind === 'dataset') {
+      setModal({ kind: 'dataset', mode: 'edit', asset: asset as DatasetAsset })
+    } else {
+      setModal({ kind: 'template', mode: 'edit', asset: asset as SwarmTemplateAsset })
+    }
+  }
+
+  const handleDelete = (kind: AssetKind, asset: SutAsset | DatasetAsset | SwarmTemplateAsset) => {
+    if (kind === 'sut') {
+      removeSut(asset.id)
+    } else if (kind === 'dataset') {
+      removeDataset(asset.id)
+    } else {
+      removeSwarmTemplate(asset.id)
+    }
+  }
+
+  const renderModal = () => {
+    if (!modal) {
+      return null
+    }
+
+    const containerClass =
+      'fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 backdrop-blur-sm p-6'
+    const panelClass = 'w-full max-w-2xl rounded-xl border border-slate-700 bg-slate-900 p-6 shadow-xl'
+
+    if (modal.kind === 'sut') {
+      return (
+        <div className={containerClass} role="presentation">
+          <div className={panelClass} role="dialog" aria-modal="true">
+            <SutForm
+              initialValue={modal.mode === 'edit' ? modal.asset : undefined}
+              onCancel={closeModal}
+              onSubmit={(asset) => {
+                upsertSut(asset)
+                closeModal()
+              }}
+            />
+          </div>
+        </div>
+      )
+    }
+
+    if (modal.kind === 'dataset') {
+      return (
+        <div className={containerClass} role="presentation">
+          <div className={panelClass} role="dialog" aria-modal="true">
+            <DatasetForm
+              initialValue={modal.mode === 'edit' ? modal.asset : undefined}
+              onCancel={closeModal}
+              onSubmit={(asset) => {
+                upsertDataset(asset)
+                closeModal()
+              }}
+            />
+          </div>
+        </div>
+      )
+    }
+
+    return (
+      <div className={containerClass} role="presentation">
+        <div className={panelClass} role="dialog" aria-modal="true">
+          <SwarmTemplateForm
+            initialValue={modal.mode === 'edit' ? modal.asset : undefined}
+            sutOptions={sutAssets}
+            datasetOptions={datasetAssets}
+            onCancel={closeModal}
+            onSubmit={(asset) => {
+              upsertSwarmTemplate(asset)
+              closeModal()
+            }}
+          />
+        </div>
+      </div>
+    )
+  }
 
   return (
-    <Section
-      title="Host Integration"
-      description={
-        <dl className="grid gap-2 text-left">
-          <div>
-            <dt className="font-medium text-slate-200">RabbitMQ endpoint</dt>
-            <dd data-testid="config-rabbitmq" className="font-mono text-xs text-amber-300">
-              {config.rabbitmq}
-            </dd>
-          </div>
-          <div>
-            <dt className="font-medium text-slate-200">Prometheus endpoint</dt>
-            <dd data-testid="config-prometheus" className="font-mono text-xs text-amber-300">
-              {config.prometheus}
-            </dd>
-          </div>
-          <div>
-            <dt className="font-medium text-slate-200">Active message limit</dt>
-            <dd data-testid="ui-message-limit" className="font-mono text-xs text-amber-300">
-              {messageLimit}
-            </dd>
-          </div>
-        </dl>
-      }
-    />
+    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-8 text-slate-100">
+      <div className="mx-auto flex w-full max-w-6xl gap-6">
+        <LeftNav active={activeSection} sections={sections} onSelect={setActiveSection} />
+
+        <main className="flex flex-1 flex-col gap-6">
+          <section className="rounded-xl border border-slate-800 bg-slate-900/60 p-6">
+            <header className="mb-4 flex flex-wrap items-center justify-between gap-4">
+              <div>
+                <p className="text-xs uppercase tracking-[0.35em] text-amber-400">Host configuration</p>
+                <h2 className="text-xl font-semibold">Runtime context</h2>
+              </div>
+              <span
+                data-testid="ui-message-limit"
+                className="rounded bg-slate-800 px-3 py-1 text-xs text-slate-300"
+              >
+                Messages limited to {messageLimit}
+              </span>
+            </header>
+            <dl className="grid gap-3 md:grid-cols-2">
+              <div>
+                <dt className="text-sm text-slate-300">RabbitMQ endpoint</dt>
+                <dd data-testid="config-rabbitmq" className="font-mono text-xs text-amber-300">
+                  {config.rabbitmq}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-sm text-slate-300">Prometheus endpoint</dt>
+                <dd data-testid="config-prometheus" className="font-mono text-xs text-amber-300">
+                  {config.prometheus}
+                </dd>
+              </div>
+            </dl>
+          </section>
+
+          <section className="flex-1 rounded-xl border border-slate-800 bg-slate-900/60 p-6">
+            <Inspector
+              active={activeSection}
+              sutAssets={sutAssets}
+              datasetAssets={datasetAssets}
+              swarmTemplates={swarmTemplates}
+              onCreate={handleCreate}
+              onEdit={handleEdit}
+              onDelete={handleDelete}
+            />
+          </section>
+        </main>
+      </div>
+
+      {renderModal()}
+    </div>
   )
 }
-
-const ScenarioApp: FC = () => (
-  <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 p-8 text-slate-100">
-    <div className="mx-auto flex w-full max-w-4xl flex-col gap-6">
-      <header className="space-y-2 text-center">
-        <p className="text-sm uppercase tracking-[0.35em] text-amber-400">PocketHive Remote</p>
-        <h1 className="text-4xl font-bold">Scenario Builder Placeholder</h1>
-        <p className="text-base text-slate-300">
-          This layout confirms the Module Federation remote is wired correctly. Replace this scaffold with the interactive
-          Scenario Builder once the remote APIs are available.
-        </p>
-      </header>
-
-      <Section
-        title="Getting Started"
-        description='Import the "@ph/scenario/ScenarioApp" module from the remote entry to mount this placeholder in any host UI.'
-      />
-
-      <Section
-        title="Next Steps"
-        description={
-          <>
-            <span>
-              Build out the Scenario Builder screens here. Shared UI elements can be composed from the PocketHive design system
-              to ensure the embedded experience matches the host application.
-            </span>
-          </>
-        }
-      />
-
-      <HostIntegration />
-    </div>
-  </div>
-)
 
 export default ScenarioApp

--- a/ui/src/scenario/assets/AssetForm.tsx
+++ b/ui/src/scenario/assets/AssetForm.tsx
@@ -1,0 +1,56 @@
+import type { FC, ReactNode } from 'react'
+
+interface AssetFormProps {
+  title: string
+  description?: ReactNode
+  submitLabel?: string
+  onSubmit: () => void
+  onCancel: () => void
+  isSubmitDisabled?: boolean
+  children: ReactNode
+}
+
+export const AssetForm: FC<AssetFormProps> = ({
+  title,
+  description,
+  submitLabel = 'Save',
+  onSubmit,
+  onCancel,
+  isSubmitDisabled,
+  children,
+}) => (
+  <form
+    aria-label={title}
+    className="flex w-full flex-col gap-6"
+    onSubmit={(event) => {
+      event.preventDefault()
+      onSubmit()
+    }}
+  >
+    <header className="space-y-2">
+      <h2 className="text-2xl font-semibold text-slate-100">{title}</h2>
+      {description ? <p className="text-sm text-slate-300">{description}</p> : null}
+    </header>
+
+    <div className="flex flex-col gap-4">{children}</div>
+
+    <footer className="flex justify-end gap-3">
+      <button
+        type="button"
+        onClick={onCancel}
+        className="rounded-md border border-slate-600 px-4 py-2 text-sm font-medium text-slate-200 transition hover:bg-slate-800"
+      >
+        Cancel
+      </button>
+      <button
+        type="submit"
+        disabled={isSubmitDisabled}
+        className="rounded-md bg-amber-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-amber-400 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {submitLabel}
+      </button>
+    </footer>
+  </form>
+)
+
+export default AssetForm

--- a/ui/src/scenario/assets/AssetList.tsx
+++ b/ui/src/scenario/assets/AssetList.tsx
@@ -1,0 +1,83 @@
+import type { ReactNode } from 'react'
+
+import type { AssetBase } from './assets'
+
+interface AssetListProps<T extends AssetBase> {
+  title: string
+  assets: T[]
+  createLabel: string
+  emptyLabel: string
+  onCreate: () => void
+  onEdit: (asset: T) => void
+  onDelete: (asset: T) => void
+  renderMetadata?: (asset: T) => ReactNode
+}
+
+export const AssetList = <T extends AssetBase>({
+  title,
+  assets,
+  createLabel,
+  emptyLabel,
+  onCreate,
+  onEdit,
+  onDelete,
+  renderMetadata,
+}: AssetListProps<T>) => (
+  <div className="flex h-full flex-col gap-4">
+    <header className="flex items-center justify-between">
+      <div>
+        <h2 className="text-xl font-semibold text-slate-100">{title}</h2>
+        <p className="text-sm text-slate-400">{assets.length} saved</p>
+      </div>
+      <button
+        type="button"
+        onClick={onCreate}
+        className="rounded-md bg-amber-500 px-3 py-2 text-sm font-semibold text-slate-950 transition hover:bg-amber-400"
+      >
+        {createLabel}
+      </button>
+    </header>
+
+    {assets.length === 0 ? (
+      <p className="rounded-md border border-dashed border-slate-700 bg-slate-900/40 p-6 text-sm text-slate-400">
+        {emptyLabel}
+      </p>
+    ) : (
+      <ul className="flex flex-col gap-3">
+        {assets.map((asset) => (
+          <li
+            key={asset.id}
+            className="flex flex-col gap-3 rounded-md border border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-200"
+          >
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div>
+                <p className="text-base font-semibold text-slate-50">{asset.name}</p>
+                <p className="font-mono text-xs uppercase tracking-widest text-amber-300">{asset.id}</p>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  className="rounded border border-slate-600 px-3 py-1 text-xs font-semibold text-slate-200 transition hover:bg-slate-800"
+                  onClick={() => onEdit(asset)}
+                >
+                  Edit
+                </button>
+                <button
+                  type="button"
+                  className="rounded border border-red-500/60 px-3 py-1 text-xs font-semibold text-red-300 transition hover:bg-red-500/20"
+                  onClick={() => onDelete(asset)}
+                >
+                  Delete
+                </button>
+              </div>
+            </div>
+            {asset.description ? <p className="text-slate-400">{asset.description}</p> : null}
+            {renderMetadata ? <div className="text-xs text-slate-300">{renderMetadata(asset)}</div> : null}
+          </li>
+        ))}
+      </ul>
+    )}
+  </div>
+)
+
+export default AssetList

--- a/ui/src/scenario/assets/DatasetForm.tsx
+++ b/ui/src/scenario/assets/DatasetForm.tsx
@@ -1,0 +1,163 @@
+import { useMemo, useState } from 'react'
+
+import AssetForm from './AssetForm'
+import type { DatasetAsset } from './assets'
+
+interface DatasetFormProps {
+  initialValue?: DatasetAsset
+  onCancel: () => void
+  onSubmit: (asset: DatasetAsset) => void
+}
+
+type DatasetFields = {
+  id: string
+  name: string
+  description: string
+  uri: string
+  format: string
+}
+
+const sanitize = (value: string) => value.trim()
+
+const buildErrors = (fields: DatasetFields) => {
+  const next: Partial<Record<keyof DatasetFields, string>> = {}
+  if (!sanitize(fields.id)) {
+    next.id = 'Provide a unique identifier.'
+  }
+  if (!sanitize(fields.name)) {
+    next.name = 'Provide a friendly name.'
+  }
+  if (!sanitize(fields.uri)) {
+    next.uri = 'Provide a dataset source URI.'
+  }
+  if (!sanitize(fields.format)) {
+    next.format = 'Select or describe a format.'
+  }
+  return next
+}
+
+export const DatasetForm = ({ initialValue, onCancel, onSubmit }: DatasetFormProps) => {
+  const [fields, setFields] = useState<DatasetFields>({
+    id: initialValue?.id ?? '',
+    name: initialValue?.name ?? '',
+    description: initialValue?.description ?? '',
+    uri: initialValue?.uri ?? '',
+    format: initialValue?.format ?? '',
+  })
+
+  const errors = useMemo(() => buildErrors(fields), [fields])
+
+  const updateField = <K extends keyof DatasetFields>(key: K, value: DatasetFields[K]) => {
+    setFields((current) => ({
+      ...current,
+      [key]: value,
+    }))
+  }
+
+  const handleSubmit = () => {
+    if (Object.keys(errors).length > 0) {
+      return
+    }
+
+    onSubmit({
+      id: sanitize(fields.id),
+      name: sanitize(fields.name),
+      description: sanitize(fields.description) || undefined,
+      uri: sanitize(fields.uri),
+      format: sanitize(fields.format),
+    })
+  }
+
+  return (
+    <AssetForm
+      title={initialValue ? 'Edit dataset' : 'Create dataset'}
+      description="Register datasets that scenarios can mount at runtime."
+      onCancel={onCancel}
+      onSubmit={handleSubmit}
+      submitLabel={initialValue ? 'Save changes' : 'Create dataset'}
+      isSubmitDisabled={Object.keys(errors).length > 0}
+    >
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-semibold text-slate-200">Identifier</span>
+        <input
+          type="text"
+          value={fields.id}
+          onChange={(event) => updateField('id', event.target.value)}
+          aria-invalid={Boolean(errors.id)}
+          aria-describedby="dataset-id-error"
+          className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-amber-400 focus:outline-none"
+          disabled={Boolean(initialValue)}
+        />
+        {errors.id ? (
+          <span id="dataset-id-error" role="alert" className="text-xs text-red-300">
+            {errors.id}
+          </span>
+        ) : null}
+      </label>
+
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-semibold text-slate-200">Name</span>
+        <input
+          type="text"
+          value={fields.name}
+          onChange={(event) => updateField('name', event.target.value)}
+          aria-invalid={Boolean(errors.name)}
+          aria-describedby="dataset-name-error"
+          className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-amber-400 focus:outline-none"
+        />
+        {errors.name ? (
+          <span id="dataset-name-error" role="alert" className="text-xs text-red-300">
+            {errors.name}
+          </span>
+        ) : null}
+      </label>
+
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-semibold text-slate-200">Source URI</span>
+        <input
+          type="text"
+          value={fields.uri}
+          onChange={(event) => updateField('uri', event.target.value)}
+          aria-invalid={Boolean(errors.uri)}
+          aria-describedby="dataset-uri-error"
+          placeholder="s3://bucket/datasets/example.json"
+          className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-amber-400 focus:outline-none"
+        />
+        {errors.uri ? (
+          <span id="dataset-uri-error" role="alert" className="text-xs text-red-300">
+            {errors.uri}
+          </span>
+        ) : null}
+      </label>
+
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-semibold text-slate-200">Format</span>
+        <input
+          type="text"
+          value={fields.format}
+          onChange={(event) => updateField('format', event.target.value)}
+          aria-invalid={Boolean(errors.format)}
+          aria-describedby="dataset-format-error"
+          placeholder="json | csv | parquet"
+          className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-amber-400 focus:outline-none"
+        />
+        {errors.format ? (
+          <span id="dataset-format-error" role="alert" className="text-xs text-red-300">
+            {errors.format}
+          </span>
+        ) : null}
+      </label>
+
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-semibold text-slate-200">Description</span>
+        <textarea
+          value={fields.description}
+          onChange={(event) => updateField('description', event.target.value)}
+          className="min-h-[96px] rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-amber-400 focus:outline-none"
+        />
+      </label>
+    </AssetForm>
+  )
+}
+
+export default DatasetForm

--- a/ui/src/scenario/assets/SutForm.tsx
+++ b/ui/src/scenario/assets/SutForm.tsx
@@ -1,0 +1,163 @@
+import { useMemo, useState } from 'react'
+
+import AssetForm from './AssetForm'
+import type { SutAsset } from './assets'
+
+interface SutFormProps {
+  initialValue?: SutAsset
+  onCancel: () => void
+  onSubmit: (asset: SutAsset) => void
+}
+
+type SutFields = {
+  id: string
+  name: string
+  description: string
+  entrypoint: string
+  version: string
+}
+
+const sanitize = (value: string) => value.trim()
+
+const buildErrors = (fields: SutFields) => {
+  const next: Partial<Record<keyof SutFields, string>> = {}
+  if (!sanitize(fields.id)) {
+    next.id = 'Provide a unique identifier.'
+  }
+  if (!sanitize(fields.name)) {
+    next.name = 'Provide a friendly name.'
+  }
+  if (!sanitize(fields.entrypoint)) {
+    next.entrypoint = 'Provide an executable entrypoint.'
+  }
+  if (!sanitize(fields.version)) {
+    next.version = 'Specify a version tag.'
+  }
+  return next
+}
+
+export const SutForm = ({ initialValue, onCancel, onSubmit }: SutFormProps) => {
+  const [fields, setFields] = useState<SutFields>({
+    id: initialValue?.id ?? '',
+    name: initialValue?.name ?? '',
+    description: initialValue?.description ?? '',
+    entrypoint: initialValue?.entrypoint ?? '',
+    version: initialValue?.version ?? '',
+  })
+
+  const errors = useMemo(() => buildErrors(fields), [fields])
+
+  const updateField = <K extends keyof SutFields>(key: K, value: SutFields[K]) => {
+    setFields((current) => ({
+      ...current,
+      [key]: value,
+    }))
+  }
+
+  const handleSubmit = () => {
+    if (Object.keys(errors).length > 0) {
+      return
+    }
+
+    onSubmit({
+      id: sanitize(fields.id),
+      name: sanitize(fields.name),
+      description: sanitize(fields.description) || undefined,
+      entrypoint: sanitize(fields.entrypoint),
+      version: sanitize(fields.version),
+    })
+  }
+
+  return (
+    <AssetForm
+      title={initialValue ? 'Edit system under test' : 'Create system under test'}
+      description="Define how PocketHive should launch and identify this system."
+      onCancel={onCancel}
+      onSubmit={handleSubmit}
+      submitLabel={initialValue ? 'Save changes' : 'Create system'}
+      isSubmitDisabled={Object.keys(errors).length > 0}
+    >
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-semibold text-slate-200">Identifier</span>
+        <input
+          type="text"
+          value={fields.id}
+          onChange={(event) => updateField('id', event.target.value)}
+          aria-invalid={Boolean(errors.id)}
+          aria-describedby="sut-id-error"
+          className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-amber-400 focus:outline-none"
+          disabled={Boolean(initialValue)}
+        />
+        {errors.id ? (
+          <span id="sut-id-error" role="alert" className="text-xs text-red-300">
+            {errors.id}
+          </span>
+        ) : null}
+      </label>
+
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-semibold text-slate-200">Name</span>
+        <input
+          type="text"
+          value={fields.name}
+          onChange={(event) => updateField('name', event.target.value)}
+          aria-invalid={Boolean(errors.name)}
+          aria-describedby="sut-name-error"
+          className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-amber-400 focus:outline-none"
+        />
+        {errors.name ? (
+          <span id="sut-name-error" role="alert" className="text-xs text-red-300">
+            {errors.name}
+          </span>
+        ) : null}
+      </label>
+
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-semibold text-slate-200">Entry point</span>
+        <input
+          type="text"
+          value={fields.entrypoint}
+          onChange={(event) => updateField('entrypoint', event.target.value)}
+          aria-invalid={Boolean(errors.entrypoint)}
+          aria-describedby="sut-entrypoint-error"
+          placeholder="docker.io/acme/sut:latest"
+          className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-amber-400 focus:outline-none"
+        />
+        {errors.entrypoint ? (
+          <span id="sut-entrypoint-error" role="alert" className="text-xs text-red-300">
+            {errors.entrypoint}
+          </span>
+        ) : null}
+      </label>
+
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-semibold text-slate-200">Version</span>
+        <input
+          type="text"
+          value={fields.version}
+          onChange={(event) => updateField('version', event.target.value)}
+          aria-invalid={Boolean(errors.version)}
+          aria-describedby="sut-version-error"
+          placeholder="v1.0.0"
+          className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-amber-400 focus:outline-none"
+        />
+        {errors.version ? (
+          <span id="sut-version-error" role="alert" className="text-xs text-red-300">
+            {errors.version}
+          </span>
+        ) : null}
+      </label>
+
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-semibold text-slate-200">Description</span>
+        <textarea
+          value={fields.description}
+          onChange={(event) => updateField('description', event.target.value)}
+          className="min-h-[96px] rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-amber-400 focus:outline-none"
+        />
+      </label>
+    </AssetForm>
+  )
+}
+
+export default SutForm

--- a/ui/src/scenario/assets/SwarmTemplateForm.tsx
+++ b/ui/src/scenario/assets/SwarmTemplateForm.tsx
@@ -1,0 +1,230 @@
+import { useEffect, useMemo, useState } from 'react'
+
+import AssetForm from './AssetForm'
+import type { DatasetAsset, SwarmTemplateAsset, SutAsset } from './assets'
+
+interface SwarmTemplateFormProps {
+  initialValue?: SwarmTemplateAsset
+  sutOptions: SutAsset[]
+  datasetOptions: DatasetAsset[]
+  onCancel: () => void
+  onSubmit: (asset: SwarmTemplateAsset) => void
+}
+
+type SwarmTemplateFields = {
+  id: string
+  name: string
+  description: string
+  sutId: string
+  datasetId: string
+  swarmSize: number
+}
+
+const sanitize = (value: string) => value.trim()
+
+const buildErrors = (
+  fields: SwarmTemplateFields,
+  sutOptions: SutAsset[],
+  datasetOptions: DatasetAsset[],
+) => {
+  const next: Partial<Record<keyof SwarmTemplateFields, string>> = {}
+  if (!sanitize(fields.id)) {
+    next.id = 'Provide a unique identifier.'
+  }
+  if (!sanitize(fields.name)) {
+    next.name = 'Provide a friendly name.'
+  }
+  if (!sutOptions.some((option) => option.id === fields.sutId)) {
+    next.sutId = 'Select a registered system under test.'
+  }
+  if (!datasetOptions.some((option) => option.id === fields.datasetId)) {
+    next.datasetId = 'Select an available dataset.'
+  }
+  if (!Number.isFinite(fields.swarmSize) || fields.swarmSize < 1) {
+    next.swarmSize = 'Specify a swarm size of at least 1.'
+  }
+  return next
+}
+
+export const SwarmTemplateForm = ({
+  initialValue,
+  sutOptions,
+  datasetOptions,
+  onCancel,
+  onSubmit,
+}: SwarmTemplateFormProps) => {
+  const [fields, setFields] = useState<SwarmTemplateFields>({
+    id: initialValue?.id ?? '',
+    name: initialValue?.name ?? '',
+    description: initialValue?.description ?? '',
+    sutId: initialValue?.sutId ?? sutOptions[0]?.id ?? '',
+    datasetId: initialValue?.datasetId ?? datasetOptions[0]?.id ?? '',
+    swarmSize: initialValue?.swarmSize ?? 1,
+  })
+
+  useEffect(() => {
+    setFields((current) => {
+      let next = current
+      if (sutOptions.length > 0 && !sutOptions.some((sut) => sut.id === current.sutId)) {
+        next = { ...next, sutId: sutOptions[0]!.id }
+      }
+      if (datasetOptions.length > 0 && !datasetOptions.some((dataset) => dataset.id === current.datasetId)) {
+        next = { ...next, datasetId: datasetOptions[0]!.id }
+      }
+      return next
+    })
+  }, [sutOptions, datasetOptions])
+
+  const errors = useMemo(() => buildErrors(fields, sutOptions, datasetOptions), [
+    fields,
+    sutOptions,
+    datasetOptions,
+  ])
+
+  const updateField = <K extends keyof SwarmTemplateFields>(key: K, value: SwarmTemplateFields[K]) => {
+    setFields((current) => ({
+      ...current,
+      [key]: value,
+    }))
+  }
+
+  const handleSubmit = () => {
+    if (Object.keys(errors).length > 0) {
+      return
+    }
+
+    onSubmit({
+      id: sanitize(fields.id),
+      name: sanitize(fields.name),
+      description: sanitize(fields.description) || undefined,
+      sutId: fields.sutId,
+      datasetId: fields.datasetId,
+      swarmSize: Math.max(1, Math.floor(fields.swarmSize)),
+    })
+  }
+
+  return (
+    <AssetForm
+      title={initialValue ? 'Edit swarm template' : 'Create swarm template'}
+      description="Templates combine a system under test with datasets and execution scale."
+      onCancel={onCancel}
+      onSubmit={handleSubmit}
+      submitLabel={initialValue ? 'Save changes' : 'Create template'}
+      isSubmitDisabled={Object.keys(errors).length > 0}
+    >
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-semibold text-slate-200">Identifier</span>
+        <input
+          type="text"
+          value={fields.id}
+          onChange={(event) => updateField('id', event.target.value)}
+          aria-invalid={Boolean(errors.id)}
+          aria-describedby="template-id-error"
+          className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-amber-400 focus:outline-none"
+          disabled={Boolean(initialValue)}
+        />
+        {errors.id ? (
+          <span id="template-id-error" role="alert" className="text-xs text-red-300">
+            {errors.id}
+          </span>
+        ) : null}
+      </label>
+
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-semibold text-slate-200">Name</span>
+        <input
+          type="text"
+          value={fields.name}
+          onChange={(event) => updateField('name', event.target.value)}
+          aria-invalid={Boolean(errors.name)}
+          aria-describedby="template-name-error"
+          className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-amber-400 focus:outline-none"
+        />
+        {errors.name ? (
+          <span id="template-name-error" role="alert" className="text-xs text-red-300">
+            {errors.name}
+          </span>
+        ) : null}
+      </label>
+
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-semibold text-slate-200">System under test</span>
+        <select
+          value={fields.sutId}
+          onChange={(event) => updateField('sutId', event.target.value)}
+          aria-invalid={Boolean(errors.sutId)}
+          aria-describedby="template-sut-error"
+          className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-amber-400 focus:outline-none"
+        >
+          <option value="" disabled>
+            Select a system under test
+          </option>
+          {sutOptions.map((sut) => (
+            <option key={sut.id} value={sut.id}>
+              {sut.name}
+            </option>
+          ))}
+        </select>
+        {errors.sutId ? (
+          <span id="template-sut-error" role="alert" className="text-xs text-red-300">
+            {errors.sutId}
+          </span>
+        ) : null}
+      </label>
+
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-semibold text-slate-200">Dataset</span>
+        <select
+          value={fields.datasetId}
+          onChange={(event) => updateField('datasetId', event.target.value)}
+          aria-invalid={Boolean(errors.datasetId)}
+          aria-describedby="template-dataset-error"
+          className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-amber-400 focus:outline-none"
+        >
+          <option value="" disabled>
+            Select a dataset
+          </option>
+          {datasetOptions.map((dataset) => (
+            <option key={dataset.id} value={dataset.id}>
+              {dataset.name}
+            </option>
+          ))}
+        </select>
+        {errors.datasetId ? (
+          <span id="template-dataset-error" role="alert" className="text-xs text-red-300">
+            {errors.datasetId}
+          </span>
+        ) : null}
+      </label>
+
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-semibold text-slate-200">Swarm size</span>
+        <input
+          type="number"
+          min={1}
+          value={fields.swarmSize}
+          onChange={(event) => updateField('swarmSize', Number.parseInt(event.target.value, 10) || 0)}
+          aria-invalid={Boolean(errors.swarmSize)}
+          aria-describedby="template-swarm-error"
+          className="rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-amber-400 focus:outline-none"
+        />
+        {errors.swarmSize ? (
+          <span id="template-swarm-error" role="alert" className="text-xs text-red-300">
+            {errors.swarmSize}
+          </span>
+        ) : null}
+      </label>
+
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-semibold text-slate-200">Description</span>
+        <textarea
+          value={fields.description}
+          onChange={(event) => updateField('description', event.target.value)}
+          className="min-h-[96px] rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-amber-400 focus:outline-none"
+        />
+      </label>
+    </AssetForm>
+  )
+}
+
+export default SwarmTemplateForm

--- a/ui/src/scenario/assets/assetStore.test.ts
+++ b/ui/src/scenario/assets/assetStore.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { useAssetStore } from './assetStore'
+
+const resetStore = () => {
+  useAssetStore.getState().reset()
+  if (typeof window !== 'undefined' && window.localStorage) {
+    window.localStorage.removeItem('ph.scenario.assets')
+  }
+}
+
+describe('asset store', () => {
+  beforeEach(() => {
+    resetStore()
+  })
+
+  it('creates and updates systems under test', () => {
+    const { upsertSut } = useAssetStore.getState()
+
+    upsertSut({ id: 'sut-1', name: 'Primary', description: 'demo', entrypoint: 'image:latest', version: 'v1' })
+    upsertSut({ id: 'sut-2', name: 'Secondary', description: 'demo 2', entrypoint: 'image:v2', version: 'v2' })
+
+    expect(useAssetStore.getState().sutAssets).toHaveLength(2)
+    expect(useAssetStore.getState().sutAssets[0]?.id).toBe('sut-1')
+
+    upsertSut({ id: 'sut-1', name: 'Primary updated', entrypoint: 'image:v3', version: 'v3' })
+    expect(useAssetStore.getState().sutAssets.find((sut) => sut.id === 'sut-1')).toMatchObject({
+      name: 'Primary updated',
+      entrypoint: 'image:v3',
+      version: 'v3',
+    })
+  })
+
+  it('creates and updates datasets', () => {
+    const { upsertDataset } = useAssetStore.getState()
+
+    upsertDataset({ id: 'dataset-1', name: 'Dataset', description: 'docs', uri: 's3://bucket', format: 'json' })
+    upsertDataset({ id: 'dataset-2', name: 'Another', description: 'docs', uri: 'file://local', format: 'csv' })
+
+    expect(useAssetStore.getState().datasetAssets).toHaveLength(2)
+
+    upsertDataset({ id: 'dataset-2', name: 'Updated', uri: 'file://new', format: 'csv' })
+    expect(useAssetStore.getState().datasetAssets.find((dataset) => dataset.id === 'dataset-2')).toMatchObject({
+      name: 'Updated',
+      uri: 'file://new',
+    })
+  })
+
+  it('removes dependent templates when removing assets', () => {
+    const {
+      upsertSut,
+      upsertDataset,
+      upsertSwarmTemplate,
+      removeSut,
+      removeDataset,
+    } = useAssetStore.getState()
+
+    upsertSut({ id: 'sut-1', name: 'Primary', entrypoint: 'image', version: 'v1' })
+    upsertDataset({ id: 'dataset-1', name: 'Dataset', uri: 's3://bucket', format: 'json' })
+    upsertSwarmTemplate({
+      id: 'template-1',
+      name: 'Template',
+      sutId: 'sut-1',
+      datasetId: 'dataset-1',
+      swarmSize: 3,
+    })
+
+    expect(useAssetStore.getState().swarmTemplates).toHaveLength(1)
+
+    removeSut('sut-1')
+    expect(useAssetStore.getState().swarmTemplates).toHaveLength(0)
+
+    upsertSut({ id: 'sut-1', name: 'Primary', entrypoint: 'image', version: 'v1' })
+    upsertDataset({ id: 'dataset-1', name: 'Dataset', uri: 's3://bucket', format: 'json' })
+    upsertSwarmTemplate({
+      id: 'template-1',
+      name: 'Template',
+      sutId: 'sut-1',
+      datasetId: 'dataset-1',
+      swarmSize: 3,
+    })
+
+    removeDataset('dataset-1')
+    expect(useAssetStore.getState().swarmTemplates).toHaveLength(0)
+  })
+
+  it('normalises swarm size and updates templates', () => {
+    const { upsertSut, upsertDataset, upsertSwarmTemplate } = useAssetStore.getState()
+
+    upsertSut({ id: 'sut-1', name: 'Primary', entrypoint: 'image', version: 'v1' })
+    upsertDataset({ id: 'dataset-1', name: 'Dataset', uri: 's3://bucket', format: 'json' })
+
+    upsertSwarmTemplate({
+      id: 'template-1',
+      name: 'Template',
+      sutId: 'sut-1',
+      datasetId: 'dataset-1',
+      swarmSize: 0,
+    })
+
+    expect(useAssetStore.getState().swarmTemplates[0]?.swarmSize).toBe(1)
+
+    upsertSwarmTemplate({
+      id: 'template-1',
+      name: 'Template updated',
+      sutId: 'sut-1',
+      datasetId: 'dataset-1',
+      swarmSize: 5,
+    })
+
+    expect(useAssetStore.getState().swarmTemplates[0]).toMatchObject({
+      name: 'Template updated',
+      swarmSize: 5,
+    })
+  })
+})

--- a/ui/src/scenario/assets/assetStore.ts
+++ b/ui/src/scenario/assets/assetStore.ts
@@ -1,0 +1,96 @@
+import { create } from 'zustand'
+import { StateStorage, createJSONStorage, persist } from 'zustand/middleware'
+
+import {
+  DatasetAsset,
+  SwarmTemplateAsset,
+  SutAsset,
+  emptyCollections,
+  sortByName,
+} from './assets'
+
+const STORAGE_KEY = 'ph.scenario.assets'
+
+const ensureUnique = <T extends SutAsset | DatasetAsset | SwarmTemplateAsset>(
+  collection: T[],
+  asset: T,
+): T[] => {
+  const next = collection.some((item) => item.id === asset.id)
+    ? collection.map((item) => (item.id === asset.id ? asset : item))
+    : [...collection, asset]
+  return sortByName(next)
+}
+
+interface AssetState {
+  sutAssets: SutAsset[]
+  datasetAssets: DatasetAsset[]
+  swarmTemplates: SwarmTemplateAsset[]
+  upsertSut: (asset: SutAsset) => void
+  removeSut: (id: string) => void
+  upsertDataset: (asset: DatasetAsset) => void
+  removeDataset: (id: string) => void
+  upsertSwarmTemplate: (asset: SwarmTemplateAsset) => void
+  removeSwarmTemplate: (id: string) => void
+  reset: () => void
+}
+const memoryStorage: StateStorage = {
+  getItem: () => null,
+  setItem: () => undefined,
+  removeItem: () => undefined,
+}
+
+const storage = createJSONStorage(() => {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return memoryStorage
+  }
+  return window.localStorage
+})
+
+export const useAssetStore = create<AssetState>()(
+  persist(
+    (set) => ({
+      ...emptyCollections(),
+      upsertSut: (asset: SutAsset) =>
+        set((state) => ({
+          sutAssets: ensureUnique(state.sutAssets, asset),
+        })),
+      removeSut: (id: string) =>
+        set((state) => ({
+          sutAssets: state.sutAssets.filter((asset) => asset.id !== id),
+          swarmTemplates: state.swarmTemplates.filter((template) => template.sutId !== id),
+        })),
+      upsertDataset: (asset: DatasetAsset) =>
+        set((state) => ({
+          datasetAssets: ensureUnique(state.datasetAssets, asset),
+        })),
+      removeDataset: (id: string) =>
+        set((state) => ({
+          datasetAssets: state.datasetAssets.filter((asset) => asset.id !== id),
+          swarmTemplates: state.swarmTemplates.filter((template) => template.datasetId !== id),
+        })),
+      upsertSwarmTemplate: (asset: SwarmTemplateAsset) =>
+        set((state) => ({
+          swarmTemplates: ensureUnique(state.swarmTemplates, {
+            ...asset,
+            swarmSize: Math.max(1, asset.swarmSize),
+          }),
+        })),
+      removeSwarmTemplate: (id: string) =>
+        set((state) => ({
+          swarmTemplates: state.swarmTemplates.filter((asset) => asset.id !== id),
+        })),
+      reset: () => set(() => emptyCollections()),
+    }),
+    {
+      name: STORAGE_KEY,
+      storage,
+      partialize: (state) => ({
+        sutAssets: state.sutAssets,
+        datasetAssets: state.datasetAssets,
+        swarmTemplates: state.swarmTemplates,
+      }),
+    },
+  ),
+)
+
+export type { AssetState }

--- a/ui/src/scenario/assets/assets.ts
+++ b/ui/src/scenario/assets/assets.ts
@@ -1,0 +1,38 @@
+export interface AssetBase {
+  id: string
+  name: string
+  description?: string
+}
+
+export interface SutAsset extends AssetBase {
+  entrypoint: string
+  version: string
+}
+
+export interface DatasetAsset extends AssetBase {
+  uri: string
+  format: string
+}
+
+export interface SwarmTemplateAsset extends AssetBase {
+  sutId: string
+  datasetId: string
+  swarmSize: number
+}
+
+export type AssetKind = 'sut' | 'dataset' | 'template'
+
+export interface AssetCollections {
+  sutAssets: SutAsset[]
+  datasetAssets: DatasetAsset[]
+  swarmTemplates: SwarmTemplateAsset[]
+}
+
+export const emptyCollections = (): AssetCollections => ({
+  sutAssets: [],
+  datasetAssets: [],
+  swarmTemplates: [],
+})
+
+export const sortByName = <T extends AssetBase>(items: T[]): T[] =>
+  [...items].sort((a, b) => a.name.localeCompare(b.name))


### PR DESCRIPTION
## Summary
- add typed asset models and a persisted zustand asset store for the scenario builder
- build shared asset form primitives and per-asset editors with validation and linkage requirements
- surface asset management in the Scenario app with navigation, modals, and component/unit tests

## Testing
- npx vitest run --config ui/vite.config.ts ui/src/scenario/assets/assetStore.test.ts ui/src/scenario/ScenarioApp.integration.test.tsx ui/src/scenario/ScenarioApp.assets.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68dac5a6002883289b0fd733140b7f96