### PR TITLE
Extend swarm lifecycle e2e coverage for mock-1 components

### DIFF
--- a/e2e-tests/src/main/java/io/pockethive/e2e/support/QueueProbe.java
+++ b/e2e-tests/src/main/java/io/pockethive/e2e/support/QueueProbe.java
@@ -23,4 +23,28 @@ public final class QueueProbe {
     Properties properties = rabbitAdmin.getQueueProperties(queueName);
     return properties != null;
   }
+
+  /**
+   * Returns the total number of messages currently buffered in the queue.
+   *
+   * @param queueName queue to inspect
+   * @return message count (zero when the queue is empty)
+   * @throws IllegalArgumentException if the queue does not exist
+   */
+  public long messageCount(String queueName) {
+    Objects.requireNonNull(queueName, "queueName");
+    Properties properties = rabbitAdmin.getQueueProperties(queueName);
+    if (properties == null) {
+      throw new IllegalArgumentException("Queue not found: " + queueName);
+    }
+    Object value = properties.get(RabbitAdmin.QUEUE_MESSAGE_COUNT);
+    if (value instanceof Number number) {
+      return number.longValue();
+    }
+    if (value == null) {
+      return 0L;
+    }
+    throw new IllegalStateException("Unsupported message count type " + value.getClass().getName()
+        + " for queue " + queueName);
+  }
 }

--- a/e2e-tests/src/test/resources/features/swarm-lifecycle.feature
+++ b/e2e-tests/src/test/resources/features/swarm-lifecycle.feature
@@ -9,7 +9,10 @@ Feature: Swarm lifecycle golden path
     Then the swarm is registered and queues are declared
     When I start the swarm
     Then the swarm reports running
+    And each template component reports running and enabled
     When I stop the swarm
     Then the swarm reports stopped
+    And each template component reports disabled
+    And the workload queues remain stable
     When I remove the swarm
     Then the swarm is removed and lifecycle confirmations are recorded


### PR DESCRIPTION
## Summary
- extend the swarm lifecycle Cucumber feature with assertions that every mock-1 component enables, reports health, then disables cleanly
- watch config-update ready confirmations to ensure each role toggles as expected and monitor queue depths to guard against runaway traffic
- expose queue message counts to the test harness to support Rabbit stability assertions

## Testing
- ./mvnw -pl e2e-tests test *(fails: network unreachable while downloading Maven wrapper distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb7b61e6083289991f94d65c877b9