### PR TITLE
Update Worker SDK documentation and add Javadoc

### DIFF
--- a/common/worker-sdk/README.md
+++ b/common/worker-sdk/README.md
@@ -1,17 +1,16 @@
 # PocketHive Worker SDK
 
-The Worker SDK packages the Spring Boot auto-configuration and testing helpers required to bootstrap PocketHive control-plane
-participants. It combines the shared topology descriptors, emitters, and AMQP infrastructure from the `control-plane-*`
-modules so new workers can be scaffolded with minimal ceremony.
+The Worker SDK packages the Spring Boot auto-configuration, runtime loop, and testing helpers required to bootstrap PocketHive control-plane participants. It combines the shared topology descriptors, emitters, runtime dispatch, and AMQP infrastructure from the `control-plane-*` modules so new workers can be scaffolded with minimal ceremony.
+
+To understand the evolution of the SDK, see the [simplification roadmap](../../docs/sdk/worker-sdk-simplification-plan.md) and the [Stage 1 runtime notes](../../docs/sdk/worker-sdk-stage1-runtime.md).
 
 ## Modules
 
-* `io.pockethive.worker.sdk.autoconfigure.PocketHiveWorkerSdkAutoConfiguration` exposes the canonical control-plane beans for
-  worker and manager roles.
-* `io.pockethive.worker.sdk.testing.ControlPlaneTestFixtures` provides pre-configured descriptors, identities, and property
-  builders that make unit tests easier to wire.
+* `io.pockethive.worker.sdk.autoconfigure.PocketHiveWorkerSdkAutoConfiguration` exposes the canonical control-plane beans for worker and manager roles.
+* `io.pockethive.worker.sdk.runtime` provides the Stage 1–3 runtime (`WorkerRuntime`, `WorkerControlPlaneRuntime`, interceptors, and state store) that discovers worker beans and drives invocation.
+* `io.pockethive.worker.sdk.testing.ControlPlaneTestFixtures` provides pre-configured descriptors, identities, and property builders that make unit tests easier to wire.
 
-Add the dependency to a worker service to automatically register the control-plane beans:
+Add the dependency to a worker service to automatically register the control-plane beans and runtime:
 
 ```xml
 <dependency>
@@ -19,3 +18,92 @@ Add the dependency to a worker service to automatically register the control-pla
   <artifactId>worker-sdk</artifactId>
 </dependency>
 ```
