### PR TITLE
fix: include worker-sdk module in service Docker builds

### DIFF
--- a/generator-service/Dockerfile
+++ b/generator-service/Dockerfile
@@ -8,6 +8,7 @@ COPY common/docker-client/pom.xml common/docker-client/pom.xml
 COPY common/swarm-model/pom.xml common/swarm-model/pom.xml
 COPY common/control-plane-core/pom.xml common/control-plane-core/pom.xml
 COPY common/control-plane-spring/pom.xml common/control-plane-spring/pom.xml
+COPY common/worker-sdk/pom.xml common/worker-sdk/pom.xml
 COPY test/pom.xml test/pom.xml
 COPY e2e-tests/pom.xml e2e-tests/pom.xml
 COPY generator-service/pom.xml generator-service/pom.xml
@@ -25,6 +26,7 @@ COPY common/docker-client/src common/docker-client/src
 COPY common/swarm-model/src common/swarm-model/src
 COPY common/control-plane-core/src common/control-plane-core/src
 COPY common/control-plane-spring/src common/control-plane-spring/src
+COPY common/worker-sdk/src common/worker-sdk/src
 COPY test/src test/src
 COPY e2e-tests/src e2e-tests/src
 COPY generator-service/src generator-service/src

--- a/log-aggregator-service/Dockerfile
+++ b/log-aggregator-service/Dockerfile
@@ -7,6 +7,7 @@ COPY common/docker-client/pom.xml common/docker-client/pom.xml
 COPY common/swarm-model/pom.xml common/swarm-model/pom.xml
 COPY common/control-plane-core/pom.xml common/control-plane-core/pom.xml
 COPY common/control-plane-spring/pom.xml common/control-plane-spring/pom.xml
+COPY common/worker-sdk/pom.xml common/worker-sdk/pom.xml
 COPY test/pom.xml test/pom.xml
 COPY e2e-tests/pom.xml e2e-tests/pom.xml
 COPY log-aggregator-service/pom.xml log-aggregator-service/pom.xml
@@ -24,6 +25,7 @@ COPY common/docker-client/src common/docker-client/src
 COPY common/swarm-model/src common/swarm-model/src
 COPY common/control-plane-core/src common/control-plane-core/src
 COPY common/control-plane-spring/src common/control-plane-spring/src
+COPY common/worker-sdk/src common/worker-sdk/src
 COPY test/src test/src
 COPY e2e-tests/src e2e-tests/src
 COPY log-aggregator-service/src log-aggregator-service/src

--- a/moderator-service/Dockerfile
+++ b/moderator-service/Dockerfile
@@ -8,6 +8,7 @@ COPY common/docker-client/pom.xml common/docker-client/pom.xml
 COPY common/swarm-model/pom.xml common/swarm-model/pom.xml
 COPY common/control-plane-core/pom.xml common/control-plane-core/pom.xml
 COPY common/control-plane-spring/pom.xml common/control-plane-spring/pom.xml
+COPY common/worker-sdk/pom.xml common/worker-sdk/pom.xml
 COPY test/pom.xml test/pom.xml
 COPY e2e-tests/pom.xml e2e-tests/pom.xml
 COPY generator-service/pom.xml generator-service/pom.xml
@@ -25,6 +26,7 @@ COPY common/docker-client/src common/docker-client/src
 COPY common/swarm-model/src common/swarm-model/src
 COPY common/control-plane-core/src common/control-plane-core/src
 COPY common/control-plane-spring/src common/control-plane-spring/src
+COPY common/worker-sdk/src common/worker-sdk/src
 COPY test/src test/src
 COPY e2e-tests/src e2e-tests/src
 COPY generator-service/src generator-service/src

--- a/orchestrator-service/Dockerfile
+++ b/orchestrator-service/Dockerfile
@@ -8,6 +8,7 @@ COPY common/docker-client/pom.xml common/docker-client/pom.xml
 COPY common/swarm-model/pom.xml common/swarm-model/pom.xml
 COPY common/control-plane-core/pom.xml common/control-plane-core/pom.xml
 COPY common/control-plane-spring/pom.xml common/control-plane-spring/pom.xml
+COPY common/worker-sdk/pom.xml common/worker-sdk/pom.xml
 COPY test/pom.xml test/pom.xml
 COPY e2e-tests/pom.xml e2e-tests/pom.xml
 COPY orchestrator-service/pom.xml orchestrator-service/pom.xml
@@ -25,6 +26,7 @@ COPY common/docker-client/src common/docker-client/src
 COPY common/swarm-model/src common/swarm-model/src
 COPY common/control-plane-core/src common/control-plane-core/src
 COPY common/control-plane-spring/src common/control-plane-spring/src
+COPY common/worker-sdk/src common/worker-sdk/src
 COPY test/src test/src
 COPY e2e-tests/src e2e-tests/src
 COPY orchestrator-service/src orchestrator-service/src

--- a/postprocessor-service/Dockerfile
+++ b/postprocessor-service/Dockerfile
@@ -7,6 +7,7 @@ COPY common/docker-client/pom.xml common/docker-client/pom.xml
 COPY common/swarm-model/pom.xml common/swarm-model/pom.xml
 COPY common/control-plane-core/pom.xml common/control-plane-core/pom.xml
 COPY common/control-plane-spring/pom.xml common/control-plane-spring/pom.xml
+COPY common/worker-sdk/pom.xml common/worker-sdk/pom.xml
 COPY test/pom.xml test/pom.xml
 COPY e2e-tests/pom.xml e2e-tests/pom.xml
 COPY observability/pom.xml observability/pom.xml
