### PR TITLE
Remove PH_ENABLED from swarm container environment

### DIFF
--- a/moderator-service/src/test/java/io/pockethive/moderator/ModeratorRuntimeAdapterTest.java
+++ b/moderator-service/src/test/java/io/pockethive/moderator/ModeratorRuntimeAdapterTest.java
@@ -72,12 +72,16 @@ class ModeratorRuntimeAdapterTest {
         ModeratorWorkerConfig.class
     );
     when(workerRegistry.all()).thenReturn(List.of(definition));
+  }
+
+  private void stubListenerContainerStopped() {
     when(listenerRegistry.getListenerContainer("moderatorWorkerListener")).thenReturn(listenerContainer);
     when(listenerContainer.isRunning()).thenReturn(false);
   }
 
   @Test
   void onWorkDispatchesToWorkerAndPublishesResult() throws Exception {
+    stubListenerContainerStopped();
     doReturn(WorkResult.message(WorkMessage.text("forwarded").build()))
         .when(workerRuntime)
         .dispatch(eq("moderatorWorker"), any(WorkMessage.class));
@@ -107,6 +111,7 @@ class ModeratorRuntimeAdapterTest {
 
   @Test
   void onControlDelegatesToControlPlaneRuntime() {
+    stubListenerContainerStopped();
     ModeratorRuntimeAdapter adapter = new ModeratorRuntimeAdapter(
         workerRuntime,
         workerRegistry,
@@ -134,6 +139,7 @@ class ModeratorRuntimeAdapterTest {
 
   @Test
   void registersListenerAndAppliesDesiredState() {
+    stubListenerContainerStopped();
     ModeratorRuntimeAdapter adapter = new ModeratorRuntimeAdapter(
         workerRuntime,
         workerRegistry,

--- a/processor-service/src/test/java/io/pockethive/processor/ProcessorRuntimeAdapterTest.java
+++ b/processor-service/src/test/java/io/pockethive/processor/ProcessorRuntimeAdapterTest.java
@@ -73,8 +73,6 @@ class ProcessorRuntimeAdapterTest {
         ProcessorWorkerConfig.class
     );
     when(workerRegistry.all()).thenReturn(List.of(definition));
-    when(listenerRegistry.getListenerContainer("processorWorkerListener")).thenReturn(listenerContainer);
-    when(listenerContainer.isRunning()).thenReturn(false);
   }
 
   @Test
@@ -135,6 +133,9 @@ class ProcessorRuntimeAdapterTest {
 
   @Test
   void registersListenerAppliesDesiredStateAndEmitsSnapshot() {
+    when(listenerRegistry.getListenerContainer("processorWorkerListener")).thenReturn(listenerContainer);
+    when(listenerContainer.isRunning()).thenReturn(false);
+
     ProcessorRuntimeAdapter adapter = new ProcessorRuntimeAdapter(
         workerRuntime,
         workerRegistry,

--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmLifecycleManager.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmLifecycleManager.java
@@ -123,7 +123,6 @@ public class SwarmLifecycleManager implements SwarmLifecycle {
             env.put("PH_CONTROL_EXCHANGE", Topology.CONTROL_EXCHANGE);
             env.put("RABBITMQ_HOST", java.util.Optional.ofNullable(System.getenv("RABBITMQ_HOST")).orElse("rabbitmq"));
             env.put("PH_LOGS_EXCHANGE", java.util.Optional.ofNullable(System.getenv("PH_LOGS_EXCHANGE")).orElse("ph.logs"));
-            env.put("PH_ENABLED", "false");
             String net = docker.resolveControlNetwork();
             if (net != null && !net.isBlank()) {
               env.put("CONTROL_NETWORK", net);

--- a/swarm-controller-service/src/test/java/io/pockethive/swarmcontroller/SwarmLifecycleManagerTest.java
+++ b/swarm-controller-service/src/test/java/io/pockethive/swarmcontroller/SwarmLifecycleManagerTest.java
@@ -79,7 +79,6 @@ class SwarmLifecycleManagerTest {
     assertEquals("ctrl-net", env.get("CONTROL_NETWORK"));
     assertEquals("ph." + Topology.SWARM_ID + ".qin", env.get("PH_MOD_QUEUE"));
     assertEquals("ph." + Topology.SWARM_ID + ".qout", env.get("PH_GEN_QUEUE"));
-    assertEquals("false", env.get("PH_ENABLED"));
     assertTrue(env.get("JAVA_TOOL_OPTIONS").endsWith("-Dbee.name=" + assignedName));
     verify(docker).startContainer("c1");
     assertEquals(SwarmStatus.RUNNING, manager.getStatus());
@@ -150,7 +149,6 @@ class SwarmLifecycleManagerTest {
     verify(docker).createContainer(eq("img1"), envCap2.capture(), nameCap2.capture());
     Map<String,String> env = envCap2.getValue();
     assertTrue(env.get("JAVA_TOOL_OPTIONS").endsWith("-Dbee.name=" + nameCap2.getValue()));
-    assertEquals("false", env.get("PH_ENABLED"));
     verify(docker).resolveControlNetwork();
     verify(docker).startContainer("c1");
     verify(amqp).declareExchange(argThat((TopicExchange e) -> e.getName().equals("ph." + Topology.SWARM_ID + ".hive")));


### PR DESCRIPTION
## Summary
- stop injecting the PH_ENABLED flag when starting swarm containers
- align SwarmLifecycleManager tests with the updated environment expectations

## Testing
- ./mvnw -pl swarm-controller-service test *(fails: Maven wrapper cannot download distribution due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ef1f52ec832897b0adbba1b3587c