+
+## Runtime APIs
+
+### `GeneratorWorker`
+
+Generator workers periodically emit messages without a triggering inbound queue. The runtime calls `generate(WorkerContext)` on a schedule that honours per-worker quotas derived from control-plane config. Implementations build a `WorkMessage` and return it wrapped in `WorkResult.message(...)`.
+
+```java
+@Component("generatorWorker")
+@PocketHiveWorker(
+    role = "generator",
+    type = WorkerType.GENERATOR,
+    outQueue = TopologyDefaults.GEN_QUEUE,
+    config = GeneratorWorkerConfig.class
+)
+class GeneratorWorkerImpl implements GeneratorWorker {
+
+  private final GeneratorDefaults defaults;
+
+  @Override
+  public WorkResult generate(WorkerContext context) {
+    GeneratorWorkerConfig config = context.config(GeneratorWorkerConfig.class)
+        .orElseGet(defaults::asConfig);
+    context.statusPublisher()
+        .workOut(Topology.GEN_QUEUE)
+        .update(status -> status.data("path", config.path()));
+    return WorkResult.message(WorkMessage.json(buildPayload(config)).build());
+  }
+}
+```
+
+The full implementation lives in [`generator-service`](../../generator-service/src/main/java/io/pockethive/generator/GeneratorWorkerImpl.java).
+
+### `MessageWorker`
+
+Message workers react to inbound queues. The runtime maps RabbitMQ deliveries into `WorkMessage` instances and invokes `onMessage(WorkMessage, WorkerContext)`. The return value controls whether a response is published downstream.
+
+```java
+@Component("processorWorker")
+@PocketHiveWorker(
+    role = "processor",
+    type = WorkerType.MESSAGE,
+    inQueue = TopologyDefaults.MOD_QUEUE,
+    outQueue = TopologyDefaults.FINAL_QUEUE,
+    config = ProcessorWorkerConfig.class
+)
+class ProcessorWorkerImpl implements MessageWorker {
+
+  @Override
+  public WorkResult onMessage(WorkMessage in, WorkerContext context) {
+    ProcessorWorkerConfig config = context.config(ProcessorWorkerConfig.class)
+        .orElseGet(defaults::asConfig);
+    context.statusPublisher()
+        .workIn(Topology.MOD_QUEUE)
+        .workOut(Topology.FINAL_QUEUE)
+        .update(status -> status.data("baseUrl", config.baseUrl()));
+    WorkMessage enriched = invokeHttpAndEnrich(in, context, config);
+    return WorkResult.message(enriched);
+  }
+}
+```
+
+See [`processor-service`](../../processor-service/src/main/java/io/pockethive/processor/ProcessorWorkerImpl.java) for the full example, including metrics and observability integration.
+
+### `WorkMessage`
+
+`WorkMessage` is the immutable representation of a worker payload (body, headers, charset, and optional `ObservabilityContext`). Builders support text, JSON, and binary bodies, plus accessors like `asJsonNode()` for consumers. All runtime adapters use `WorkMessage` as the canonical format when bridging transports.
+
+### `WorkerContext`
+
+Every invocation receives a `WorkerContext` that exposes topology metadata (`WorkerInfo`), typed configuration, logging, Micrometer/Observation registries, and the `StatusPublisher`. Use the context helpers to record metrics, enrich status snapshots, and access control-plane config documented in the [Worker SDK quick start](../../docs/sdk/worker-sdk-quickstart.md).
+
+### `WorkerRuntime`
+
+Transports interact with the runtime through `WorkerRuntime.dispatch(beanName, WorkMessage)`. The `DefaultWorkerRuntime` is provided by auto-configuration and resolves worker beans, builds invocation contexts, runs interceptors, and translates results back to the transport-specific adapter. See the runtime adapters in the [trigger](../../trigger-service/src/main/java/io/pockethive/trigger/TriggerRuntimeAdapter.java) and [generator](../../generator-service/src/main/java/io/pockethive/generator/GeneratorRuntimeAdapter.java) services for integration patterns.
+
+### `WorkerControlPlaneRuntime`
+
+The control-plane runtime bridges the SDK with the control-plane topic. It applies config updates, maintains per-worker state, publishes ready/status events, and exposes listeners. Stage 2 and Stage 3 capabilities (config hydration, status deltas, observability scaffolding) are described in [worker-sdk-stage1-runtime.md](../../docs/sdk/worker-sdk-stage1-runtime.md) and extended in the [quick start](../../docs/sdk/worker-sdk-quickstart.md).
+
+## Putting it together
+
+1. Add the `worker-sdk` dependency to your service.
+2. Annotate business beans with `@PocketHiveWorker`, selecting the worker type and queues.
+3. Implement `GeneratorWorker` or `MessageWorker` interfaces and return `WorkResult` instances.
+4. Inject `WorkerRuntime` and `WorkerControlPlaneRuntime` into your transport adapter to dispatch messages and surface control-plane state (see the `*RuntimeAdapter` classes in each migrated service).
+5. Use `WorkerContext` for config, metrics, observability, and status reporting.
+
+For a full walkthrough consult the [Worker SDK quick start](../../docs/sdk/worker-sdk-quickstart.md), which links to Stage 1–3 features and migration tips.

--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/api/GeneratorWorker.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/api/GeneratorWorker.java
@@ -2,9 +2,23 @@ package io.pockethive.worker.sdk.api;
 
 /**
  * Defines the minimal business contract for generator-style workers.
+ * <p>
+ * Generator workers are invoked on a schedule managed by the runtime. See the
+ * {@code docs/sdk/worker-sdk-quickstart.md} guide for usage examples and Stage 1–3
+ * behaviour notes.
  */
 @FunctionalInterface
 public interface GeneratorWorker {
 
+    /**
+     * Generates the next message to send downstream.
+     *
+     * @param context runtime context populated with control-plane configuration, status publisher,
+     *                logging, and observability hooks
+     * @return a {@link WorkResult#message(WorkMessage)} to emit or {@link WorkResult#none()} when
+     *         no message should be produced
+     * @throws Exception any exception raised during generation. The runtime records the failure and
+     *                   emits status updates according to the quick start guide.
+     */
     WorkResult generate(WorkerContext context) throws Exception;
 }

