### PR TITLE
feat: extract reusable rabbit worker adapter

### DIFF
--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/transport/rabbit/RabbitMessageWorkerAdapter.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/transport/rabbit/RabbitMessageWorkerAdapter.java
@@ -1,0 +1,419 @@
+package io.pockethive.worker.sdk.transport.rabbit;
+
+import io.pockethive.observability.ObservabilityContext;
+import io.pockethive.observability.ObservabilityContextUtil;
+import io.pockethive.worker.sdk.api.WorkMessage;
+import io.pockethive.worker.sdk.api.WorkResult;
+import io.pockethive.worker.sdk.runtime.WorkerControlPlaneRuntime;
+import io.pockethive.worker.sdk.runtime.WorkerControlPlaneRuntime.WorkerStateSnapshot;
+import io.pockethive.worker.sdk.runtime.WorkerDefinition;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.MDC;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.rabbit.listener.MessageListenerContainer;
+import org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistry;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+
+/**
+ * Helper that encapsulates the common RabbitMQ plumbing required by message-based PocketHive workers.
+ * <p>
+ * The adapter centralises the listener lifecycle management, control-plane signal wiring and message
+ * conversion concerns that historically lived in each service implementation. Runtime adapters can now
+ * supply only their queue configuration and service specific callbacks while delegating the reusable
+ * behaviour to this class.
+ * <p>
+ * Responsibilities covered by the helper include:
+ * <ul>
+ *     <li>Starting and stopping the Spring AMQP listener container based on the control-plane desired
+ *         state for the worker instance.</li>
+ *     <li>Translating inbound {@link Message AMQP messages} into {@link WorkMessage} envelopes using the
+ *         {@link RabbitWorkMessageConverter} that is shared across PocketHive workers.</li>
+ *     <li>Invoking the provided {@link WorkDispatcher} callback and, when a {@link WorkResult.Message}
+ *         result is produced, publishing it via the optional {@link MessageResultPublisher} hook.</li>
+ *     <li>Relaying control-plane payloads through the {@link WorkerControlPlaneRuntime} with the expected
+ *         observability context population and validation semantics.</li>
+ *     <li>Surfacing status snapshots and deltas to the control plane so orchestration components can track
+ *         worker health.</li>
+ * </ul>
+ * The helper is intentionally stateless aside from the desired listener state toggle which is derived
+ * from the control plane. This keeps the adapter safe to reuse across different runtime adapters while
+ * still exposing extension points for service specific logging or result handling.
+ */
+public final class RabbitMessageWorkerAdapter implements ApplicationListener<ContextRefreshedEvent> {
+
+    private final Logger log;
+    private final String listenerId;
+    private final String displayName;
+    private final WorkerDefinition workerDefinition;
+    private final WorkerControlPlaneRuntime controlPlaneRuntime;
+    private final RabbitListenerEndpointRegistry listenerRegistry;
+    private final io.pockethive.controlplane.ControlPlaneIdentity identity;
+    private final Supplier<Boolean> defaultEnabledSupplier;
+    private final Function<WorkerStateSnapshot, Boolean> desiredStateResolver;
+    private final WorkDispatcher dispatcher;
+    private final MessageResultPublisher messageResultPublisher;
+    private final Consumer<Exception> dispatchErrorHandler;
+    private final RabbitWorkMessageConverter messageConverter = new RabbitWorkMessageConverter();
+    private volatile boolean desiredEnabled;
+
+    private RabbitMessageWorkerAdapter(Builder builder) {
+        this.log = builder.log;
+        this.listenerId = builder.listenerId;
+        this.displayName = builder.displayName;
+        this.workerDefinition = builder.workerDefinition;
+        this.controlPlaneRuntime = builder.controlPlaneRuntime;
+        this.listenerRegistry = builder.listenerRegistry;
+        this.identity = builder.identity;
+        this.defaultEnabledSupplier = builder.defaultEnabledSupplier;
+        this.desiredStateResolver = builder.desiredStateResolver;
+        this.dispatcher = builder.dispatcher;
+        this.messageResultPublisher = builder.messageResultPublisher;
+        this.dispatchErrorHandler = builder.dispatchErrorHandler;
+    }
+
+    /**
+     * Creates a new {@link Builder} instance used to construct the adapter.
+     *
+     * @return a fresh builder pre-configured for {@link RabbitMessageWorkerAdapter}
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Registers the control-plane listener and applies the default enabled state.
+     * <p>
+     * This method should be invoked during service initialisation (typically in a {@code @PostConstruct}
+     * method) so that the helper can record the desired state communicated by the control plane. The
+     * listener state is immediately applied and a status snapshot emitted to ensure upstream components
+     * observe the current worker availability.
+     */
+    public void initialiseStateListener() {
+        desiredEnabled = defaultEnabledSupplier.get();
+        controlPlaneRuntime.registerStateListener(workerDefinition.beanName(), snapshot -> {
+            boolean enabled = Optional.ofNullable(desiredStateResolver.apply(snapshot)).orElse(desiredEnabled);
+            toggleListener(enabled);
+        });
+        applyListenerState();
+        controlPlaneRuntime.emitStatusSnapshot();
+    }
+
+    /**
+     * Converts inbound AMQP messages and dispatches them through the configured worker runtime.
+     * <p>
+     * The message payload is translated using {@link RabbitWorkMessageConverter} before being handed off
+     * to the {@link WorkDispatcher}. Any {@link WorkResult.Message} outputs are converted back into AMQP
+     * {@link Message messages} and forwarded to the optional {@link MessageResultPublisher}. Exceptions
+     * thrown by the dispatcher are routed to the configured {@link #dispatchErrorHandler} allowing
+     * services to integrate with their own error handling strategies.
+     *
+     * @param message inbound message delivered by Spring AMQP
+     */
+    public void onWork(Message message) {
+        WorkMessage workMessage = messageConverter.fromMessage(message);
+        try {
+            WorkResult result = dispatcher.dispatch(workMessage);
+            if (result instanceof WorkResult.Message messageResult) {
+                if (messageResultPublisher != null) {
+                    Message outbound = messageConverter.toMessage(messageResult.value());
+                    messageResultPublisher.publish(messageResult, outbound);
+                } else if (log.isDebugEnabled()) {
+                    log.debug("{} worker produced message result with {} bytes but no publisher is configured", displayName,
+                        messageResult.value().body().length);
+                }
+            }
+        } catch (Exception ex) {
+            dispatchErrorHandler.accept(ex);
+        }
+    }
+
+    /**
+     * Forwards scheduled status delta requests to the control plane helper.
+     *
+     * @see WorkerControlPlaneRuntime#emitStatusDelta()
+     */
+    public void emitStatusDelta() {
+        controlPlaneRuntime.emitStatusDelta();
+    }
+
+    /**
+     * Handles control-plane payloads, enforcing the standard validation and observability wiring.
+     * <p>
+     * Implementations should delegate any inbound control queue consumption to this method so that the
+     * shared validation and MDC propagation rules are consistently applied across workers.
+     *
+     * @param payload     JSON payload supplied by the control plane
+     * @param routingKey  routing key describing the control action
+     * @param traceHeader optional observability header propagated from upstream components
+     */
+    public void onControl(String payload, String routingKey, String traceHeader) {
+        ObservabilityContext context = ObservabilityContextUtil.fromHeader(traceHeader);
+        ObservabilityContextUtil.populateMdc(context);
+        try {
+            if (routingKey == null || routingKey.isBlank()) {
+                throw new IllegalArgumentException("Control routing key must not be null or blank");
+            }
+            if (payload == null || payload.isBlank()) {
+                throw new IllegalArgumentException("Control payload must not be null or blank");
+            }
+            boolean handled = controlPlaneRuntime.handle(payload, routingKey);
+            if (!handled) {
+                log.debug("Ignoring control-plane payload on routing key {}", routingKey);
+            }
+        } finally {
+            MDC.clear();
+        }
+    }
+
+    @Override
+    public void onApplicationEvent(ContextRefreshedEvent event) {
+        applyListenerState();
+    }
+
+    private void toggleListener(boolean enabled) {
+        this.desiredEnabled = enabled;
+        applyListenerState();
+    }
+
+    /**
+     * Applies the desired listener state to the Spring AMQP {@link MessageListenerContainer} if it is
+     * already available. The container may not yet be registered when the application context is starting,
+     * in which case the helper logs the desired state and waits for a subsequent refresh event.
+     */
+    private void applyListenerState() {
+        MessageListenerContainer container = listenerRegistry.getListenerContainer(listenerId);
+        if (container == null) {
+            log.debug("{} listener container not yet available; desiredEnabled={} (instance={})", displayName, desiredEnabled,
+                identity.instanceId());
+            return;
+        }
+        if (desiredEnabled && !container.isRunning()) {
+            container.start();
+            log.info("{} work listener started (instance={})", displayName, identity.instanceId());
+        } else if (!desiredEnabled && container.isRunning()) {
+            container.stop();
+            log.info("{} work listener stopped (instance={})", displayName, identity.instanceId());
+        }
+    }
+
+    /**
+     * Builder for {@link RabbitMessageWorkerAdapter} instances.
+     * <p>
+     * The builder requires explicit configuration for the worker metadata, control plane runtime, listener
+     * registry and dispatcher callback. Optional hooks include a {@link MessageResultPublisher} (for
+     * forwarding downstream work) and a custom dispatch error handler.
+     */
+    public static final class Builder {
+
+        private Logger log;
+        private String listenerId;
+        private String displayName;
+        private WorkerDefinition workerDefinition;
+        private WorkerControlPlaneRuntime controlPlaneRuntime;
+        private RabbitListenerEndpointRegistry listenerRegistry;
+        private io.pockethive.controlplane.ControlPlaneIdentity identity;
+        private Supplier<Boolean> defaultEnabledSupplier;
+        private Function<WorkerStateSnapshot, Boolean> desiredStateResolver;
+        private WorkDispatcher dispatcher;
+        private MessageResultPublisher messageResultPublisher;
+        private Consumer<Exception> dispatchErrorHandler;
+
+        private Builder() {
+        }
+
+        /**
+         * Provides the logger used for lifecycle and diagnostic output.
+         *
+         * @param log logger bound to the owning service
+         * @return this builder instance
+         */
+        public Builder logger(Logger log) {
+            this.log = Objects.requireNonNull(log, "log");
+            return this;
+        }
+
+        /**
+         * Sets the Spring AMQP listener id used to resolve the {@link MessageListenerContainer} from the
+         * {@link RabbitListenerEndpointRegistry}.
+         *
+         * @param listenerId listener identifier configured via {@code @RabbitListener(id=...)}
+         * @return this builder instance
+         */
+        public Builder listenerId(String listenerId) {
+            this.listenerId = Objects.requireNonNull(listenerId, "listenerId");
+            return this;
+        }
+
+        /**
+         * Sets a human readable display name used in log entries. When omitted the worker role from the
+         * {@link WorkerDefinition} is used.
+         *
+         * @param displayName descriptive label for log messages
+         * @return this builder instance
+         */
+        public Builder displayName(String displayName) {
+            this.displayName = Objects.requireNonNull(displayName, "displayName");
+            return this;
+        }
+
+        /**
+         * Supplies the {@link WorkerDefinition} associated with the adapter. The definition is used for
+         * control-plane registration and to resolve the default display name when none is provided.
+         *
+         * @param workerDefinition worker metadata from the hosting service
+         * @return this builder instance
+         */
+        public Builder workerDefinition(WorkerDefinition workerDefinition) {
+            this.workerDefinition = Objects.requireNonNull(workerDefinition, "workerDefinition");
+            return this;
+        }
+
+        /**
+         * Configures the control-plane runtime that handles state changes, status reporting and command
+         * dispatch for the worker.
+         *
+         * @param controlPlaneRuntime runtime responsible for interacting with the PocketHive control plane
+         * @return this builder instance
+         */
+        public Builder controlPlaneRuntime(WorkerControlPlaneRuntime controlPlaneRuntime) {
+            this.controlPlaneRuntime = Objects.requireNonNull(controlPlaneRuntime, "controlPlaneRuntime");
+            return this;
+        }
+
+        /**
+         * Provides the Spring registry that contains the listener container backing the worker's queue
+         * subscription.
+         *
+         * @param listenerRegistry registry supplied by Spring AMQP
+         * @return this builder instance
+         */
+        public Builder listenerRegistry(RabbitListenerEndpointRegistry listenerRegistry) {
+            this.listenerRegistry = Objects.requireNonNull(listenerRegistry, "listenerRegistry");
+            return this;
+        }
+
+        /**
+         * Sets the control plane identity representing the running worker instance. It is used to enrich
+         * log messages when the listener toggles state.
+         *
+         * @param identity identity assigned to the worker instance
+         * @return this builder instance
+         */
+        public Builder identity(io.pockethive.controlplane.ControlPlaneIdentity identity) {
+            this.identity = Objects.requireNonNull(identity, "identity");
+            return this;
+        }
+
+        /**
+         * Supplies a callback that determines the default enabled state when the worker starts. The control
+         * plane desired state can later override this initial value.
+         *
+         * @param defaultEnabledSupplier supplier that provides the default enabled flag
+         * @return this builder instance
+         */
+        public Builder defaultEnabledSupplier(Supplier<Boolean> defaultEnabledSupplier) {
+            this.defaultEnabledSupplier = Objects.requireNonNull(defaultEnabledSupplier, "defaultEnabledSupplier");
+            return this;
+        }
+
+        /**
+         * Supplies the function that interprets control-plane snapshots and returns the desired listener
+         * state. The helper will fall back to the last known desired value when {@code null} is returned.
+         *
+         * @param desiredStateResolver resolver transforming {@link WorkerStateSnapshot snapshots} to
+         *                             enabled flags
+         * @return this builder instance
+         */
+        public Builder desiredStateResolver(Function<WorkerStateSnapshot, Boolean> desiredStateResolver) {
+            this.desiredStateResolver = Objects.requireNonNull(desiredStateResolver, "desiredStateResolver");
+            return this;
+        }
+
+        /**
+         * Configures the callback responsible for executing the business logic once an inbound work message
+         * has been converted.
+         *
+         * @param dispatcher dispatcher invoked for each {@link WorkMessage}
+         * @return this builder instance
+         */
+        public Builder dispatcher(WorkDispatcher dispatcher) {
+            this.dispatcher = Objects.requireNonNull(dispatcher, "dispatcher");
+            return this;
+        }
+
+        /**
+         * Provides the optional hook for publishing downstream {@link WorkResult.Message message results}.
+         * Services that do not produce message results can omit this configuration.
+         *
+         * @param messageResultPublisher callback invoked when a message result is produced
+         * @return this builder instance
+         */
+        public Builder messageResultPublisher(MessageResultPublisher messageResultPublisher) {
+            this.messageResultPublisher = messageResultPublisher;
+            return this;
+        }
+
+        /**
+         * Overrides the default dispatch error handling behaviour which logs a warning when the dispatcher
+         * throws. This allows services to integrate with their own observability or retry strategies.
+         *
+         * @param dispatchErrorHandler callback invoked when the dispatcher throws an exception
+         * @return this builder instance
+         */
+        public Builder dispatchErrorHandler(Consumer<Exception> dispatchErrorHandler) {
+            this.dispatchErrorHandler = Objects.requireNonNull(dispatchErrorHandler, "dispatchErrorHandler");
+            return this;
+        }
+
+        /**
+         * Validates the builder configuration and creates a {@link RabbitMessageWorkerAdapter} instance.
+         *
+         * @return a fully configured adapter ready for use by a worker runtime
+         */
+        public RabbitMessageWorkerAdapter build() {
+            Objects.requireNonNull(log, "log");
+            Objects.requireNonNull(listenerId, "listenerId");
+            if (displayName == null) {
+                displayName = workerDefinition != null ? workerDefinition.role() : "worker";
+            }
+            Objects.requireNonNull(workerDefinition, "workerDefinition");
+            Objects.requireNonNull(controlPlaneRuntime, "controlPlaneRuntime");
+            Objects.requireNonNull(listenerRegistry, "listenerRegistry");
+            Objects.requireNonNull(identity, "identity");
+            Objects.requireNonNull(defaultEnabledSupplier, "defaultEnabledSupplier");
+            Objects.requireNonNull(desiredStateResolver, "desiredStateResolver");
+            Objects.requireNonNull(dispatcher, "dispatcher");
+            if (dispatchErrorHandler == null) {
+                dispatchErrorHandler = ex -> log.warn("{} worker invocation failed", displayName, ex);
+            }
+            return new RabbitMessageWorkerAdapter(this);
+        }
+    }
+
+    /**
+     * Callback invoked by the helper to dispatch converted {@link WorkMessage} instances.
+     * Implementations typically wrap the service specific runtime that processes the work message and
+     * returns a {@link WorkResult}.
+     */
+    @FunctionalInterface
+    public interface WorkDispatcher {
+        WorkResult dispatch(WorkMessage message) throws Exception;
+    }
+
+    /**
+     * Callback invoked when the worker returns a {@link WorkResult.Message}. Implementations can forward the
+     * AMQP {@link Message} downstream or perform service-specific logging.
+     * The helper intentionally exposes the converted {@link Message} to avoid repeated converter lookups in
+     * service adapters.
+     */
+    @FunctionalInterface
+    public interface MessageResultPublisher {
+        void publish(WorkResult.Message result, Message message);
+    }
+}

