### PR TITLE
feat: validate scenario assets in scenario manager

### DIFF
--- a/scenario-manager-service/README.md
+++ b/scenario-manager-service/README.md
@@ -4,3 +4,51 @@ Manages simulation scenarios over a REST API.
 
 See the [architecture reference](../docs/ARCHITECTURE.md) for endpoint and signal details.
 
+## Scenario payload schema
+
+Scenarios embed references to registered assets. Requests submitted to `POST /scenarios`
+and `PUT /scenarios/{id}` must conform to [`src/main/resources/scenario-schema.json`](src/main/resources/scenario-schema.json).
+
+```json
+{
+  "id": "mock-1",
+  "name": "Mock scenario",
+  "assets": {
+    "suts": [
+      {
+        "id": "sut-generic",
+        "name": "Generic workload",
+        "entrypoint": "/opt/start.sh",
+        "version": "1.0.0"
+      }
+    ],
+    "datasets": [
+      {
+        "id": "dataset-gen",
+        "name": "Generator seed",
+        "uri": "s3://bucket/datasets/generator.json",
+        "format": "json"
+      }
+    ],
+    "swarmTemplates": [
+      {
+        "id": "swarm-default",
+        "name": "Default swarm",
+        "sutId": "sut-generic",
+        "datasetId": "dataset-gen",
+        "swarmSize": 1
+      }
+    ]
+  },
+  "template": {
+    "image": "pockethive-swarm-controller:latest",
+    "bees": []
+  },
+  "tracks": []
+}
+```
+
+All identifiers, entrypoints, URIs, and formats must be non-blank. Swarm template
+references must use registered SUT and dataset identifiers, and `swarmSize` must be a
+positive integer. Submit empty arrays when an asset catalog entry is not yet required.
+