--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/api/MessageWorker.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/api/MessageWorker.java
@@ -2,9 +2,24 @@ package io.pockethive.worker.sdk.api;
 
 /**
  * Defines the minimal business contract for message-processing workers.
+ * <p>
+ * Message workers are invoked when transports deliver inbound work messages. Consult the
+ * {@code docs/sdk/worker-sdk-quickstart.md} guide for lifecycle, status, and observability
+ * conventions.
  */
 @FunctionalInterface
 public interface MessageWorker {
 
+    /**
+     * Processes an inbound message and optionally emits a new payload.
+     *
+     * @param in      inbound payload converted to a {@link WorkMessage}
+     * @param context runtime context populated with control-plane configuration, status publisher,
+     *                logging, and observability hooks
+     * @return {@link WorkResult#message(WorkMessage)} to publish downstream or
+     *         {@link WorkResult#none()} when no response is required
+     * @throws Exception any exception raised while handling the message. The runtime records the
+     *                   failure and emits status updates according to the quick start guide.
+     */
     WorkResult onMessage(WorkMessage in, WorkerContext context) throws Exception;
 }

--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/api/StatusPublisher.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/api/StatusPublisher.java
@@ -4,6 +4,9 @@ import java.util.function.Consumer;
 
 /**
  * Allows workers to enrich status snapshots emitted by the runtime.
+ * <p>
+ * Status publishers provide Stage 2 status integration points. The quick start guide in
+ * {@code docs/sdk/worker-sdk-quickstart.md} illustrates how generators and message workers use these helpers.
  */
 public interface StatusPublisher {
 
@@ -14,29 +17,50 @@ public interface StatusPublisher {
         }
     };
 
+    /**
+     * Applies mutations to the mutable status map before the runtime emits the snapshot.
+     */
     void update(Consumer<MutableStatus> consumer);
 
+    /**
+     * Records an inbound work route associated with the status update.
+     */
     default StatusPublisher workIn(String route) {
         return this;
     }
 
+    /**
+     * Records an outbound work route associated with the status update.
+     */
     default StatusPublisher workOut(String route) {
         return this;
     }
 
+    /**
+     * Forces the runtime to emit a full snapshot for the worker.
+     */
     default void emitFull() {
         // no-op
     }
 
+    /**
+     * Requests a delta snapshot emission.
+     */
     default void emitDelta() {
         // no-op
     }
 
+    /**
+     * Increments the processed counter associated with the worker.
+     */
     default void recordProcessed() {
         // no-op
     }
 
     interface MutableStatus {
+        /**
+         * Adds or replaces a key/value pair in the emitted status payload.
+         */
         MutableStatus data(String key, Object value);
     }
 }