@@ -24,6 +25,7 @@ COPY common/docker-client/src common/docker-client/src
 COPY common/swarm-model/src common/swarm-model/src
 COPY common/control-plane-core/src common/control-plane-core/src
 COPY common/control-plane-spring/src common/control-plane-spring/src
+COPY common/worker-sdk/src common/worker-sdk/src
 COPY test/src test/src
 COPY e2e-tests/src e2e-tests/src
 COPY observability/src observability/src

--- a/processor-service/Dockerfile
+++ b/processor-service/Dockerfile
@@ -8,6 +8,7 @@ COPY common/docker-client/pom.xml common/docker-client/pom.xml
 COPY common/swarm-model/pom.xml common/swarm-model/pom.xml
 COPY common/control-plane-core/pom.xml common/control-plane-core/pom.xml
 COPY common/control-plane-spring/pom.xml common/control-plane-spring/pom.xml
+COPY common/worker-sdk/pom.xml common/worker-sdk/pom.xml
 COPY test/pom.xml test/pom.xml
 COPY e2e-tests/pom.xml e2e-tests/pom.xml
 COPY generator-service/pom.xml generator-service/pom.xml
@@ -25,6 +26,7 @@ COPY common/docker-client/src common/docker-client/src
 COPY common/swarm-model/src common/swarm-model/src
 COPY common/control-plane-core/src common/control-plane-core/src
 COPY common/control-plane-spring/src common/control-plane-spring/src
+COPY common/worker-sdk/src common/worker-sdk/src
 COPY test/src test/src
 COPY e2e-tests/src e2e-tests/src
 COPY generator-service/src generator-service/src

--- a/scenario-manager-service/Dockerfile
+++ b/scenario-manager-service/Dockerfile
@@ -8,6 +8,7 @@ COPY common/docker-client/pom.xml common/docker-client/pom.xml
 COPY common/swarm-model/pom.xml common/swarm-model/pom.xml
 COPY common/control-plane-core/pom.xml common/control-plane-core/pom.xml
 COPY common/control-plane-spring/pom.xml common/control-plane-spring/pom.xml
+COPY common/worker-sdk/pom.xml common/worker-sdk/pom.xml
 COPY test/pom.xml test/pom.xml
 COPY e2e-tests/pom.xml e2e-tests/pom.xml
 COPY scenario-manager-service/pom.xml scenario-manager-service/pom.xml
@@ -25,6 +26,7 @@ COPY common/docker-client/src common/docker-client/src
 COPY common/swarm-model/src common/swarm-model/src
 COPY common/control-plane-core/src common/control-plane-core/src
 COPY common/control-plane-spring/src common/control-plane-spring/src
+COPY common/worker-sdk/src common/worker-sdk/src
 COPY test/src test/src
 COPY e2e-tests/src e2e-tests/src
 COPY scenario-manager-service/src scenario-manager-service/src

--- a/swarm-controller-service/Dockerfile
+++ b/swarm-controller-service/Dockerfile
@@ -8,6 +8,7 @@ COPY common/docker-client/pom.xml common/docker-client/pom.xml
 COPY common/swarm-model/pom.xml common/swarm-model/pom.xml
 COPY common/control-plane-core/pom.xml common/control-plane-core/pom.xml
 COPY common/control-plane-spring/pom.xml common/control-plane-spring/pom.xml
+COPY common/worker-sdk/pom.xml common/worker-sdk/pom.xml
 COPY test/pom.xml test/pom.xml
 COPY e2e-tests/pom.xml e2e-tests/pom.xml
 COPY generator-service/pom.xml generator-service/pom.xml
@@ -25,6 +26,7 @@ COPY common/docker-client/src common/docker-client/src
 COPY common/swarm-model/src common/swarm-model/src
 COPY common/control-plane-core/src common/control-plane-core/src
 COPY common/control-plane-spring/src common/control-plane-spring/src
+COPY common/worker-sdk/src common/worker-sdk/src
 COPY test/src test/src
 COPY e2e-tests/src e2e-tests/src
 COPY generator-service/src generator-service/src

--- a/trigger-service/Dockerfile
+++ b/trigger-service/Dockerfile
@@ -8,6 +8,7 @@ COPY common/docker-client/pom.xml common/docker-client/pom.xml
 COPY common/swarm-model/pom.xml common/swarm-model/pom.xml
 COPY common/control-plane-core/pom.xml common/control-plane-core/pom.xml
 COPY common/control-plane-spring/pom.xml common/control-plane-spring/pom.xml
+COPY common/worker-sdk/pom.xml common/worker-sdk/pom.xml
 COPY test/pom.xml test/pom.xml
 COPY e2e-tests/pom.xml e2e-tests/pom.xml
 COPY trigger-service/pom.xml trigger-service/pom.xml
@@ -25,6 +26,7 @@ COPY common/docker-client/src common/docker-client/src
 COPY common/swarm-model/src common/swarm-model/src
 COPY common/control-plane-core/src common/control-plane-core/src
 COPY common/control-plane-spring/src common/control-plane-spring/src
+COPY common/worker-sdk/src common/worker-sdk/src
 COPY test/src test/src
 COPY e2e-tests/src e2e-tests/src
 COPY trigger-service/src trigger-service/src


### PR DESCRIPTION
## Summary
- copy the common worker-sdk module into every service Docker build context so Maven can resolve the module

## Testing
- mvn -q -pl orchestrator-service -am -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68de651d6f7083289f1fa9672f81ecc9