--- a/scenario-manager-service/pom.xml
+++ b/scenario-manager-service/pom.xml
@@ -83,6 +83,12 @@
       <version>${archunit.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.networknt</groupId>
+      <artifactId>json-schema-validator</artifactId>
+      <version>1.4.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/scenario-manager-service/scenarios/mock-1.yaml
+++ b/scenario-manager-service/scenarios/mock-1.yaml
@@ -1,6 +1,26 @@
 id: mock-1
 name: Mock-1
 description: Sample scenario with generator, moderator, processor and postprocessor.
+assets:
+  suts:
+    - id: sut-generic
+      name: Sample Generator SUT
+      description: Sample entrypoint for the generator role.
+      entrypoint: /opt/bin/start-generator.sh
+      version: "1.0.0"
+  datasets:
+    - id: dataset-gen
+      name: Generator output seed
+      description: Seed data used by the generator stage.
+      uri: s3://pockethive/mock/datasets/generator-seed.json
+      format: json
+  swarmTemplates:
+    - id: swarm-default
+      name: Default swarm
+      description: Generator to postprocessor baseline pipeline.
+      sutId: sut-generic
+      datasetId: dataset-gen
+      swarmSize: 1
 template:
   image: pockethive-swarm-controller:latest
   bees:
@@ -22,3 +42,4 @@ template:
       image: pockethive-postprocessor:latest
       work:
         in: final
+tracks: []

--- a/scenario-manager-service/src/main/java/io/pockethive/scenarios/Scenario.java
+++ b/scenario-manager-service/src/main/java/io/pockethive/scenarios/Scenario.java
@@ -1,9 +1,15 @@
 package io.pockethive.scenarios;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.pockethive.scenarios.assets.ScenarioAssets;
 import io.pockethive.swarm.model.SwarmTemplate;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Scenario {
     @NotBlank
     private String id;
@@ -12,14 +18,23 @@ public class Scenario {
     private String description;
     @Valid
     private SwarmTemplate template;
+    @Valid
+    private ScenarioAssets assets = new ScenarioAssets();
+    private List<JsonNode> tracks = List.of();
 
     public Scenario() {}
 
     public Scenario(String id, String name, String description, SwarmTemplate template) {
+        this(id, name, description, template, new ScenarioAssets(), List.of());
+    }
+
+    public Scenario(String id, String name, String description, SwarmTemplate template, ScenarioAssets assets, List<JsonNode> tracks) {
         this.id = id;
         this.name = name;
         this.description = description;
         this.template = template;
+        this.assets = assets == null ? new ScenarioAssets() : assets;
+        this.tracks = tracks == null || tracks.isEmpty() ? List.of() : List.copyOf(tracks);
     }
 
     public String getId() {
@@ -52,5 +67,21 @@ public class Scenario {
 
     public void setTemplate(SwarmTemplate template) {
         this.template = template;
+    }
+
+    public ScenarioAssets getAssets() {
+        return assets;
+    }
+
+    public void setAssets(ScenarioAssets assets) {
+        this.assets = assets == null ? new ScenarioAssets() : assets;
+    }
+
+    public List<JsonNode> getTracks() {
+        return tracks;
+    }
+
+    public void setTracks(List<JsonNode> tracks) {
+        this.tracks = tracks == null || tracks.isEmpty() ? List.of() : List.copyOf(tracks);
     }
 }

--- a/scenario-manager-service/src/main/java/io/pockethive/scenarios/assets/DatasetAsset.java
+++ b/scenario-manager-service/src/main/java/io/pockethive/scenarios/assets/DatasetAsset.java
@@ -1,0 +1,66 @@
+package io.pockethive.scenarios.assets;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class DatasetAsset {
+    @NotBlank
+    private String id;
+    @NotBlank
+    private String name;
+    private String description;
+    @NotBlank
+    private String uri;
+    @NotBlank
+    private String format;
+
+    public DatasetAsset() {
+    }
+
+    public DatasetAsset(String id, String name, String description, String uri, String format) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.uri = uri;
+        this.format = format;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    public String getFormat() {
+        return format;
+    }
+
+    public void setFormat(String format) {
+        this.format = format;
+    }
+}

--- a/scenario-manager-service/src/main/java/io/pockethive/scenarios/assets/ScenarioAssets.java
+++ b/scenario-manager-service/src/main/java/io/pockethive/scenarios/assets/ScenarioAssets.java
@@ -1,0 +1,51 @@
+package io.pockethive.scenarios.assets;
+
+import jakarta.validation.Valid;
+
+import java.util.List;
+
+public class ScenarioAssets {
+    @Valid
+    private List<SutAsset> suts = List.of();
+    @Valid
+    private List<DatasetAsset> datasets = List.of();
+    @Valid
+    private List<SwarmTemplateAsset> swarmTemplates = List.of();
+
+    public ScenarioAssets() {
+    }
+
+    public ScenarioAssets(List<SutAsset> suts, List<DatasetAsset> datasets, List<SwarmTemplateAsset> swarmTemplates) {
+        this.suts = copyOrEmpty(suts);
+        this.datasets = copyOrEmpty(datasets);
+        this.swarmTemplates = copyOrEmpty(swarmTemplates);
+    }
+
+    public List<SutAsset> getSuts() {
+        return suts;
+    }
+
+    public void setSuts(List<SutAsset> suts) {
+        this.suts = copyOrEmpty(suts);
+    }
+
+    public List<DatasetAsset> getDatasets() {
+        return datasets;
+    }
+
+    public void setDatasets(List<DatasetAsset> datasets) {
+        this.datasets = copyOrEmpty(datasets);
+    }
+
+    public List<SwarmTemplateAsset> getSwarmTemplates() {
+        return swarmTemplates;
+    }
+
+    public void setSwarmTemplates(List<SwarmTemplateAsset> swarmTemplates) {
+        this.swarmTemplates = copyOrEmpty(swarmTemplates);
+    }
+
+    private <T> List<T> copyOrEmpty(List<T> source) {
+        return source == null || source.isEmpty() ? List.of() : List.copyOf(source);
+    }
+}

--- a/scenario-manager-service/src/main/java/io/pockethive/scenarios/assets/SutAsset.java
+++ b/scenario-manager-service/src/main/java/io/pockethive/scenarios/assets/SutAsset.java
@@ -1,0 +1,66 @@
+package io.pockethive.scenarios.assets;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class SutAsset {
+    @NotBlank
+    private String id;
+    @NotBlank
+    private String name;
+    private String description;
+    @NotBlank
+    private String entrypoint;
+    @NotBlank
+    private String version;
+
+    public SutAsset() {
+    }
+
+    public SutAsset(String id, String name, String description, String entrypoint, String version) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.entrypoint = entrypoint;
+        this.version = version;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getEntrypoint() {
+        return entrypoint;
+    }
+
+    public void setEntrypoint(String entrypoint) {
+        this.entrypoint = entrypoint;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+}

--- a/scenario-manager-service/src/main/java/io/pockethive/scenarios/assets/SwarmTemplateAsset.java
+++ b/scenario-manager-service/src/main/java/io/pockethive/scenarios/assets/SwarmTemplateAsset.java
@@ -1,0 +1,78 @@
+package io.pockethive.scenarios.assets;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+
+public class SwarmTemplateAsset {
+    @NotBlank
+    private String id;
+    @NotBlank
+    private String name;
+    private String description;
+    @NotBlank
+    private String sutId;
+    @NotBlank
+    private String datasetId;
+    @Min(1)
+    private int swarmSize = 1;
+
+    public SwarmTemplateAsset() {
+    }
+
+    public SwarmTemplateAsset(String id, String name, String description, String sutId, String datasetId, int swarmSize) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.sutId = sutId;
+        this.datasetId = datasetId;
+        this.swarmSize = swarmSize;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getSutId() {
+        return sutId;
+    }
+
+    public void setSutId(String sutId) {
+        this.sutId = sutId;
+    }
+
+    public String getDatasetId() {
+        return datasetId;
+    }
+
+    public void setDatasetId(String datasetId) {
+        this.datasetId = datasetId;
+    }
+
+    public int getSwarmSize() {
+        return swarmSize;
+    }
+
+    public void setSwarmSize(int swarmSize) {
+        this.swarmSize = swarmSize;
+    }
+}

--- a/scenario-manager-service/src/main/resources/scenario-schema.json
+++ b/scenario-manager-service/src/main/resources/scenario-schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://pockethive.io/schema/scenario",
+  "title": "Scenario",
+  "type": "object",
+  "required": ["id", "name", "assets"],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1
+    },
+    "description": {
+      "type": "string"
+    },
+    "assets": {
+      "type": "object",
+      "required": ["suts", "datasets", "swarmTemplates"],
+      "additionalProperties": false,
+      "properties": {
+        "suts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id", "name", "entrypoint", "version"],
+            "additionalProperties": false,
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "name": { "type": "string", "minLength": 1 },
+              "description": { "type": "string" },
+              "entrypoint": { "type": "string", "minLength": 1 },
+              "version": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "datasets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id", "name", "uri", "format"],
+            "additionalProperties": false,
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "name": { "type": "string", "minLength": 1 },
+              "description": { "type": "string" },
+              "uri": { "type": "string", "minLength": 1 },
+              "format": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "swarmTemplates": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id", "name", "sutId", "datasetId", "swarmSize"],
+            "additionalProperties": false,
+            "properties": {
+              "id": { "type": "string", "minLength": 1 },
+              "name": { "type": "string", "minLength": 1 },
+              "description": { "type": "string" },
+              "sutId": { "type": "string", "minLength": 1 },
+              "datasetId": { "type": "string", "minLength": 1 },
+              "swarmSize": { "type": "integer", "minimum": 1 }
+            }
+          }
+        }
+      }
+    },
+    "template": {
+      "type": ["object", "null"],
+      "additionalProperties": true
+    },
+    "tracks": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    }
+  }
+}

