### PR TITLE
Add worker registry helpers and refactor runtime adapters

### DIFF
--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerRegistry.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerRegistry.java
@@ -1,10 +1,13 @@
 package io.pockethive.worker.sdk.runtime;
 
+import io.pockethive.worker.sdk.config.WorkerType;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 /**
  * Keeps a registry of discovered workers keyed by bean name.
@@ -37,5 +40,35 @@ public final class WorkerRegistry {
      */
     public Optional<WorkerDefinition> find(String beanName) {
         return Optional.ofNullable(workers.get(beanName));
+    }
+
+    /**
+     * Returns a stream of worker definitions registered for the given role.
+     */
+    public Stream<WorkerDefinition> streamByRole(String role) {
+        String resolvedRole = requireText(role, "role");
+        return workers.values().stream().filter(definition -> resolvedRole.equals(definition.role()));
+    }
+
+    /**
+     * Returns a stream of worker definitions matching the supplied role and worker type.
+     */
+    public Stream<WorkerDefinition> streamByRoleAndType(String role, WorkerType type) {
+        Objects.requireNonNull(type, "type");
+        return streamByRole(role).filter(definition -> definition.workerType() == type);
+    }
+
+    /**
+     * Finds the first worker definition matching the supplied role and worker type.
+     */
+    public Optional<WorkerDefinition> findByRoleAndType(String role, WorkerType type) {
+        return streamByRoleAndType(role, type).findFirst();
+    }
+
+    private static String requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(field + " must not be blank");
+        }
+        return value;
     }
 }

--- a/common/worker-sdk/src/test/java/io/pockethive/worker/sdk/runtime/WorkerRegistryTest.java
+++ b/common/worker-sdk/src/test/java/io/pockethive/worker/sdk/runtime/WorkerRegistryTest.java
@@ -1,0 +1,88 @@
+package io.pockethive.worker.sdk.runtime;
+
+import io.pockethive.worker.sdk.config.WorkerType;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class WorkerRegistryTest {
+
+    private static final WorkerDefinition GENERATOR_TRIGGER = new WorkerDefinition(
+        "triggerWorker",
+        Object.class,
+        WorkerType.GENERATOR,
+        "trigger",
+        null,
+        null,
+        Void.class
+    );
+
+    private static final WorkerDefinition MESSAGE_PROCESSOR = new WorkerDefinition(
+        "processorWorker",
+        Object.class,
+        WorkerType.MESSAGE,
+        "processor",
+        "in",
+        "out",
+        Void.class
+    );
+
+    private static final WorkerDefinition MESSAGE_TRIGGER = new WorkerDefinition(
+        "triggerMessageWorker",
+        Object.class,
+        WorkerType.MESSAGE,
+        "trigger",
+        null,
+        null,
+        Void.class
+    );
+
+    private final WorkerRegistry registry = new WorkerRegistry(List.of(
+        GENERATOR_TRIGGER,
+        MESSAGE_PROCESSOR,
+        MESSAGE_TRIGGER
+    ));
+
+    @Test
+    void findByRoleAndTypeReturnsMatchingDefinition() {
+        Optional<WorkerDefinition> result = registry.findByRoleAndType("processor", WorkerType.MESSAGE);
+
+        assertThat(result).contains(MESSAGE_PROCESSOR);
+    }
+
+    @Test
+    void findByRoleAndTypeReturnsEmptyWhenNoMatch() {
+        Optional<WorkerDefinition> result = registry.findByRoleAndType("missing", WorkerType.MESSAGE);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void streamByRoleFiltersDefinitions() {
+        assertThat(registry.streamByRole("trigger").toList())
+            .containsExactlyInAnyOrder(GENERATOR_TRIGGER, MESSAGE_TRIGGER);
+    }
+
+    @Test
+    void streamByRoleAndTypeFiltersDefinitions() {
+        assertThat(registry.streamByRoleAndType("trigger", WorkerType.GENERATOR).toList())
+            .containsExactly(GENERATOR_TRIGGER);
+    }
+
+    @Test
+    void streamByRoleRejectsBlankRole() {
+        assertThatThrownBy(() -> registry.streamByRole(" "))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("role");
+    }
+
+    @Test
+    void streamByRoleAndTypeRejectsNullType() {
+        assertThatThrownBy(() -> registry.streamByRoleAndType("trigger", null))
+            .isInstanceOf(NullPointerException.class)
+            .hasMessageContaining("type");
+    }
+}

--- a/moderator-service/src/main/java/io/pockethive/moderator/ModeratorRuntimeAdapter.java
+++ b/moderator-service/src/main/java/io/pockethive/moderator/ModeratorRuntimeAdapter.java
@@ -59,9 +59,7 @@ class ModeratorRuntimeAdapter implements ApplicationListener<ContextRefreshedEve
     this.listenerRegistry = Objects.requireNonNull(listenerRegistry, "listenerRegistry");
     this.identity = Objects.requireNonNull(identity, "identity");
     this.defaults = Objects.requireNonNull(defaults, "defaults");
-    this.workerDefinition = workerRegistry.all().stream()
-        .filter(def -> def.workerType() == WorkerType.MESSAGE && "moderator".equals(def.role()))
-        .findFirst()
+    this.workerDefinition = workerRegistry.findByRoleAndType("moderator", WorkerType.MESSAGE)
         .orElseThrow(() -> new IllegalStateException("Moderator worker definition not found"));
   }
 