--- a/common/worker-sdk/src/test/java/io/pockethive/worker/sdk/transport/rabbit/RabbitMessageWorkerAdapterTest.java
+++ b/common/worker-sdk/src/test/java/io/pockethive/worker/sdk/transport/rabbit/RabbitMessageWorkerAdapterTest.java
@@ -1,0 +1,188 @@
+package io.pockethive.worker.sdk.transport.rabbit;
+
+import io.pockethive.controlplane.ControlPlaneIdentity;
+import io.pockethive.worker.sdk.api.WorkMessage;
+import io.pockethive.worker.sdk.api.WorkResult;
+import io.pockethive.worker.sdk.config.WorkerType;
+import io.pockethive.worker.sdk.runtime.WorkerControlPlaneRuntime;
+import io.pockethive.worker.sdk.runtime.WorkerDefinition;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.rabbit.listener.MessageListenerContainer;
+import org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistry;
+import org.springframework.context.event.ContextRefreshedEvent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RabbitMessageWorkerAdapterTest {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RabbitMessageWorkerAdapterTest.class);
+
+    @Mock
+    private WorkerControlPlaneRuntime controlPlaneRuntime;
+
+    @Mock
+    private RabbitListenerEndpointRegistry listenerRegistry;
+
+    @Mock
+    private MessageListenerContainer listenerContainer;
+
+    @Mock
+    private RabbitMessageWorkerAdapter.WorkDispatcher dispatcher;
+
+    @Mock
+    private RabbitMessageWorkerAdapter.MessageResultPublisher resultPublisher;
+
+    @Mock
+    private Consumer<Exception> errorHandler;
+
+    private WorkerDefinition workerDefinition;
+    private ControlPlaneIdentity identity;
+    private Supplier<Boolean> defaultEnabled;
+    private Function<WorkerControlPlaneRuntime.WorkerStateSnapshot, Boolean> desiredStateResolver;
+
+    @BeforeEach
+    void setUp() {
+        workerDefinition = new WorkerDefinition(
+            "processorWorker",
+            Object.class,
+            WorkerType.MESSAGE,
+            "processor",
+            "processor.in",
+            "processor.out",
+            Object.class
+        );
+        identity = new ControlPlaneIdentity("swarm-1", "processor", "instance-1");
+        defaultEnabled = () -> true;
+        desiredStateResolver = snapshot -> snapshot.enabled().orElseGet(defaultEnabled);
+    }
+
+    @Test
+    void initialiseStateListenerRegistersControlPlaneHookAndAppliesDefault() {
+        when(listenerRegistry.getListenerContainer("listener")).thenReturn(listenerContainer);
+        when(listenerContainer.isRunning()).thenReturn(false);
+
+        RabbitMessageWorkerAdapter adapter = builder().build();
+
+        adapter.initialiseStateListener();
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Consumer<WorkerControlPlaneRuntime.WorkerStateSnapshot>> listenerCaptor = ArgumentCaptor.forClass(Consumer.class);
+        verify(controlPlaneRuntime).registerStateListener(eq("processorWorker"), listenerCaptor.capture());
+        verify(listenerContainer).start();
+        verify(controlPlaneRuntime).emitStatusSnapshot();
+
+        WorkerControlPlaneRuntime.WorkerStateSnapshot snapshot = mock(WorkerControlPlaneRuntime.WorkerStateSnapshot.class);
+        when(snapshot.enabled()).thenReturn(Optional.of(false));
+        when(listenerContainer.isRunning()).thenReturn(true);
+
+        listenerCaptor.getValue().accept(snapshot);
+
+        verify(listenerContainer).stop();
+    }
+
+    @Test
+    void onWorkDispatchesAndPublishesMessageResults() throws Exception {
+        RabbitMessageWorkerAdapter adapter = builder().build();
+        RabbitWorkMessageConverter converter = new RabbitWorkMessageConverter();
+        Message inbound = converter.toMessage(WorkMessage.text("payload").build());
+
+        when(dispatcher.dispatch(any(WorkMessage.class)))
+            .thenReturn(WorkResult.message(WorkMessage.text("processed").build()));
+
+        adapter.onWork(inbound);
+
+        ArgumentCaptor<WorkMessage> workCaptor = ArgumentCaptor.forClass(WorkMessage.class);
+        verify(dispatcher).dispatch(workCaptor.capture());
+        assertThat(workCaptor.getValue().body()).isEqualTo("payload".getBytes(StandardCharsets.UTF_8));
+
+        ArgumentCaptor<Message> outboundCaptor = ArgumentCaptor.forClass(Message.class);
+        verify(resultPublisher).publish(any(WorkResult.Message.class), outboundCaptor.capture());
+        assertThat(outboundCaptor.getValue().getBody()).isEqualTo("processed".getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void onWorkErrorsDelegateToErrorHandler() throws Exception {
+        RabbitMessageWorkerAdapter adapter = builder().build();
+        RabbitWorkMessageConverter converter = new RabbitWorkMessageConverter();
+        Message inbound = converter.toMessage(WorkMessage.text("payload").build());
+        RuntimeException failure = new RuntimeException("boom");
+        doThrow(failure).when(dispatcher).dispatch(any(WorkMessage.class));
+
+        adapter.onWork(inbound);
+
+        verify(errorHandler).accept(failure);
+        verify(resultPublisher, never()).publish(any(), any());
+    }
+
+    @Test
+    void onControlValidatesPayloadAndDelegates() {
+        RabbitMessageWorkerAdapter adapter = builder().build();
+        when(controlPlaneRuntime.handle("{}", "processor.control")).thenReturn(true);
+
+        adapter.onControl("{}", "processor.control", null);
+
+        verify(controlPlaneRuntime).handle("{}", "processor.control");
+
+        assertThatThrownBy(() -> adapter.onControl(" ", "processor.control", null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("payload");
+        assertThatThrownBy(() -> adapter.onControl("{}", " ", null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("routing");
+    }
+
+    @Test
+    void onApplicationEventReappliesListenerState() {
+        RabbitMessageWorkerAdapter adapter = builder().build();
+        when(listenerContainer.isRunning()).thenReturn(false);
+
+        adapter.initialiseStateListener();
+
+        reset(listenerRegistry, listenerContainer);
+        when(listenerRegistry.getListenerContainer("listener")).thenReturn(listenerContainer);
+        when(listenerContainer.isRunning()).thenReturn(true);
+
+        adapter.onApplicationEvent(mock(ContextRefreshedEvent.class));
+
+        verify(listenerRegistry).getListenerContainer("listener");
+    }
+
+    private RabbitMessageWorkerAdapter.Builder builder() {
+        return RabbitMessageWorkerAdapter.builder()
+            .logger(LOGGER)
+            .listenerId("listener")
+            .displayName("Processor")
+            .workerDefinition(workerDefinition)
+            .controlPlaneRuntime(controlPlaneRuntime)
+            .listenerRegistry(listenerRegistry)
+            .identity(identity)
+            .defaultEnabledSupplier(defaultEnabled)
+            .desiredStateResolver(desiredStateResolver)
+            .dispatcher(dispatcher)
+            .messageResultPublisher(resultPublisher)
+            .dispatchErrorHandler(errorHandler);
+    }
+}

--- a/moderator-service/src/main/java/io/pockethive/moderator/ModeratorRuntimeAdapter.java
+++ b/moderator-service/src/main/java/io/pockethive/moderator/ModeratorRuntimeAdapter.java
@@ -3,22 +3,18 @@ package io.pockethive.moderator;
 import io.pockethive.Topology;
 import io.pockethive.TopologyDefaults;
 import io.pockethive.controlplane.ControlPlaneIdentity;
-import io.pockethive.observability.ObservabilityContext;
 import io.pockethive.observability.ObservabilityContextUtil;
-import io.pockethive.worker.sdk.api.WorkMessage;
-import io.pockethive.worker.sdk.api.WorkResult;
 import io.pockethive.worker.sdk.config.WorkerType;
 import io.pockethive.worker.sdk.runtime.WorkerControlPlaneRuntime;
 import io.pockethive.worker.sdk.runtime.WorkerDefinition;
 import io.pockethive.worker.sdk.runtime.WorkerRegistry;
 import io.pockethive.worker.sdk.runtime.WorkerRuntime;
-import io.pockethive.worker.sdk.transport.rabbit.RabbitWorkMessageConverter;
+import io.pockethive.worker.sdk.transport.rabbit.RabbitMessageWorkerAdapter;
 import jakarta.annotation.PostConstruct;
 import java.util.Objects;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -36,15 +32,7 @@ class ModeratorRuntimeAdapter implements ApplicationListener<ContextRefreshedEve
   private static final Logger log = LoggerFactory.getLogger(ModeratorRuntimeAdapter.class);
   private static final String LISTENER_ID = "moderatorWorkerListener";
 
-  private final WorkerRuntime workerRuntime;
-  private final WorkerControlPlaneRuntime controlPlaneRuntime;
-  private final RabbitTemplate rabbitTemplate;
-  private final RabbitListenerEndpointRegistry listenerRegistry;
-  private final ControlPlaneIdentity identity;
-  private final ModeratorDefaults defaults;
-  private final RabbitWorkMessageConverter messageConverter = new RabbitWorkMessageConverter();
-  private final WorkerDefinition workerDefinition;
-  private volatile boolean desiredEnabled;
+  private final RabbitMessageWorkerAdapter delegate;
 
   ModeratorRuntimeAdapter(WorkerRuntime workerRuntime,
                           WorkerRegistry workerRegistry,
@@ -53,97 +41,62 @@ class ModeratorRuntimeAdapter implements ApplicationListener<ContextRefreshedEve
                           RabbitListenerEndpointRegistry listenerRegistry,
                           ControlPlaneIdentity identity,
                           ModeratorDefaults defaults) {
-    this.workerRuntime = Objects.requireNonNull(workerRuntime, "workerRuntime");
-    this.controlPlaneRuntime = Objects.requireNonNull(controlPlaneRuntime, "controlPlaneRuntime");
-    this.rabbitTemplate = Objects.requireNonNull(rabbitTemplate, "rabbitTemplate");
-    this.listenerRegistry = Objects.requireNonNull(listenerRegistry, "listenerRegistry");
-    this.identity = Objects.requireNonNull(identity, "identity");
-    this.defaults = Objects.requireNonNull(defaults, "defaults");
-    this.workerDefinition = workerRegistry.findByRoleAndType("moderator", WorkerType.MESSAGE)
+    WorkerRuntime runtime = Objects.requireNonNull(workerRuntime, "workerRuntime");
+    WorkerRegistry registry = Objects.requireNonNull(workerRegistry, "workerRegistry");
+    WorkerControlPlaneRuntime controlRuntime = Objects.requireNonNull(controlPlaneRuntime, "controlPlaneRuntime");
+    RabbitTemplate template = Objects.requireNonNull(rabbitTemplate, "rabbitTemplate");
+    RabbitListenerEndpointRegistry endpointRegistry = Objects.requireNonNull(listenerRegistry, "listenerRegistry");
+    ControlPlaneIdentity controlIdentity = Objects.requireNonNull(identity, "identity");
+    ModeratorDefaults moderatorDefaults = Objects.requireNonNull(defaults, "defaults");
+
+    WorkerDefinition workerDefinition = registry.findByRoleAndType("moderator", WorkerType.MESSAGE)
         .orElseThrow(() -> new IllegalStateException("Moderator worker definition not found"));
+
+    this.delegate = RabbitMessageWorkerAdapter.builder()
+        .logger(log)
+        .listenerId(LISTENER_ID)
+        .displayName("Moderator")
+        .workerDefinition(workerDefinition)
+        .controlPlaneRuntime(controlRuntime)
+        .listenerRegistry(endpointRegistry)
+        .identity(controlIdentity)
+        .defaultEnabledSupplier(() -> moderatorDefaults.asConfig().enabled())
+        .desiredStateResolver(snapshot -> snapshot.enabled().orElseGet(() -> snapshot.config(ModeratorWorkerConfig.class)
+            .map(ModeratorWorkerConfig::enabled)
+            .orElse(moderatorDefaults.asConfig().enabled())))
+        .dispatcher(message -> runtime.dispatch(workerDefinition.beanName(), message))
+        .messageResultPublisher((result, outbound) -> {
+          String routingKey = Optional.ofNullable(workerDefinition.outQueue()).orElse(Topology.MOD_QUEUE);
+          template.send(Topology.EXCHANGE, routingKey, outbound);
+        })
+        .dispatchErrorHandler(ex -> log.warn("Moderator worker invocation failed", ex))
+        .build();
   }
 
   @PostConstruct
   void initialiseStateListener() {
-    desiredEnabled = defaults.asConfig().enabled();
-    controlPlaneRuntime.registerStateListener(workerDefinition.beanName(), snapshot -> {
-      boolean enabled = snapshot.enabled().orElseGet(() -> snapshot.config(ModeratorWorkerConfig.class)
-          .map(ModeratorWorkerConfig::enabled).orElse(defaults.asConfig().enabled()));
-      toggleListener(enabled);
-    });
-    applyListenerState();
-    controlPlaneRuntime.emitStatusSnapshot();
+    delegate.initialiseStateListener();
   }
 
   @RabbitListener(id = LISTENER_ID, queues = "${ph.genQueue:" + TopologyDefaults.GEN_QUEUE + "}")
   public void onWork(Message message) {
-    WorkMessage workMessage = messageConverter.fromMessage(message);
-    try {
-      WorkResult result = workerRuntime.dispatch(workerDefinition.beanName(), workMessage);
-      publishResult(result);
-    } catch (Exception ex) {
-      log.warn("Moderator worker invocation failed", ex);
-    }
+    delegate.onWork(message);
   }
 
   @Scheduled(fixedRate = 5000)
   public void emitStatusDelta() {
-    controlPlaneRuntime.emitStatusDelta();
+    delegate.emitStatusDelta();
   }
 
   @RabbitListener(queues = "#{@moderatorControlQueueName}")
   public void onControl(String payload,
                         @Header(AmqpHeaders.RECEIVED_ROUTING_KEY) String routingKey,
                         @Header(value = ObservabilityContextUtil.HEADER, required = false) String traceHeader) {
-    ObservabilityContext context = ObservabilityContextUtil.fromHeader(traceHeader);
-    ObservabilityContextUtil.populateMdc(context);
-    try {
-      if (routingKey == null || routingKey.isBlank()) {
-        throw new IllegalArgumentException("Control routing key must not be null or blank");
-      }
-      if (payload == null || payload.isBlank()) {
-        throw new IllegalArgumentException("Control payload must not be null or blank");
-      }
-      boolean handled = controlPlaneRuntime.handle(payload, routingKey);
-      if (!handled) {
-        log.debug("Ignoring control-plane payload on routing key {}", routingKey);
-      }
-    } finally {
-      MDC.clear();
-    }
-  }
-
-  private void publishResult(WorkResult result) {
-    if (!(result instanceof WorkResult.Message messageResult)) {
-      return;
-    }
-    Message outbound = messageConverter.toMessage(messageResult.value());
-    String routingKey = Optional.ofNullable(workerDefinition.outQueue()).orElse(Topology.MOD_QUEUE);
-    rabbitTemplate.send(Topology.EXCHANGE, routingKey, outbound);
-  }
-
-  private void toggleListener(boolean enabled) {
-    this.desiredEnabled = enabled;
-    applyListenerState();
-  }
-
-  private void applyListenerState() {
-    var container = listenerRegistry.getListenerContainer(LISTENER_ID);
-    if (container == null) {
-      log.debug("Moderator listener container not yet available; desiredEnabled={} (instance={})", desiredEnabled, identity.instanceId());
-      return;
-    }
-    if (desiredEnabled && !container.isRunning()) {
-      container.start();
-      log.info("Moderator work listener started (instance={})", identity.instanceId());
-    } else if (!desiredEnabled && container.isRunning()) {
-      container.stop();
-      log.info("Moderator work listener stopped (instance={})", identity.instanceId());
-    }
+    delegate.onControl(payload, routingKey, traceHeader);
   }
 
   @Override
   public void onApplicationEvent(ContextRefreshedEvent event) {
-    applyListenerState();
+    delegate.onApplicationEvent(event);
   }
 }

--- a/moderator-service/src/test/java/io/pockethive/moderator/ModeratorRuntimeAdapterTest.java
+++ b/moderator-service/src/test/java/io/pockethive/moderator/ModeratorRuntimeAdapterTest.java
@@ -98,7 +98,7 @@ class ModeratorRuntimeAdapterTest {
     );
 
     adapter.initialiseStateListener();
-  verify(controlPlaneRuntime).emitStatusSnapshot();
+    verify(controlPlaneRuntime).emitStatusSnapshot();
 
     Message inbound = new RabbitWorkMessageConverter().toMessage(WorkMessage.text("body").build());
     adapter.onWork(inbound);
@@ -124,7 +124,7 @@ class ModeratorRuntimeAdapterTest {
     );
 
     adapter.initialiseStateListener();
-  verify(controlPlaneRuntime).emitStatusSnapshot();
+    verify(controlPlaneRuntime).emitStatusSnapshot();
 
     adapter.onControl("{}", "moderator.control", null);
     verify(controlPlaneRuntime).handle("{}", "moderator.control");

--- a/postprocessor-service/src/main/java/io/pockethive/postprocessor/PostProcessorRuntimeAdapter.java
+++ b/postprocessor-service/src/main/java/io/pockethive/postprocessor/PostProcessorRuntimeAdapter.java
@@ -2,21 +2,17 @@ package io.pockethive.postprocessor;
 
 import io.pockethive.TopologyDefaults;
 import io.pockethive.controlplane.ControlPlaneIdentity;
-import io.pockethive.observability.ObservabilityContext;
 import io.pockethive.observability.ObservabilityContextUtil;
-import io.pockethive.worker.sdk.api.WorkMessage;
-import io.pockethive.worker.sdk.api.WorkResult;
 import io.pockethive.worker.sdk.config.WorkerType;
 import io.pockethive.worker.sdk.runtime.WorkerControlPlaneRuntime;
 import io.pockethive.worker.sdk.runtime.WorkerDefinition;
 import io.pockethive.worker.sdk.runtime.WorkerRegistry;
 import io.pockethive.worker.sdk.runtime.WorkerRuntime;
-import io.pockethive.worker.sdk.transport.rabbit.RabbitWorkMessageConverter;
+import io.pockethive.worker.sdk.transport.rabbit.RabbitMessageWorkerAdapter;
 import jakarta.annotation.PostConstruct;
 import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistry;
@@ -33,14 +29,7 @@ class PostProcessorRuntimeAdapter implements ApplicationListener<ContextRefreshe
   private static final Logger log = LoggerFactory.getLogger(PostProcessorRuntimeAdapter.class);
   private static final String LISTENER_ID = "postProcessorWorkerListener";
 
-  private final WorkerRuntime workerRuntime;
-  private final WorkerControlPlaneRuntime controlPlaneRuntime;
-  private final RabbitListenerEndpointRegistry listenerRegistry;
-  private final ControlPlaneIdentity identity;
-  private final PostProcessorDefaults defaults;
-  private final RabbitWorkMessageConverter messageConverter = new RabbitWorkMessageConverter();
-  private final WorkerDefinition workerDefinition;
-  private volatile boolean desiredEnabled;
+  private final RabbitMessageWorkerAdapter delegate;
 
   PostProcessorRuntimeAdapter(WorkerRuntime workerRuntime,
                               WorkerRegistry workerRegistry,
@@ -48,94 +37,59 @@ class PostProcessorRuntimeAdapter implements ApplicationListener<ContextRefreshe
                               RabbitListenerEndpointRegistry listenerRegistry,
                               ControlPlaneIdentity identity,
                               PostProcessorDefaults defaults) {
-    this.workerRuntime = Objects.requireNonNull(workerRuntime, "workerRuntime");
-    this.controlPlaneRuntime = Objects.requireNonNull(controlPlaneRuntime, "controlPlaneRuntime");
-    this.listenerRegistry = Objects.requireNonNull(listenerRegistry, "listenerRegistry");
-    this.identity = Objects.requireNonNull(identity, "identity");
-    this.defaults = Objects.requireNonNull(defaults, "defaults");
-    this.workerDefinition = workerRegistry.findByRoleAndType("postprocessor", WorkerType.MESSAGE)
+    WorkerRuntime runtime = Objects.requireNonNull(workerRuntime, "workerRuntime");
+    WorkerRegistry registry = Objects.requireNonNull(workerRegistry, "workerRegistry");
+    WorkerControlPlaneRuntime controlRuntime = Objects.requireNonNull(controlPlaneRuntime, "controlPlaneRuntime");
+    RabbitListenerEndpointRegistry endpointRegistry = Objects.requireNonNull(listenerRegistry, "listenerRegistry");
+    ControlPlaneIdentity controlIdentity = Objects.requireNonNull(identity, "identity");
+    PostProcessorDefaults postProcessorDefaults = Objects.requireNonNull(defaults, "defaults");
+
+    WorkerDefinition workerDefinition = registry.findByRoleAndType("postprocessor", WorkerType.MESSAGE)
         .orElseThrow(() -> new IllegalStateException("Post-processor worker definition not found"));
+
+    this.delegate = RabbitMessageWorkerAdapter.builder()
+        .logger(log)
+        .listenerId(LISTENER_ID)
+        .displayName("Post-processor")
+        .workerDefinition(workerDefinition)
+        .controlPlaneRuntime(controlRuntime)
+        .listenerRegistry(endpointRegistry)
+        .identity(controlIdentity)
+        .defaultEnabledSupplier(() -> postProcessorDefaults.asConfig().enabled())
+        .desiredStateResolver(snapshot -> snapshot.enabled().orElseGet(() -> snapshot.config(PostProcessorWorkerConfig.class)
+            .map(PostProcessorWorkerConfig::enabled)
+            .orElse(postProcessorDefaults.asConfig().enabled())))
+        .dispatcher(message -> runtime.dispatch(workerDefinition.beanName(), message))
+        .messageResultPublisher((result, outbound) ->
+            log.debug("Dropping unexpected outbound message from post-processor worker: {} bytes", outbound.getBody().length))
+        .dispatchErrorHandler(ex -> log.warn("Post-processor worker invocation failed", ex))
+        .build();
   }
 
   @PostConstruct
   void initialiseStateListener() {
-    desiredEnabled = defaults.asConfig().enabled();
-    controlPlaneRuntime.registerStateListener(workerDefinition.beanName(), snapshot -> {
-      boolean enabled = snapshot.enabled().orElseGet(() -> snapshot.config(PostProcessorWorkerConfig.class)
-          .map(PostProcessorWorkerConfig::enabled)
-          .orElse(defaults.asConfig().enabled()));
-      toggleListener(enabled);
-    });
-    applyListenerState();
-    controlPlaneRuntime.emitStatusSnapshot();
+    delegate.initialiseStateListener();
   }
 
   @RabbitListener(id = LISTENER_ID, queues = "${ph.finalQueue:" + TopologyDefaults.FINAL_QUEUE + "}")
   public void onWork(Message message) {
-    WorkMessage workMessage = messageConverter.fromMessage(message);
-    try {
-      WorkResult result = workerRuntime.dispatch(workerDefinition.beanName(), workMessage);
-      publishResult(result);
-    } catch (Exception ex) {
-      log.warn("Post-processor worker invocation failed", ex);
-    }
+    delegate.onWork(message);
   }
 
   @Scheduled(fixedRate = 5000)
   public void emitStatusDelta() {
-    controlPlaneRuntime.emitStatusDelta();
+    delegate.emitStatusDelta();
   }
 
   @RabbitListener(queues = "#{@postProcessorControlQueueName}")
   public void onControl(String payload,
                         @Header(AmqpHeaders.RECEIVED_ROUTING_KEY) String routingKey,
                         @Header(value = ObservabilityContextUtil.HEADER, required = false) String traceHeader) {
-    ObservabilityContext context = ObservabilityContextUtil.fromHeader(traceHeader);
-    ObservabilityContextUtil.populateMdc(context);
-    try {
-      if (routingKey == null || routingKey.isBlank()) {
-        throw new IllegalArgumentException("Control routing key must not be null or blank");
-      }
-      if (payload == null || payload.isBlank()) {
-        throw new IllegalArgumentException("Control payload must not be null or blank");
-      }
-      boolean handled = controlPlaneRuntime.handle(payload, routingKey);
-      if (!handled) {
-        log.debug("Ignoring control-plane payload on routing key {}", routingKey);
-      }
-    } finally {
-      MDC.clear();
-    }
-  }
-
-  private void publishResult(WorkResult result) {
-    if (result instanceof WorkResult.Message messageResult) {
-      log.debug("Dropping unexpected outbound message from post-processor worker: {} bytes", messageResult.value().body().length);
-    }
-  }
-
-  private void toggleListener(boolean enabled) {
-    this.desiredEnabled = enabled;
-    applyListenerState();
-  }
-
-  private void applyListenerState() {
-    var container = listenerRegistry.getListenerContainer(LISTENER_ID);
-    if (container == null) {
-      log.debug("Post-processor listener container not yet available; desiredEnabled={} (instance={})", desiredEnabled, identity.instanceId());
-      return;
-    }
-    if (desiredEnabled && !container.isRunning()) {
-      container.start();
-      log.info("Post-processor work listener started (instance={})", identity.instanceId());
-    } else if (!desiredEnabled && container.isRunning()) {
-      container.stop();
-      log.info("Post-processor work listener stopped (instance={})", identity.instanceId());
-    }
+    delegate.onControl(payload, routingKey, traceHeader);
   }
 
   @Override
   public void onApplicationEvent(ContextRefreshedEvent event) {
-    applyListenerState();
+    delegate.onApplicationEvent(event);
   }
 }

--- a/processor-service/src/main/java/io/pockethive/processor/ProcessorRuntimeAdapter.java
+++ b/processor-service/src/main/java/io/pockethive/processor/ProcessorRuntimeAdapter.java
@@ -3,22 +3,18 @@ package io.pockethive.processor;
 import io.pockethive.Topology;
 import io.pockethive.TopologyDefaults;
 import io.pockethive.controlplane.ControlPlaneIdentity;
-import io.pockethive.observability.ObservabilityContext;
 import io.pockethive.observability.ObservabilityContextUtil;
-import io.pockethive.worker.sdk.api.WorkMessage;
-import io.pockethive.worker.sdk.api.WorkResult;
 import io.pockethive.worker.sdk.config.WorkerType;
 import io.pockethive.worker.sdk.runtime.WorkerControlPlaneRuntime;
 import io.pockethive.worker.sdk.runtime.WorkerDefinition;
 import io.pockethive.worker.sdk.runtime.WorkerRegistry;
 import io.pockethive.worker.sdk.runtime.WorkerRuntime;
-import io.pockethive.worker.sdk.transport.rabbit.RabbitWorkMessageConverter;
+import io.pockethive.worker.sdk.transport.rabbit.RabbitMessageWorkerAdapter;
 import jakarta.annotation.PostConstruct;
 import java.util.Objects;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -31,30 +27,9 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /**
- * Bridges the Spring Boot runtime with the PocketHive worker SDK for the processor service.
- * <p>
- * The adapter's lifecycle consists of three main responsibilities:
- * <ol>
- *   <li><strong>State listener registration</strong> – During {@link #initialiseStateListener()} we
- *       subscribe to the control plane so feature flags (for example a payload on
- *       {@code processor.control.toggle}) can enable or disable the Rabbit listener at runtime. The
- *       default desired state is read from {@link ProcessorDefaults}.</li>
- *   <li><strong>Work dispatch</strong> – {@link #onWork(Message)} is bound to the moderator queue via
- *       {@link RabbitListener}. Incoming AMQP messages are converted into {@link WorkMessage}
- *       instances and dispatched through {@link WorkerRuntime#dispatch(String, WorkMessage)}. When
- *       a {@link WorkResult#message(WorkMessage) message result} is returned we forward it to the
- *       final queue inside {@link #publishResult(WorkResult)}.</li>
- *   <li><strong>Control-plane handling</strong> – {@link #onControl(String, String, String)} listens to
- *       control topics (for example {@code processor.control.config}) so operators can push config
- *       updates or request snapshots. Observability headers are preserved using
- *       {@link ObservabilityContextUtil} to keep traces intact.</li>
- * </ol>
- * <p>
- * Users can use this adapter as a blueprint for new workers: wire in your
- * {@link WorkerDefinition} via the {@link WorkerRegistry}, bind listeners to your service-specific
- * queues, and reuse {@link #toggleListener(boolean)} to guard your Rabbit containers with
- * control-plane state. Override {@link #publishResult(WorkResult)} if your worker emits non-message
- * results (e.g., acknowledgements only).
+ * Bridges the Spring Boot runtime with the PocketHive worker SDK for the processor service while delegating
+ * shared plumbing to {@link RabbitMessageWorkerAdapter}. Role-specific concerns such as outbound routing remain in
+ * this adapter.
  */
 @Component
 class ProcessorRuntimeAdapter implements ApplicationListener<ContextRefreshedEvent> {
@@ -62,30 +37,8 @@ class ProcessorRuntimeAdapter implements ApplicationListener<ContextRefreshedEve
   private static final Logger log = LoggerFactory.getLogger(ProcessorRuntimeAdapter.class);
   private static final String LISTENER_ID = "processorWorkerListener";
 
-  private final WorkerRuntime workerRuntime;
-  private final WorkerControlPlaneRuntime controlPlaneRuntime;
-  private final RabbitTemplate rabbitTemplate;
-  private final RabbitListenerEndpointRegistry listenerRegistry;
-  private final ControlPlaneIdentity identity;
-  private final ProcessorDefaults defaults;
-  private final RabbitWorkMessageConverter messageConverter = new RabbitWorkMessageConverter();
-  private final WorkerDefinition workerDefinition;
-  private volatile boolean desiredEnabled;
+  private final RabbitMessageWorkerAdapter delegate;
 
-  /**
-   * Creates the runtime adapter with all infrastructure dependencies needed to dispatch work.
-   *
-   * @param workerRuntime worker engine that invokes {@code processorWorker}
-   * @param workerRegistry registry used to resolve the {@link WorkerDefinition} metadata such as
-   *                       queue bindings and bean names
-   * @param controlPlaneRuntime facade used to register state listeners and emit status snapshots
-   * @param rabbitTemplate template for publishing enriched {@link WorkMessage} instances back to
-   *                       RabbitMQ
-   * @param listenerRegistry Spring registry used to locate and control the listener container for
-   *                         {@link #LISTENER_ID}
-   * @param identity identifies the running instance (swarm, instance id) for logging and metrics
-   * @param defaults fallback configuration for the processor worker (base URL and enable flag)
-   */
   ProcessorRuntimeAdapter(WorkerRuntime workerRuntime,
                           WorkerRegistry workerRegistry,
                           WorkerControlPlaneRuntime controlPlaneRuntime,
@@ -93,157 +46,62 @@ class ProcessorRuntimeAdapter implements ApplicationListener<ContextRefreshedEve
                           RabbitListenerEndpointRegistry listenerRegistry,
                           ControlPlaneIdentity identity,
                           ProcessorDefaults defaults) {
-    this.workerRuntime = Objects.requireNonNull(workerRuntime, "workerRuntime");
-    this.controlPlaneRuntime = Objects.requireNonNull(controlPlaneRuntime, "controlPlaneRuntime");
-    this.rabbitTemplate = Objects.requireNonNull(rabbitTemplate, "rabbitTemplate");
-    this.listenerRegistry = Objects.requireNonNull(listenerRegistry, "listenerRegistry");
-    this.identity = Objects.requireNonNull(identity, "identity");
-    this.defaults = Objects.requireNonNull(defaults, "defaults");
-    this.workerDefinition = workerRegistry.findByRoleAndType("processor", WorkerType.MESSAGE)
+    WorkerRuntime runtime = Objects.requireNonNull(workerRuntime, "workerRuntime");
+    WorkerRegistry registry = Objects.requireNonNull(workerRegistry, "workerRegistry");
+    WorkerControlPlaneRuntime controlRuntime = Objects.requireNonNull(controlPlaneRuntime, "controlPlaneRuntime");
+    RabbitTemplate template = Objects.requireNonNull(rabbitTemplate, "rabbitTemplate");
+    RabbitListenerEndpointRegistry endpointRegistry = Objects.requireNonNull(listenerRegistry, "listenerRegistry");
+    ControlPlaneIdentity controlIdentity = Objects.requireNonNull(identity, "identity");
+    ProcessorDefaults processorDefaults = Objects.requireNonNull(defaults, "defaults");
+
+    WorkerDefinition workerDefinition = registry.findByRoleAndType("processor", WorkerType.MESSAGE)
         .orElseThrow(() -> new IllegalStateException("Processor worker definition not found"));
+
+    this.delegate = RabbitMessageWorkerAdapter.builder()
+        .logger(log)
+        .listenerId(LISTENER_ID)
+        .displayName("Processor")
+        .workerDefinition(workerDefinition)
+        .controlPlaneRuntime(controlRuntime)
+        .listenerRegistry(endpointRegistry)
+        .identity(controlIdentity)
+        .defaultEnabledSupplier(() -> processorDefaults.asConfig().enabled())
+        .desiredStateResolver(snapshot -> snapshot.enabled().orElseGet(() -> snapshot.config(ProcessorWorkerConfig.class)
+            .map(ProcessorWorkerConfig::enabled)
+            .orElse(processorDefaults.asConfig().enabled())))
+        .dispatcher(message -> runtime.dispatch(workerDefinition.beanName(), message))
+        .messageResultPublisher((result, outbound) -> {
+          String routingKey = Optional.ofNullable(workerDefinition.outQueue()).orElse(Topology.FINAL_QUEUE);
+          template.send(Topology.EXCHANGE, routingKey, outbound);
+        })
+        .dispatchErrorHandler(ex -> log.warn("Processor worker invocation failed", ex))
+        .build();
   }
 
-  /**
-   * Registers the control-plane listener after Spring constructs the adapter.
-   * <p>
-   * We capture the default {@link ProcessorWorkerConfig#enabled()} value, subscribe to
-   * {@link WorkerControlPlaneRuntime#registerStateListener(String, java.util.function.Consumer)},
-   * and immediately apply the desired state. This ensures that messages such as
-   * <pre>{@code {
-   *   "enabled": false
-   * }}</pre>
-   * sent on {@code processor.control.config} take effect without restarts.
-   */
   @PostConstruct
   void initialiseStateListener() {
-    desiredEnabled = defaults.asConfig().enabled();
-    controlPlaneRuntime.registerStateListener(workerDefinition.beanName(), snapshot -> {
-      boolean enabled = snapshot.enabled().orElseGet(() -> snapshot.config(ProcessorWorkerConfig.class)
-          .map(ProcessorWorkerConfig::enabled).orElse(defaults.asConfig().enabled()));
-      toggleListener(enabled);
-    });
-    applyListenerState();
-    controlPlaneRuntime.emitStatusSnapshot();
+    delegate.initialiseStateListener();
   }
 
-  /**
-   * Handles moderator queue messages and delegates them to the registered worker bean.
-   *
-   * @param message AMQP payload (converted to {@link WorkMessage}) received on the moderator queue
-   */
   @RabbitListener(id = LISTENER_ID, queues = "${ph.modQueue:" + TopologyDefaults.MOD_QUEUE + "}")
   public void onWork(Message message) {
-    WorkMessage workMessage = messageConverter.fromMessage(message);
-    try {
-      WorkResult result = workerRuntime.dispatch(workerDefinition.beanName(), workMessage);
-      publishResult(result);
-    } catch (Exception ex) {
-      log.warn("Processor worker invocation failed", ex);
-    }
+    delegate.onWork(message);
   }
 
-  /**
-   * Periodically forwards worker status deltas to the control plane (every 5 seconds by default).
-   * Beginners can tweak the schedule with {@code ph.processor.statusIntervalMs} if the service
-   * needs faster or slower updates.
-   */
   @Scheduled(fixedRate = 5000)
   public void emitStatusDelta() {
-    controlPlaneRuntime.emitStatusDelta();
+    delegate.emitStatusDelta();
   }
 
-  /**
-   * Consumes control-plane messages used to toggle the worker or push configuration.
-   * <p>
-   * Example routing keys include {@code processor.control.config} (config snapshots) and
-   * {@code processor.control.toggle} (explicit enable/disable). The payload is forwarded to
-   * {@link WorkerControlPlaneRuntime#handle(String, String)} which returns {@code true} when a
-   * handler is registered for the routing key. Observability context headers are propagated so
-   * dashboards can correlate operator actions.
-   *
-   * @param payload JSON control message (for example {@code {"baseUrl":"https://mock"}})
-   * @param routingKey AMQP routing key derived from the control exchange
-   * @param traceHeader optional observability header forwarded from orchestrator tooling
-   */
   @RabbitListener(queues = "#{@processorControlQueueName}")
   public void onControl(String payload,
                         @Header(AmqpHeaders.RECEIVED_ROUTING_KEY) String routingKey,
                         @Header(value = ObservabilityContextUtil.HEADER, required = false) String traceHeader) {
-    ObservabilityContext context = ObservabilityContextUtil.fromHeader(traceHeader);
-    ObservabilityContextUtil.populateMdc(context);
-    try {
-      if (routingKey == null || routingKey.isBlank()) {
-        throw new IllegalArgumentException("Control routing key must not be null or blank");
-      }
-      if (payload == null || payload.isBlank()) {
-        throw new IllegalArgumentException("Control payload must not be null or blank");
-      }
-      boolean handled = controlPlaneRuntime.handle(payload, routingKey);
-      if (!handled) {
-        log.debug("Ignoring control-plane payload on routing key {}", routingKey);
-      }
-    } finally {
-      MDC.clear();
-    }
+    delegate.onControl(payload, routingKey, traceHeader);
   }
 
-  /**
-   * Publishes successful worker results to the final queue.
-   * <p>
-   * Only {@link WorkResult.Message} instances are forwarded; other result types (ack/nack) are
-   * ignored because the worker runtime already acknowledged them. Override this method if your
-   * worker emits other types that must be bridged to Rabbit.
-   */
-  private void publishResult(WorkResult result) {
-    if (!(result instanceof WorkResult.Message messageResult)) {
-      return;
-    }
-    Message outbound = messageConverter.toMessage(messageResult.value());
-    String routingKey = Optional.ofNullable(workerDefinition.outQueue()).orElse(Topology.FINAL_QUEUE);
-    rabbitTemplate.send(Topology.EXCHANGE, routingKey, outbound);
-  }
-
-  /**
-   * Updates the desired state of the Rabbit listener and applies it immediately.
-   *
-   * @param enabled {@code true} to start consuming from the moderator queue, {@code false} to stop
-   */
-  private void toggleListener(boolean enabled) {
-    this.desiredEnabled = enabled;
-    applyListenerState();
-  }
-
-  /**
-   * Starts or stops the Rabbit listener container so the runtime matches {@link #desiredEnabled}.
-   * <p>
-   * This method is idempotent and can safely be called during context refreshes or control-plane
-   * updates. When the listener container is not yet registered we log the desired state for
-   * troubleshooting; subsequent invocations (triggered by
-   * {@link ApplicationListener#onApplicationEvent(org.springframework.context.ApplicationEvent)})
-   * will retry.
-   */
-  private void applyListenerState() {
-    var container = listenerRegistry.getListenerContainer(LISTENER_ID);
-    if (container == null) {
-      log.debug("Processor listener container not yet available; desiredEnabled={} (instance={})", desiredEnabled, identity.instanceId());
-      return;
-    }
-    if (desiredEnabled && !container.isRunning()) {
-      container.start();
-      log.info("Processor work listener started (instance={})", identity.instanceId());
-    } else if (!desiredEnabled && container.isRunning()) {
-      container.stop();
-      log.info("Processor work listener stopped (instance={})", identity.instanceId());
-    }
-  }
-
-  /**
-   * Re-applies listener state when the Spring context is refreshed (e.g., after the container is
-   * fully initialised). This acts as a safety net in case {@link #applyListenerState()} ran before
-   * the listener container became available.
-   */
   @Override
   public void onApplicationEvent(ContextRefreshedEvent event) {
-    applyListenerState();
+    delegate.onApplicationEvent(event);
   }
 }

--- a/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmLifecycle.java
+++ b/swarm-controller-service/src/main/java/io/pockethive/swarmcontroller/SwarmLifecycle.java
@@ -149,7 +149,7 @@ public interface SwarmLifecycle {
   /**
    * Convenience toggle invoked by REST endpoints to flip swarm workloads on or off.
    * <p>
-   * <strong>When it runs:</strong> triggered by {@code POST /api/swarm-managers/*/enabled} calls.
+   * <strong>When it runs:</strong> triggered by {@code POST /api/swarm-managers/{id}/enabled} calls.
    * Implementations should emit {@code config-update} signals and update
    * {@link #getStatus()} accordingly.
    *


### PR DESCRIPTION
## Summary
- add RabbitMessageWorkerAdapter helper in worker-sdk with listener toggling, conversion, control-plane wiring, and comprehensive in-class Javadoc
- refactor processor, moderator, and postprocessor runtime adapters to delegate to the helper while preserving role-specific routing
- document the new helper in the worker SDK quickstart and cover it with dedicated unit tests

## Testing
- mvn -pl common/worker-sdk test

------
https://chatgpt.com/codex/tasks/task_e_68e586b4afb48328825a7477e8281e36