--- a/scenario-manager-service/src/test/java/io/pockethive/scenarios/ScenarioControllerTest.java
+++ b/scenario-manager-service/src/test/java/io/pockethive/scenarios/ScenarioControllerTest.java
@@ -32,7 +32,9 @@ class ScenarioControllerTest {
 
     @Test
     void crudOperations() throws Exception {
-        String body = "{\"id\":\"1\",\"name\":\"Test\"}";
+        String body = """
+            {"id":"1","name":"Test","assets":{"suts":[{"id":"sut-1","name":"SUT","entrypoint":"/run.sh","version":"1.0"}],"datasets":[{"id":"dataset-1","name":"Dataset","uri":"s3://bucket/data.json","format":"json"}],"swarmTemplates":[{"id":"template-1","name":"Template","sutId":"sut-1","datasetId":"dataset-1","swarmSize":1}]},"template":{"image":"controller","bees":[]},"tracks":[]}
+            """;
         mvc.perform(post("/scenarios").contentType(MediaType.APPLICATION_JSON).content(body))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value("1"));
@@ -44,12 +46,15 @@ class ScenarioControllerTest {
 
         mvc.perform(get("/scenarios/1").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.name").value("Test"));
+                .andExpect(jsonPath("$.assets.swarmTemplates[0].sutId").value("sut-1"));
 
+        String updateBody = """
+            {"id":"1","name":"Updated","assets":{"suts":[{"id":"sut-1","name":"Updated SUT","entrypoint":"/run.sh","version":"1.1"}],"datasets":[{"id":"dataset-1","name":"Dataset","uri":"s3://bucket/data.json","format":"json"}],"swarmTemplates":[{"id":"template-1","name":"Template","sutId":"sut-1","datasetId":"dataset-1","swarmSize":2}]},"template":{"image":"controller","bees":[]},"tracks":[]}
+            """;
         mvc.perform(put("/scenarios/1").contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"id\":\"1\",\"name\":\"Updated\"}"))
+                        .content(updateBody))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.name").value("Updated"));
+                .andExpect(jsonPath("$.assets.swarmTemplates[0].swarmSize").value(2));
 
         mvc.perform(delete("/scenarios/1"))
                 .andExpect(status().isNoContent());
@@ -60,26 +65,55 @@ class ScenarioControllerTest {
 
     @Test
     void yamlSupport() throws Exception {
-        String yaml = "id: 2\nname: Yaml";
+        String yaml = """
+            id: 2
+            name: Yaml
+            assets:
+              suts:
+                - id: sut-2
+                  name: YAML SUT
+                  entrypoint: /run.sh
+                  version: "1.0"
+              datasets:
+                - id: dataset-2
+                  name: YAML Dataset
+                  uri: s3://bucket/data.json
+                  format: json
+              swarmTemplates:
+                - id: template-2
+                  name: YAML Template
+                  sutId: sut-2
+                  datasetId: dataset-2
+                  swarmSize: 1
+            template:
+              image: controller
+              bees: []
+            tracks: []
+            """;
         mvc.perform(post("/scenarios").contentType("application/x-yaml").content(yaml))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.id").value("2"));
 
         mvc.perform(get("/scenarios/2").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.name").value("Yaml"));
+                .andExpect(jsonPath("$.assets.suts[0].entrypoint").value("/run.sh"));
     }
 
     @Test
     void validationFailure() throws Exception {
+        String body = """
+            {"id":"","name":"","assets":{"suts":[{"id":"","name":"","entrypoint":"","version":""}],"datasets":[{"id":"","name":"","uri":"","format":""}],"swarmTemplates":[{"id":"","name":"","sutId":"","datasetId":"","swarmSize":0}]},"template":{"image":"controller","bees":[]}}
+            """;
         mvc.perform(post("/scenarios").contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"id\":\"\",\"name\":\"\"}"))
+                        .content(body))
                 .andExpect(status().isBadRequest());
     }
 
     @Test
     void pathTraversalRejected() throws Exception {
-        String body = "{\"id\":\"../evil\",\"name\":\"Hack\"}";
+        String body = """
+            {"id":"../evil","name":"Hack","assets":{"suts":[],"datasets":[],"swarmTemplates":[]},"template":{"image":"controller","bees":[]}}
+            """;
         mvc.perform(post("/scenarios").contentType(MediaType.APPLICATION_JSON).content(body))
                 .andExpect(status().isBadRequest());
     }

--- a/scenario-manager-service/src/test/java/io/pockethive/scenarios/ScenarioSchemaValidationTest.java
+++ b/scenario-manager-service/src/test/java/io/pockethive/scenarios/ScenarioSchemaValidationTest.java
@@ -1,0 +1,83 @@
+package io.pockethive.scenarios;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ScenarioSchemaValidationTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static JsonSchema schema;
+
+    @BeforeAll
+    static void loadSchema() throws IOException {
+        try (InputStream schemaStream = Objects.requireNonNull(
+                ScenarioSchemaValidationTest.class.getResourceAsStream("/scenario-schema.json"),
+                "scenario-schema.json missing from classpath")) {
+            JsonNode schemaNode = MAPPER.readTree(schemaStream);
+            schema = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V202012).getSchema(schemaNode);
+        }
+    }
+
+    @Test
+    void createRequestMatchesSchema() throws IOException {
+        JsonNode scenario = MAPPER.readTree("""
+            {
+              "id": "scenario-1",
+              "name": "Scenario 1",
+              "assets": {
+                "suts": [
+                  {"id": "sut-1", "name": "SUT", "entrypoint": "/run.sh", "version": "1.0"}
+                ],
+                "datasets": [
+                  {"id": "dataset-1", "name": "Dataset", "uri": "s3://bucket/data.json", "format": "json"}
+                ],
+                "swarmTemplates": [
+                  {"id": "template-1", "name": "Template", "sutId": "sut-1", "datasetId": "dataset-1", "swarmSize": 1}
+                ]
+              },
+              "template": {"image": "controller", "bees": []},
+              "tracks": []
+            }
+            """);
+
+        Set<ValidationMessage> violations = schema.validate(scenario);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void rejectsBlankIdentifiers() throws IOException {
+        JsonNode scenario = MAPPER.readTree("""
+            {
+              "id": "",
+              "name": "",
+              "assets": {
+                "suts": [
+                  {"id": "", "name": "", "entrypoint": "", "version": ""}
+                ],
+                "datasets": [
+                  {"id": "", "name": "", "uri": "", "format": ""}
+                ],
+                "swarmTemplates": [
+                  {"id": "", "name": "", "sutId": "", "datasetId": "", "swarmSize": 0}
+                ]
+              }
+            }
+            """);
+
+        Set<ValidationMessage> violations = schema.validate(scenario);
+        assertThat(violations).isNotEmpty();
+    }
+}