--- a/moderator-service/src/test/java/io/pockethive/moderator/ModeratorRuntimeAdapterTest.java
+++ b/moderator-service/src/test/java/io/pockethive/moderator/ModeratorRuntimeAdapterTest.java
@@ -11,7 +11,7 @@ import io.pockethive.worker.sdk.runtime.WorkerRegistry;
 import io.pockethive.worker.sdk.runtime.WorkerRuntime;
 import io.pockethive.worker.sdk.transport.rabbit.RabbitWorkMessageConverter;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -71,7 +71,8 @@ class ModeratorRuntimeAdapterTest {
         Topology.MOD_QUEUE,
         ModeratorWorkerConfig.class
     );
-    when(workerRegistry.all()).thenReturn(List.of(definition));
+    when(workerRegistry.findByRoleAndType("moderator", WorkerType.MESSAGE))
+        .thenReturn(Optional.of(definition));
   }
 
   private void stubListenerContainerStopped() {

--- a/postprocessor-service/src/main/java/io/pockethive/postprocessor/PostProcessorRuntimeAdapter.java
+++ b/postprocessor-service/src/main/java/io/pockethive/postprocessor/PostProcessorRuntimeAdapter.java
@@ -53,9 +53,7 @@ class PostProcessorRuntimeAdapter implements ApplicationListener<ContextRefreshe
     this.listenerRegistry = Objects.requireNonNull(listenerRegistry, "listenerRegistry");
     this.identity = Objects.requireNonNull(identity, "identity");
     this.defaults = Objects.requireNonNull(defaults, "defaults");
-    this.workerDefinition = workerRegistry.all().stream()
-        .filter(def -> def.workerType() == WorkerType.MESSAGE && "postprocessor".equals(def.role()))
-        .findFirst()
+    this.workerDefinition = workerRegistry.findByRoleAndType("postprocessor", WorkerType.MESSAGE)
         .orElseThrow(() -> new IllegalStateException("Post-processor worker definition not found"));
   }
 

--- a/postprocessor-service/src/test/java/io/pockethive/postprocessor/PostProcessorRuntimeAdapterTest.java
+++ b/postprocessor-service/src/test/java/io/pockethive/postprocessor/PostProcessorRuntimeAdapterTest.java
@@ -11,7 +11,7 @@ import io.pockethive.worker.sdk.runtime.WorkerDefinition;
 import io.pockethive.worker.sdk.runtime.WorkerRegistry;
 import io.pockethive.worker.sdk.runtime.WorkerRuntime;
 import io.pockethive.worker.sdk.transport.rabbit.RabbitWorkMessageConverter;
-import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -68,7 +68,8 @@ class PostProcessorRuntimeAdapterTest {
         null,
         PostProcessorWorkerConfig.class
     );
-    when(workerRegistry.all()).thenReturn(List.of(definition));
+    when(workerRegistry.findByRoleAndType("postprocessor", WorkerType.MESSAGE))
+        .thenReturn(Optional.of(definition));
   }
 
   @Test

--- a/processor-service/src/main/java/io/pockethive/processor/ProcessorRuntimeAdapter.java
+++ b/processor-service/src/main/java/io/pockethive/processor/ProcessorRuntimeAdapter.java
@@ -59,9 +59,7 @@ class ProcessorRuntimeAdapter implements ApplicationListener<ContextRefreshedEve
     this.listenerRegistry = Objects.requireNonNull(listenerRegistry, "listenerRegistry");
     this.identity = Objects.requireNonNull(identity, "identity");
     this.defaults = Objects.requireNonNull(defaults, "defaults");
-    this.workerDefinition = workerRegistry.all().stream()
-        .filter(def -> def.workerType() == WorkerType.MESSAGE && "processor".equals(def.role()))
-        .findFirst()
+    this.workerDefinition = workerRegistry.findByRoleAndType("processor", WorkerType.MESSAGE)
         .orElseThrow(() -> new IllegalStateException("Processor worker definition not found"));
   }
 

