### PR TITLE
docs: add TODO entry for ready confirmation improvements

### DIFF
--- a/docs/TODOS.md
+++ b/docs/TODOS.md
@@ -1,0 +1,3 @@
+# TODOs
+
+- [ ] Refactor ready confirmation events to include human-readable notes and reduce duplicated `scope{}` metadata so confirmations clearly state what was acknowledged.


### PR DESCRIPTION
## Summary
- add a docs/TODOS.md tracker
- record a follow-up to enhance ready confirmation human-readable notes and reduce scope duplication

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e4d21faa3c832883587e4a429f5731