--- a/scenario-manager-service/src/test/java/io/pockethive/scenarios/ScenarioServiceSerializationTest.java
+++ b/scenario-manager-service/src/test/java/io/pockethive/scenarios/ScenarioServiceSerializationTest.java
@@ -1,0 +1,82 @@
+package io.pockethive.scenarios;
+
+import io.pockethive.scenarios.assets.DatasetAsset;
+import io.pockethive.scenarios.assets.ScenarioAssets;
+import io.pockethive.scenarios.assets.SutAsset;
+import io.pockethive.scenarios.assets.SwarmTemplateAsset;
+import io.pockethive.swarm.model.SwarmTemplate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ScenarioServiceSerializationTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void writesScenarioWithAssetsToYaml() throws IOException {
+        ScenarioService service = new ScenarioService(tempDir.toString());
+        Scenario scenario = new Scenario(
+                "scenario-1",
+                "Scenario 1",
+                "Demo",
+                new SwarmTemplate("controller", List.of()),
+                new ScenarioAssets(
+                        List.of(new SutAsset("sut-1", "SUT", null, "/run.sh", "1.0")),
+                        List.of(new DatasetAsset("dataset-1", "Dataset", null, "s3://bucket/data.json", "json")),
+                        List.of(new SwarmTemplateAsset("template-1", "Template", null, "sut-1", "dataset-1", 1))
+                ),
+                List.of()
+        );
+
+        service.create(scenario, ScenarioService.Format.YAML);
+
+        Path stored = tempDir.resolve("scenario-1.yaml");
+        assertThat(Files.exists(stored)).isTrue();
+        assertThat(Files.readString(stored)).contains("assets:");
+    }
+
+    @Test
+    void readsScenarioWithAssetsFromYaml() throws IOException {
+        Files.writeString(tempDir.resolve("sample.yaml"), """
+            id: sample
+            name: Sample
+            assets:
+              suts:
+                - id: sut-1
+                  name: Sample SUT
+                  entrypoint: /run.sh
+                  version: "1.0"
+              datasets:
+                - id: dataset-1
+                  name: Dataset
+                  uri: s3://bucket/data.json
+                  format: json
+              swarmTemplates:
+                - id: template-1
+                  name: Template
+                  sutId: sut-1
+                  datasetId: dataset-1
+                  swarmSize: 1
+            template:
+              image: controller
+              bees: []
+            tracks: []
+            """);
+
+        ScenarioService service = new ScenarioService(tempDir.toString());
+        service.init();
+
+        Scenario loaded = service.find("sample").orElseThrow();
+
+        assertThat(loaded.getAssets().getSuts()).hasSize(1);
+        assertThat(loaded.getAssets().getSwarmTemplates().getFirst().getSutId()).isEqualTo("sut-1");
+    }
+}


### PR DESCRIPTION
## Summary
- add asset domain models and wire them into Scenario so richer payloads are persisted
- document and publish a JSON schema plus updated fixture describing the expanded scenario contract
- extend service and controller tests, including schema validation, to cover the new assets payload

## Testing
- mvn -pl scenario-manager-service test

------
https://chatgpt.com/codex/tasks/task_e_68dadc75932883289a32f7ebfb464b73