--- a/processor-service/src/test/java/io/pockethive/processor/ProcessorRuntimeAdapterTest.java
+++ b/processor-service/src/test/java/io/pockethive/processor/ProcessorRuntimeAdapterTest.java
@@ -11,7 +11,7 @@ import io.pockethive.worker.sdk.runtime.WorkerRegistry;
 import io.pockethive.worker.sdk.runtime.WorkerRuntime;
 import io.pockethive.worker.sdk.transport.rabbit.RabbitWorkMessageConverter;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -72,7 +72,8 @@ class ProcessorRuntimeAdapterTest {
         Topology.FINAL_QUEUE,
         ProcessorWorkerConfig.class
     );
-    when(workerRegistry.all()).thenReturn(List.of(definition));
+    when(workerRegistry.findByRoleAndType("processor", WorkerType.MESSAGE))
+        .thenReturn(Optional.of(definition));
   }
 
   @Test

--- a/processor-service/src/test/java/io/pockethive/processor/ProcessorTest.java
+++ b/processor-service/src/test/java/io/pockethive/processor/ProcessorTest.java
@@ -182,7 +182,8 @@ class ProcessorTest {
                 Topology.FINAL_QUEUE,
                 ProcessorWorkerConfig.class
         );
-        when(workerRegistry.all()).thenReturn(List.of(definition));
+        when(workerRegistry.findByRoleAndType("processor", WorkerType.MESSAGE))
+                .thenReturn(Optional.of(definition));
 
         ControlPlaneIdentity identity = new ControlPlaneIdentity("swarm", "processor", "instance");
         ProcessorDefaults defaults = new ProcessorDefaults();
@@ -234,7 +235,8 @@ class ProcessorTest {
                 Topology.FINAL_QUEUE,
                 ProcessorWorkerConfig.class
         );
-        when(workerRegistry.all()).thenReturn(List.of(definition));
+        when(workerRegistry.findByRoleAndType("processor", WorkerType.MESSAGE))
+                .thenReturn(Optional.of(definition));
 
         ControlPlaneIdentity identity = new ControlPlaneIdentity("swarm", "processor", "instance");
         ProcessorDefaults defaults = new ProcessorDefaults();

--- a/trigger-service/src/main/java/io/pockethive/trigger/TriggerRuntimeAdapter.java
+++ b/trigger-service/src/main/java/io/pockethive/trigger/TriggerRuntimeAdapter.java
@@ -32,7 +32,6 @@ class TriggerRuntimeAdapter {
   private static final Logger log = LoggerFactory.getLogger(TriggerRuntimeAdapter.class);
 
   private final WorkerRuntime workerRuntime;
-  private final WorkerRegistry workerRegistry;
   private final WorkerControlPlaneRuntime controlPlaneRuntime;
   private final ControlPlaneIdentity identity;
   private final TriggerDefaults defaults;
@@ -55,14 +54,12 @@ class TriggerRuntimeAdapter {
                         TriggerDefaults defaults,
                         Clock clock) {
     this.workerRuntime = Objects.requireNonNull(workerRuntime, "workerRuntime");
-    this.workerRegistry = Objects.requireNonNull(workerRegistry, "workerRegistry");
     this.controlPlaneRuntime = Objects.requireNonNull(controlPlaneRuntime, "controlPlaneRuntime");
     this.identity = Objects.requireNonNull(identity, "identity");
     this.defaults = Objects.requireNonNull(defaults, "defaults");
     this.clock = Objects.requireNonNull(clock, "clock");
-    this.triggerWorkers = workerRegistry.all().stream()
-        .filter(definition -> definition.workerType() == WorkerType.GENERATOR)
-        .filter(definition -> "trigger".equals(definition.role()))
+    WorkerRegistry registry = Objects.requireNonNull(workerRegistry, "workerRegistry");
+    this.triggerWorkers = registry.streamByRoleAndType("trigger", WorkerType.GENERATOR)
         .toList();
     initialiseStateListeners();
   }

--- a/trigger-service/src/test/java/io/pockethive/trigger/TriggerRuntimeAdapterTest.java
+++ b/trigger-service/src/test/java/io/pockethive/trigger/TriggerRuntimeAdapterTest.java
@@ -12,12 +12,12 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -69,7 +69,8 @@ class TriggerRuntimeAdapterTest {
         null,
         TriggerWorkerConfig.class
     );
-    when(workerRegistry.all()).thenReturn(List.of(definition));
+    when(workerRegistry.streamByRoleAndType("trigger", WorkerType.GENERATOR))
+        .thenAnswer(invocation -> Stream.of(definition));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- add role and type lookup helpers to the worker registry with accompanying unit coverage
- refactor processor, moderator, postprocessor, and trigger runtime adapters to use the shared registry lookups

## Testing
- mvn -pl common/worker-sdk,processor-service,moderator-service,postprocessor-service,trigger-service test

------
https://chatgpt.com/codex/tasks/task_e_68e53cffddfc832883a7162323733b34