### PR TITLE
Guarantee non-null observability context in worker SDK

### DIFF
--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/api/WorkerContext.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/api/WorkerContext.java
@@ -61,6 +61,9 @@ public interface WorkerContext {
 
     /**
      * Returns the propagated observability context (trace identifiers and hop history).
+     * <p>
+     * Implementations must always return a non-{@code null} instance. The SDK runtime ensures callers
+     * receive an initialised context even when the inbound message does not include one.
      */
     ObservabilityContext observabilityContext();
 }

--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/DefaultWorkerContextFactory.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/DefaultWorkerContextFactory.java
@@ -126,15 +126,14 @@ public final class DefaultWorkerContextFactory implements WorkerContextFactory {
     }
 
     private ObservabilityContext resolveObservabilityContext(WorkerInfo info, WorkMessage message) {
-        ObservabilityContext context = message.observabilityContext().orElse(null);
-        if (context == null) {
-            context = new ObservabilityContext();
+        ObservabilityContext context = message.observabilityContext().orElseGet(ObservabilityContext::new);
+        if (context.getTraceId() == null || context.getTraceId().isBlank()) {
             context.setTraceId(UUID.randomUUID().toString());
-            context.setHops(new ArrayList<>());
-        } else if (context.getHops() == null) {
+        }
+        if (context.getHops() == null) {
             context.setHops(new ArrayList<>());
         }
-        if (context.getSwarmId() == null) {
+        if (context.getSwarmId() == null || context.getSwarmId().isBlank()) {
             context.setSwarmId(info.swarmId());
         }
         return context;

--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerContextFactory.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerContextFactory.java
@@ -11,6 +11,10 @@ public interface WorkerContextFactory {
 
     /**
      * Builds a {@link WorkerContext} for the given worker definition, state, and message.
+     * <p>
+     * Implementations must ensure the returned context exposes a non-{@code null}
+     * {@link WorkerContext#observabilityContext()} populated with a trace identifier, hop list, and
+     * swarm identifier so downstream interceptors can rely on it.
      */
     WorkerContext createContext(WorkerDefinition definition, WorkerState state, WorkMessage message);
 }

--- a/common/worker-sdk/src/test/java/io/pockethive/worker/sdk/runtime/DefaultWorkerContextFactoryTest.java
+++ b/common/worker-sdk/src/test/java/io/pockethive/worker/sdk/runtime/DefaultWorkerContextFactoryTest.java
@@ -1,0 +1,68 @@
+package io.pockethive.worker.sdk.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.observation.ObservationRegistry;
+import io.pockethive.observability.ObservabilityContext;
+import io.pockethive.worker.sdk.api.WorkMessage;
+import io.pockethive.worker.sdk.api.WorkerContext;
+import io.pockethive.worker.sdk.config.WorkerType;
+import org.junit.jupiter.api.Test;
+
+class DefaultWorkerContextFactoryTest {
+
+    private static final WorkerDefinition DEFINITION = new WorkerDefinition(
+        "testWorker",
+        Object.class,
+        WorkerType.MESSAGE,
+        "role",
+        "in.queue",
+        "out.queue",
+        Void.class
+    );
+
+    private final WorkerState state = new WorkerState(DEFINITION);
+    private final DefaultWorkerContextFactory factory = new DefaultWorkerContextFactory(
+        type -> {
+            throw new IllegalStateException("No bean registered for " + type.getName());
+        },
+        new SimpleMeterRegistry(),
+        ObservationRegistry.create()
+    );
+
+    @Test
+    void generatesObservabilityContextWhenMissing() {
+        WorkMessage message = WorkMessage.text("payload")
+            .header("swarmId", "swarm-1")
+            .build();
+
+        WorkerContext context = factory.createContext(DEFINITION, state, message);
+
+        ObservabilityContext observabilityContext = context.observabilityContext();
+        assertThat(observabilityContext).isNotNull();
+        assertThat(observabilityContext.getTraceId()).isNotBlank();
+        assertThat(observabilityContext.getHops()).isEmpty();
+        assertThat(observabilityContext.getSwarmId()).isEqualTo("swarm-1");
+    }
+
+    @Test
+    void fillsMissingObservabilityFieldsAndReusesContext() {
+        ObservabilityContext inbound = new ObservabilityContext();
+        inbound.setTraceId("");
+        inbound.setSwarmId(null);
+
+        WorkMessage message = WorkMessage.text("payload")
+            .header("swarmId", "swarm-2")
+            .observabilityContext(inbound)
+            .build();
+
+        WorkerContext context = factory.createContext(DEFINITION, state, message);
+
+        ObservabilityContext observabilityContext = context.observabilityContext();
+        assertThat(observabilityContext).isSameAs(inbound);
+        assertThat(observabilityContext.getTraceId()).isNotBlank();
+        assertThat(observabilityContext.getHops()).isEmpty();
+        assertThat(observabilityContext.getSwarmId()).isEqualTo("swarm-2");
+    }
+}

--- a/common/worker-sdk/src/test/java/io/pockethive/worker/sdk/runtime/WorkerInvocationTest.java
+++ b/common/worker-sdk/src/test/java/io/pockethive/worker/sdk/runtime/WorkerInvocationTest.java
@@ -159,7 +159,12 @@ class WorkerInvocationTest {
 
             @Override
             public io.pockethive.observability.ObservabilityContext observabilityContext() {
-                return new io.pockethive.observability.ObservabilityContext();
+                io.pockethive.observability.ObservabilityContext context =
+                    new io.pockethive.observability.ObservabilityContext();
+                context.setTraceId("test-trace");
+                context.setHops(new java.util.ArrayList<>());
+                context.setSwarmId(info.swarmId());
+                return context;
             }
         };
     }

--- a/common/worker-sdk/src/test/java/io/pockethive/worker/sdk/runtime/WorkerObservabilityInterceptorTest.java
+++ b/common/worker-sdk/src/test/java/io/pockethive/worker/sdk/runtime/WorkerObservabilityInterceptorTest.java
@@ -48,9 +48,9 @@ class WorkerObservabilityInterceptorTest {
         WorkResult result = interceptor.intercept(invocationContext, ctx -> WorkResult.message(ctx.message()));
 
         ObservabilityContext context = invocationContext.workerContext().observabilityContext();
-    assertThat(context.getTraceId()).isNotBlank();
-    assertThat(context.getHops()).hasSize(1);
-    assertThat(context.getHops().get(0).getProcessedAt()).isNotNull();
+        assertThat(context.getTraceId()).isNotBlank();
+        assertThat(context.getHops()).hasSize(1);
+        assertThat(context.getHops().get(0).getProcessedAt()).isNotNull();
 
         assertThat(MDC.get("traceId")).isNull();
         assertThat(MDC.get("swarmId")).isNull();
@@ -58,12 +58,14 @@ class WorkerObservabilityInterceptorTest {
         assertThat(result).isInstanceOf(WorkResult.Message.class);
         WorkMessage outbound = ((WorkResult.Message) result).value();
         assertThat(outbound.observabilityContext()).isPresent();
-    assertThat(outbound.observabilityContext().orElseThrow().getHops()).hasSize(1);
+        assertThat(outbound.observabilityContext().orElseThrow().getHops()).hasSize(1);
     }
 
     private WorkerContext workerContext(WorkerState state) {
         WorkerInfo info = new WorkerInfo("role", "swarm", "instance", "in.queue", "out.queue");
         ObservabilityContext observabilityContext = new ObservabilityContext();
+        observabilityContext.setTraceId("trace-id");
+        observabilityContext.setSwarmId(info.swarmId());
         observabilityContext.setHops(new java.util.ArrayList<>());
         return new WorkerContext() {
             @Override

--- a/docs/sdk/worker-sdk-quickstart.md
+++ b/docs/sdk/worker-sdk-quickstart.md
@@ -65,7 +65,8 @@ Use the `WorkerContext` to:
 
 - Retrieve typed configuration supplied by Stage 2 control-plane commands (`context.config(MyConfig.class)`).
 - Enrich Stage 2 status payloads via `context.statusPublisher()`.
-- Access Stage 3 observability hooks (`observationRegistry`, `observabilityContext`).
+- Access Stage 3 observability hooks (`observationRegistry`, `observabilityContext`). The runtime guarantees that
+  `observabilityContext()` returns an initialised instance so workers can append hops without null checks.
 
 Refer to the migrated [generator](../../generator-service/src/main/java/io/pockethive/generator/GeneratorWorkerImpl.java)
 and [processor](../../processor-service/src/main/java/io/pockethive/processor/ProcessorWorkerImpl.java) services for
@@ -100,7 +101,9 @@ WorkerRuntime runtime = WorkerSdkTestFixtures.runtime(applicationContext);
 
 Stage 3 enriches the runtime with Micrometer and Observation support. `WorkerContext.meterRegistry()` and
 `WorkerContext.observationRegistry()` surface the shared registries, while `WorkMessage` builders accept an
-`ObservabilityContext`. Use these hooks to emit custom metrics and propagate trace metadata as shown in the
+`ObservabilityContext`. The SDK ensures that `WorkerContext.observabilityContext()` never returns {@code null} and
+includes a trace id, hop list, and swarm id, making it safe to append hop metadata or forward the context as-is.
+Use these hooks to emit custom metrics and propagate trace metadata as shown in the
 [processor worker](../../processor-service/src/main/java/io/pockethive/processor/ProcessorWorkerImpl.java).
 
 For the full roadmap and design rationale, review the [Worker SDK simplification plan](worker-sdk-simplification-plan.md).

--- a/postprocessor-service/src/test/java/io/pockethive/postprocessor/PostProcessorTest.java
+++ b/postprocessor-service/src/test/java/io/pockethive/postprocessor/PostProcessorTest.java
@@ -45,7 +45,8 @@ class PostProcessorTest {
                 .observabilityContext(context)
                 .build();
 
-        TestWorkerContext workerContext = new TestWorkerContext(new PostProcessorWorkerConfig(true));
+        TestWorkerContext workerContext =
+                new TestWorkerContext(new PostProcessorWorkerConfig(true), context);
 
         WorkResult result = worker.onMessage(message, workerContext);
 
@@ -83,7 +84,7 @@ class PostProcessorTest {
         WorkMessage message = WorkMessage.text("payload")
                 .build();
 
-        TestWorkerContext workerContext = new TestWorkerContext(null);
+        TestWorkerContext workerContext = new TestWorkerContext(null, context);
 
         worker.onMessage(message, workerContext);
 
@@ -96,9 +97,11 @@ class PostProcessorTest {
         private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
         private final CapturingStatusPublisher statusPublisher = new CapturingStatusPublisher();
         private final Logger logger = LoggerFactory.getLogger(MessageWorker.class);
+        private final ObservabilityContext observabilityContext;
 
-        private TestWorkerContext(PostProcessorWorkerConfig config) {
+        private TestWorkerContext(PostProcessorWorkerConfig config, ObservabilityContext observabilityContext) {
             this.config = config;
+            this.observabilityContext = Objects.requireNonNull(observabilityContext, "observabilityContext");
         }
 
         @Override
@@ -136,7 +139,7 @@ class PostProcessorTest {
 
         @Override
         public ObservabilityContext observabilityContext() {
-            return null;
+            return observabilityContext;
         }
 
         Map<String, Object> statusData() {

--- a/processor-service/src/main/java/io/pockethive/processor/ProcessorWorkerImpl.java
+++ b/processor-service/src/main/java/io/pockethive/processor/ProcessorWorkerImpl.java
@@ -168,13 +168,7 @@ class ProcessorWorkerImpl implements MessageWorker {
                              WorkerContext context,
                              ObservabilityContext observability,
                              Instant received) {
-    ObservabilityContext targetContext = observability;
-    if (targetContext == null) {
-      targetContext = ObservabilityContextUtil.init(context.info().role(), context.info().instanceId(), context.info().swarmId());
-      if (targetContext.getHops() != null) {
-        targetContext.getHops().clear();
-      }
-    }
+    ObservabilityContext targetContext = Objects.requireNonNull(observability, "observability");
     ObservabilityContextUtil.appendHop(targetContext,
         context.info().role(),
         context.info().instanceId(),

--- a/processor-service/src/test/java/io/pockethive/processor/ProcessorTest.java
+++ b/processor-service/src/test/java/io/pockethive/processor/ProcessorTest.java
@@ -92,8 +92,10 @@ class ProcessorTest {
 
         String traceHeader = (String) outbound.headers().get(ObservabilityContextUtil.HEADER);
         ObservabilityContext trace = ObservabilityContextUtil.fromHeader(traceHeader);
-        assertThat(trace.getHops()).hasSize(1);
-        assertThat(trace.getHops().get(0).getService()).isEqualTo("processor");
+        assertThat(trace.getHops()).hasSize(2);
+        assertThat(trace.getHops().get(0).getService()).isEqualTo("ingress");
+        assertThat(trace.getHops().get(1).getService()).isEqualTo("processor");
+        assertThat(context.observabilityContext().getHops()).hasSize(2);
 
         HttpRequest request = requestRef.get();
         assertThat(request).isNotNull();
@@ -273,9 +275,16 @@ class ProcessorTest {
         private final CapturingStatusPublisher statusPublisher = new CapturingStatusPublisher();
 
         private TestWorkerContext(ProcessorWorkerConfig config) {
+            this(config, defaultObservability());
+        }
+
+        private TestWorkerContext(ProcessorWorkerConfig config, ObservabilityContext observability) {
             this.config = config;
-            this.observability = ObservabilityContextUtil.init(info.role(), info.instanceId(), info.swarmId());
-            this.observability.getHops().clear();
+            this.observability = observability;
+        }
+
+        private static ObservabilityContext defaultObservability() {
+            return ObservabilityContextUtil.init("ingress", "ingress-instance", "swarm");
         }
 
         @Override


### PR DESCRIPTION
## Summary
- guarantee WorkerContext implementations always expose an initialised ObservabilityContext and document the contract
- update DefaultWorkerContextFactory and interceptors to rely on the guaranteed context and expand coverage with new unit tests
- refresh worker SDK quick start guidance to describe the observability context guarantee

## Testing
- mvn -pl common/worker-sdk test

------
https://chatgpt.com/codex/tasks/task_e_68e52b97f8d4832894234861859b4b28