--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/api/WorkResult.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/api/WorkResult.java
@@ -3,19 +3,29 @@ package io.pockethive.worker.sdk.api;
 import java.util.Objects;
 
 /**
- * Represents the outcome of a worker invocation.
+ * Represents the outcome of a worker invocation as described in
+ * {@code docs/sdk/worker-sdk-quickstart.md}.
  */
 public sealed interface WorkResult permits WorkResult.Message, WorkResult.None {
 
+    /**
+     * Creates a result that publishes the supplied message downstream.
+     */
     static WorkResult message(WorkMessage message) {
         return new Message(message);
     }
 
+    /**
+     * Creates a result indicating the worker produced no outbound message.
+     */
     static WorkResult none() {
         return None.INSTANCE;
     }
 
     record Message(WorkMessage value) implements WorkResult {
+        /**
+         * @param value outbound message produced by the worker
+         */
         public Message {
             Objects.requireNonNull(value, "value");
         }
@@ -27,6 +37,9 @@ public sealed interface WorkResult permits WorkResult.Message, WorkResult.None {
         private None() {
         }
 
+        /**
+         * Returns the shared {@link WorkResult#none()} instance.
+         */
         static WorkResult instance() {
             return INSTANCE;
         }

--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/api/WorkerContext.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/api/WorkerContext.java
@@ -10,26 +10,57 @@ import org.slf4j.Logger;
 
 /**
  * Infrastructure-backed context passed to worker business logic.
+ * <p>
+ * Provides access to control-plane configuration, metrics, logging, and observability facilities. Refer to
+ * {@code docs/sdk/worker-sdk-quickstart.md} for usage guidance across Stage 1–3 features.
  */
 public interface WorkerContext {
 
+    /**
+     * Returns metadata about the running worker (role, queues, swarm identifiers).
+     */
     WorkerInfo info();
 
+    /**
+     * Resolves the latest typed configuration supplied by the control plane.
+     *
+     * @param type configuration class to look up
+     * @param <C>  configuration type
+     * @return a typed configuration or {@link Optional#empty()} when no config is available
+     */
     <C> Optional<C> config(Class<C> type);
 
+    /**
+     * Convenience wrapper that falls back to a supplier when no configuration is available.
+     */
     default <C> C configOrDefault(Class<C> type, Supplier<C> fallback) {
         Objects.requireNonNull(type, "type");
         Objects.requireNonNull(fallback, "fallback");
         return config(type).orElseGet(fallback);
     }
 
+    /**
+     * Returns the {@link StatusPublisher} used to enrich emitted status snapshots.
+     */
     StatusPublisher statusPublisher();
 
+    /**
+     * Returns a SLF4J logger scoped to the worker implementation.
+     */
     Logger logger();
 
+    /**
+     * Provides the Micrometer registry shared by the runtime (Stage 3).
+     */
     MeterRegistry meterRegistry();
 
+    /**
+     * Provides the Micrometer Observation registry shared by the runtime (Stage 3).
+     */
     ObservationRegistry observationRegistry();
 
+    /**
+     * Returns the propagated observability context (trace identifiers and hop history).
+     */
     ObservabilityContext observabilityContext();
 }

--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/api/WorkerInfo.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/api/WorkerInfo.java
@@ -3,7 +3,8 @@ package io.pockethive.worker.sdk.api;
 import java.util.Objects;
 
 /**
- * Describes the worker identity and routing metadata.
+ * Describes the worker identity and routing metadata available via {@link WorkerContext#info()}.
+ * See {@code docs/sdk/worker-sdk-quickstart.md} for examples of how the runtime populates this data.
  */
 public record WorkerInfo(
     String role,
@@ -13,6 +14,15 @@ public record WorkerInfo(
     String outQueue
 ) {
 
+    /**
+     * Creates a new worker description.
+     *
+     * @param role       logical role name (e.g. {@code processor})
+     * @param swarmId    swarm identifier assigned by the control plane
+     * @param instanceId unique instance identifier
+     * @param inQueue    optional inbound queue name
+     * @param outQueue   optional outbound queue name
+     */
     public WorkerInfo {
         role = requireText(role, "role");
         swarmId = requireText(swarmId, "swarmId");

--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/config/PocketHiveWorker.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/config/PocketHiveWorker.java
@@ -8,19 +8,38 @@ import java.lang.annotation.Target;
 
 /**
  * Marks a bean as a PocketHive worker and provides routing metadata.
+ * <p>
+ * The runtime scans for this annotation when building {@link io.pockethive.worker.sdk.runtime.WorkerDefinition}
+ * records. Usage examples are documented in {@code docs/sdk/worker-sdk-quickstart.md}.
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface PocketHiveWorker {
 
+    /**
+     * Logical role of the worker (e.g. {@code processor}).
+     */
     String role();
 
+    /**
+     * Worker shape supported by the runtime.
+     */
     WorkerType type();
 
+    /**
+     * Optional inbound queue name for {@link WorkerType#MESSAGE} workers.
+     */
     String inQueue() default "";
 
+    /**
+     * Optional outbound queue name for {@link WorkerType#GENERATOR} and {@link WorkerType#MESSAGE} workers.
+     */
     String outQueue() default "";
 
+    /**
+     * Optional configuration class resolved from the Spring context when the control plane does not supply
+     * a typed payload.
+     */
     Class<?> config() default Void.class;
 }

--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/config/WorkerType.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/config/WorkerType.java
@@ -1,7 +1,7 @@
 package io.pockethive.worker.sdk.config;
 
 /**
- * Enumerates the supported worker shapes.
+ * Enumerates the worker shapes supported by the Stage 1 runtime.
  */
 public enum WorkerType {
     GENERATOR,

--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/DefaultWorkerContextFactory.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/DefaultWorkerContextFactory.java
@@ -19,7 +19,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Baseline context factory used for Stage 1 runtime integration tests.
+ * Baseline context factory used for Stage 1 runtime integration tests and examples outlined in
+ * {@code docs/sdk/worker-sdk-quickstart.md}.
  */
 public final class DefaultWorkerContextFactory implements WorkerContextFactory {
 
@@ -29,10 +30,16 @@ public final class DefaultWorkerContextFactory implements WorkerContextFactory {
 
     private final Map<WorkerDefinition, Logger> loggers = new ConcurrentHashMap<>();
 
+    /**
+     * Creates a factory backed by a simple Micrometer registry and observation registry.
+     */
     public DefaultWorkerContextFactory(Function<Class<?>, Object> beanResolver) {
-    this(beanResolver, new SimpleMeterRegistry(), ObservationRegistry.create());
+        this(beanResolver, new SimpleMeterRegistry(), ObservationRegistry.create());
     }
 
+    /**
+     * Creates a factory using the provided registries.
+     */
     public DefaultWorkerContextFactory(
         Function<Class<?>, Object> beanResolver,
         MeterRegistry meterRegistry,

--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/DefaultWorkerRuntime.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/DefaultWorkerRuntime.java
@@ -10,6 +10,7 @@ import java.util.function.Function;
 
 /**
  * Default runtime implementation used by Stage 1.
+ * Integration notes and examples live in {@code docs/sdk/worker-sdk-quickstart.md}.
  */
 public final class DefaultWorkerRuntime implements WorkerRuntime {
 

--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerContextFactory.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerContextFactory.java
@@ -5,8 +5,12 @@ import io.pockethive.worker.sdk.api.WorkMessage;
 
 /**
  * Produces a {@link WorkerContext} for an incoming message.
+ * Implementations are described in {@code docs/sdk/worker-sdk-quickstart.md}.
  */
 public interface WorkerContextFactory {
 
+    /**
+     * Builds a {@link WorkerContext} for the given worker definition, state, and message.
+     */
     WorkerContext createContext(WorkerDefinition definition, WorkerState state, WorkMessage message);
 }

--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerControlPlaneRuntime.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerControlPlaneRuntime.java
@@ -14,6 +14,7 @@ import io.pockethive.controlplane.worker.WorkerControlPlane;
 import io.pockethive.controlplane.worker.WorkerSignalListener;
 import io.pockethive.controlplane.worker.WorkerStatusRequest;
 import io.pockethive.worker.sdk.api.StatusPublisher;
+import io.pockethive.worker.sdk.config.PocketHiveWorker;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -33,7 +34,8 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Integrates the worker runtime with the control-plane helper so configuration updates, status
- * requests, and confirmation events are handled consistently across worker services.
+ * requests, and confirmation events are handled consistently across worker services. Usage guidance
+ * lives in {@code docs/sdk/worker-sdk-quickstart.md}.
  */
 public final class WorkerControlPlaneRuntime {
 
@@ -555,30 +557,51 @@ public final class WorkerControlPlaneRuntime {
             this.state = Objects.requireNonNull(state, "state");
         }
 
+        /**
+         * Returns the worker definition derived from {@link PocketHiveWorker} metadata.
+         */
         public WorkerDefinition definition() {
             return state.definition();
         }
 
+        /**
+         * Indicates whether the worker is currently enabled according to the latest control-plane command.
+         */
         public Optional<Boolean> enabled() {
             return state.enabled();
         }
 
+        /**
+         * Returns the raw configuration map received from the control plane.
+         */
         public Map<String, Object> rawConfig() {
             return state.rawConfig();
         }
 
+        /**
+         * Returns the typed configuration if it can be converted to the requested class.
+         */
         public <C> Optional<C> config(Class<C> type) {
             return state.config(type);
         }
 
+        /**
+         * Returns the structured status payload last published by the worker.
+         */
         public Map<String, Object> statusData() {
             return state.statusData();
         }
 
+        /**
+         * Returns the set of inbound work routes observed for the worker.
+         */
         public Set<String> inboundRoutes() {
             return state.inboundRoutes();
         }
 
+        /**
+         * Returns the set of outbound work routes observed for the worker.
+         */
         public Set<String> outboundRoutes() {
             return state.outboundRoutes();
         }

--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerDefinition.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerDefinition.java
@@ -1,11 +1,13 @@
 package io.pockethive.worker.sdk.runtime;
 
+import io.pockethive.worker.sdk.api.WorkerContext;
 import io.pockethive.worker.sdk.config.PocketHiveWorker;
 import io.pockethive.worker.sdk.config.WorkerType;
 import java.util.Objects;
 
 /**
  * Captures metadata extracted from {@link PocketHiveWorker} annotations.
+ * Refer to {@code docs/sdk/worker-sdk-quickstart.md} for how definitions drive runtime discovery.
  */
 public record WorkerDefinition(
     String beanName,
@@ -17,6 +19,17 @@ public record WorkerDefinition(
     Class<?> configType
 ) {
 
+    /**
+     * Creates a new worker definition.
+     *
+     * @param beanName   Spring bean name
+     * @param beanType   underlying class of the bean
+     * @param workerType worker shape declared on the annotation
+     * @param role       control-plane role identifier
+     * @param inQueue    optional inbound queue name
+     * @param outQueue   optional outbound queue name
+     * @param configType configuration class exposed to {@link WorkerContext#config(Class)}
+     */
     public WorkerDefinition {
         beanName = requireText(beanName, "beanName");
         beanType = Objects.requireNonNull(beanType, "beanType");

--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerInvocationInterceptor.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerInvocationInterceptor.java
@@ -4,13 +4,20 @@ import io.pockethive.worker.sdk.api.WorkResult;
 
 /**
  * Hook that can observe or modify worker invocations.
+ * Custom interceptors are discussed in {@code docs/sdk/worker-sdk-quickstart.md}.
  */
 @FunctionalInterface
 public interface WorkerInvocationInterceptor {
 
+    /**
+     * Applies cross-cutting logic around a worker invocation.
+     */
     WorkResult intercept(WorkerInvocationContext context, Chain chain) throws Exception;
 
     interface Chain {
+        /**
+         * Invokes the next interceptor or the underlying worker implementation.
+         */
         WorkResult proceed(WorkerInvocationContext context) throws Exception;
     }
 }

--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerMetricsInterceptor.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerMetricsInterceptor.java
@@ -9,6 +9,7 @@ import org.springframework.core.Ordered;
 
 /**
  * Records per-worker invocation timings using Micrometer.
+ * Enabled as part of the Stage 3 observability work described in {@code docs/sdk/worker-sdk-quickstart.md}.
  */
 public final class WorkerMetricsInterceptor implements WorkerInvocationInterceptor, Ordered {
 

--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerObservabilityInterceptor.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerObservabilityInterceptor.java
@@ -15,6 +15,7 @@ import org.springframework.core.Ordered;
 
 /**
  * Populates MDC and propagates observability context during worker execution.
+ * Enabled by the Stage 3 observability work outlined in {@code docs/sdk/worker-sdk-quickstart.md}.
  */
 public final class WorkerObservabilityInterceptor implements WorkerInvocationInterceptor, Ordered {
 

--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerRegistry.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerRegistry.java
@@ -8,11 +8,15 @@ import java.util.Optional;
 
 /**
  * Keeps a registry of discovered workers keyed by bean name.
+ * The Stage 1 runtime uses the registry to resolve invocations (see {@code docs/sdk/worker-sdk-quickstart.md}).
  */
 public final class WorkerRegistry {
 
     private final Map<String, WorkerDefinition> workers;
 
+    /**
+     * Creates a registry from the supplied worker definitions.
+     */
     public WorkerRegistry(Collection<WorkerDefinition> definitions) {
         Map<String, WorkerDefinition> copy = new LinkedHashMap<>();
         for (WorkerDefinition definition : definitions) {
@@ -21,10 +25,16 @@ public final class WorkerRegistry {
         this.workers = Collections.unmodifiableMap(copy);
     }
 
+    /**
+     * Returns all registered worker definitions.
+     */
     public Collection<WorkerDefinition> all() {
         return workers.values();
     }
 
+    /**
+     * Looks up a worker definition by bean name.
+     */
     public Optional<WorkerDefinition> find(String beanName) {
         return Optional.ofNullable(workers.get(beanName));
     }

--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerRuntime.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerRuntime.java
@@ -5,8 +5,17 @@ import io.pockethive.worker.sdk.api.WorkResult;
 
 /**
  * Entry point used by transports to hand messages to the worker implementation.
+ * See {@code docs/sdk/worker-sdk-quickstart.md} for integration examples from the migrated services.
  */
 public interface WorkerRuntime {
 
+    /**
+     * Dispatches an inbound message to the named worker bean.
+     *
+     * @param workerBeanName Spring bean name discovered via {@link io.pockethive.worker.sdk.config.PocketHiveWorker}
+     * @param message        inbound {@link WorkMessage}
+     * @return the {@link io.pockethive.worker.sdk.api.WorkResult} returned by the worker implementation
+     * @throws Exception any exception thrown by the worker logic or interceptors
+     */
     WorkResult dispatch(String workerBeanName, WorkMessage message) throws Exception;
 }

--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerState.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerState.java
@@ -11,6 +11,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 
+/**
+ * Tracks per-worker state for the runtime. Exposed indirectly via
+ * {@link WorkerControlPlaneRuntime.WorkerStateSnapshot}.
+ */
 public final class WorkerState {
 
     private final WorkerDefinition definition;

--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerStateStore.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerStateStore.java
@@ -7,6 +7,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * Repository of {@link WorkerState} instances keyed by worker bean name.
+ */
 public final class WorkerStateStore {
 
     private final Map<String, WorkerState> states = new ConcurrentHashMap<>();

--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/testing/ControlPlaneTestFixtures.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/testing/ControlPlaneTestFixtures.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 
 /**
  * Testing helpers that expose canonical control-plane descriptors and identities.
+ * Complements the configuration steps in {@code docs/sdk/worker-sdk-quickstart.md}.
  */
 public final class ControlPlaneTestFixtures {
 

--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/testing/WorkerSdkTestFixtures.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/testing/WorkerSdkTestFixtures.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 
 /**
  * Helper utilities for exercising Worker SDK runtime components in tests.
+ * Complements the guidance in {@code docs/sdk/worker-sdk-quickstart.md}.
  */
 public final class WorkerSdkTestFixtures {
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -53,6 +53,7 @@ PocketHive splits the control plane into **managers** (orchestrator + swarm cont
 - Accept config updates from both the orchestrator (role/instance routing keys) and their controller (swarm broadcast) without relying on implicit routing conventions.
 - Emit **their own** status streams (`ev.status-{full|delta}.{swarmId}.{role}.{instance}`) and respond to manager `sig.status-request.{swarmId}.{role}.{instance}` heartbeats.
 - Apply `sig.config-update.{swarmId}.{role}.{instance}` (`enabled: true|false`) to control **workload** state only while keeping control listeners responsive.
+- Runtime behaviour, worker interfaces, and adoption guidance are covered in the [Worker SDK quick start](sdk/worker-sdk-quickstart.md).
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,11 @@ Welcome to the PocketHive documentation hub. Use these resources to understand t
 ## Core Modules
 - [Topology Core](../common/topology-core/README.md)
 
+## SDK
+- [Worker SDK Quick Start](sdk/worker-sdk-quickstart.md)
+- [Worker SDK Simplification Plan](sdk/worker-sdk-simplification-plan.md)
+- [Worker SDK Stage 1 Runtime](sdk/worker-sdk-stage1-runtime.md)
+
 ## Contributing
 - [Contributor Guide](../CONTRIBUTING.md)
 - [Control Plane Testing Playbook](ci/control-plane-testing.md)

--- a/docs/control-plane/worker-guide.md
+++ b/docs/control-plane/worker-guide.md
@@ -2,7 +2,8 @@
 
 This guide explains how to wire a new worker or manager service against the refactored control-plane APIs.
 It covers the topology descriptors, emitters, and Spring Boot starters introduced in the refactor so teams can
-bootstrap participants without copying configuration boilerplate.
+bootstrap participants without copying configuration boilerplate. For an end-to-end walkthrough of the Stage 1–3
+Worker SDK runtime, see the [Worker SDK quick start](../sdk/worker-sdk-quickstart.md).
 
 ## 1. Choose the right topology descriptor
 
@@ -40,12 +41,13 @@ emitter.emitReady(ControlPlaneEmitter.ReadyContext.builder(
 
 The emitter guarantees routing keys and payload schemas remain consistent across services.
 
-## 3. Enable the Spring Boot starters
+## 3. Enable the Spring Boot starters and runtime
 
 Include the Worker SDK starter to auto-register descriptors, identities, AMQP declarables, and the
-control-plane publisher. The starter composes `ControlPlaneCommonAutoConfiguration`,
-`WorkerControlPlaneAutoConfiguration`, and `ManagerControlPlaneAutoConfiguration` so both worker and manager
-roles can be enabled from configuration.
+control-plane publisher. The starter also exposes the Stage 1 `WorkerRuntime` and Stage 2
+`WorkerControlPlaneRuntime` beans described in the quick start. The auto-configuration composes
+`ControlPlaneCommonAutoConfiguration`, `WorkerControlPlaneAutoConfiguration`, and
+`ManagerControlPlaneAutoConfiguration` so both worker and manager roles can be enabled from configuration.
 
 ```xml
 <dependency>

--- a/docs/sdk/worker-sdk-quickstart.md
+++ b/docs/sdk/worker-sdk-quickstart.md
@@ -1,0 +1,106 @@
+# PocketHive Worker SDK Quick Start
+
+This guide shows how to adopt the simplified Worker SDK introduced in the Stage 1–3 refactor. Pair it with the
+[Stage 0 design](worker-sdk-stage0-design.md) and [Stage 1 runtime walkthrough](worker-sdk-stage1-runtime.md) when you need
+deeper architectural context.
+
+## 1. Add the dependency and starter
+
+Include the Worker SDK starter in your Spring Boot service. The starter composes the control-plane auto-configuration,
+registers the Stage 1 `WorkerRuntime`, and wires the `WorkerControlPlaneRuntime` that powers Stage 2 status/config
+synchronisation.
+
+```xml
+<dependency>
+  <groupId>io.pockethive</groupId>
+  <artifactId>worker-sdk</artifactId>
+</dependency>
+```
+
+Configure the control-plane identity and role using the shared properties:
+
+```yaml
+pockethive:
+  control-plane:
+    exchange: ph.control
+    swarm-id: swarm-1
+    worker:
+      role: processor
+      instance-id: processor-1
+```
+
+See the [control-plane worker guide](../control-plane/worker-guide.md) for full property reference.
+
+## 2. Annotate worker beans
+
+Annotate each business implementation with `@PocketHiveWorker`. Choose the worker type (`GENERATOR` or `MESSAGE`) and
+provide routing metadata. Optional `config` classes participate in Stage 2 control-plane hydration.
+
+```java
+@Component("processorWorker")
+@PocketHiveWorker(
+    role = "processor",
+    type = WorkerType.MESSAGE,
+    inQueue = TopologyDefaults.MOD_QUEUE,
+    outQueue = TopologyDefaults.FINAL_QUEUE,
+    config = ProcessorWorkerConfig.class
+)
+class ProcessorWorkerImpl implements MessageWorker {
+  // business logic
+}
+```
+
+Generator workers follow the same pattern but implement `GeneratorWorker` and omit `inQueue`.
+
+## 3. Implement the worker interfaces
+
+The Stage 1 runtime discovers annotated beans and invokes the corresponding business interface:
+
+- `GeneratorWorker.generate(WorkerContext)` emits a single `WorkMessage` per invocation. Stage 2 control-plane updates
+  determine how often `GeneratorRuntimeAdapter` schedules the call.
+- `MessageWorker.onMessage(WorkMessage, WorkerContext)` receives inbound messages converted by the SDK transport and
+  returns a `WorkResult` to publish downstream.
+
+Use the `WorkerContext` to:
+
+- Retrieve typed configuration supplied by Stage 2 control-plane commands (`context.config(MyConfig.class)`).
+- Enrich Stage 2 status payloads via `context.statusPublisher()`.
+- Access Stage 3 observability hooks (`observationRegistry`, `observabilityContext`).
+
+Refer to the migrated [generator](../../generator-service/src/main/java/io/pockethive/generator/GeneratorWorkerImpl.java)
+and [processor](../../processor-service/src/main/java/io/pockethive/processor/ProcessorWorkerImpl.java) services for
+end-to-end implementations.
+
+## 4. Dispatch work through the runtime adapters
+
+Transport adapters inject the Stage 1 `WorkerRuntime` and Stage 2 `WorkerControlPlaneRuntime` beans. The migrated
+services provide reference implementations:
+
+- [`GeneratorRuntimeAdapter`](../../generator-service/src/main/java/io/pockethive/generator/GeneratorRuntimeAdapter.java)
+  drives scheduled invocations and publishes results.
+- [`TriggerRuntimeAdapter`](../../trigger-service/src/main/java/io/pockethive/trigger/TriggerRuntimeAdapter.java) shows
+  how to fan-in RabbitMQ deliveries before calling `workerRuntime.dispatch(...)`.
+- [`ProcessorRuntimeAdapter`](../../processor-service/src/main/java/io/pockethive/processor/ProcessorRuntimeAdapter.java)
+  demonstrates how to register control-plane listeners to apply per-worker configuration.
+
+These adapters call `WorkerControlPlaneRuntime.handle(...)` for inbound control-plane messages and subscribe to
+`WorkerStateSnapshot` updates to hydrate in-memory defaults.
+
+## 5. Test with the SDK fixtures
+
+Stage 1 introduced `ControlPlaneTestFixtures` and `WorkerSdkTestFixtures` to make unit tests deterministic. Use them to
+construct canonical identities, topology descriptors, and sample payloads without repeating boilerplate.
+
+```java
+ControlPlaneProperties props = ControlPlaneTestFixtures.workerProperties("swarm-1", "processor", "processor-1");
+WorkerRuntime runtime = WorkerSdkTestFixtures.runtime(applicationContext);
+```
+
+## 6. Observability and Stage 3 enhancements
+
+Stage 3 enriches the runtime with Micrometer and Observation support. `WorkerContext.meterRegistry()` and
+`WorkerContext.observationRegistry()` surface the shared registries, while `WorkMessage` builders accept an
+`ObservabilityContext`. Use these hooks to emit custom metrics and propagate trace metadata as shown in the
+[processor worker](../../processor-service/src/main/java/io/pockethive/processor/ProcessorWorkerImpl.java).
+
+For the full roadmap and design rationale, review the [Worker SDK simplification plan](worker-sdk-simplification-plan.md).


### PR DESCRIPTION
## Summary
- expand the Worker SDK README to explain the runtime APIs and reference migrated service examples
- add a Worker SDK quick start guide and link it from the documentation hub and control-plane guides
- add Javadoc across the Worker SDK API, runtime, and testing helpers pointing developers to the new docs

## Testing
- mvn -pl common/worker-sdk -am -DskipTests compile

------
https://chatgpt.com/codex/tasks/task_e_68e5164a88d88328ab0838122cdd5ca7