### PR TITLE
Ensure worker status queues reflect runtime overrides

### DIFF
--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerState.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerState.java
@@ -106,12 +106,20 @@ public final class WorkerState {
     void addInboundRoute(String queue) {
         if (queue != null && !queue.isBlank()) {
             workInRoutes.add(queue);
+            String definitionQueue = definition.inQueue();
+            if (definitionQueue != null && !definitionQueue.equals(queue)) {
+                workInRoutes.remove(definitionQueue);
+            }
         }
     }
 
     void addOutboundRoute(String queue) {
         if (queue != null && !queue.isBlank()) {
             workOutRoutes.add(queue);
+            String definitionQueue = definition.outQueue();
+            if (definitionQueue != null && !definitionQueue.equals(queue)) {
+                workOutRoutes.remove(definitionQueue);
+            }
         }
     }
 

--- a/common/worker-sdk/src/test/java/io/pockethive/worker/sdk/runtime/WorkerStatusPublisherTest.java
+++ b/common/worker-sdk/src/test/java/io/pockethive/worker/sdk/runtime/WorkerStatusPublisherTest.java
@@ -30,15 +30,27 @@ class WorkerStatusPublisherTest {
     }
 
     @Test
-    void workRouteHelpersRegisterAdditionalRoutes() {
+    void workRouteHelpersReplaceDefinitionRoutesWhenDifferent() {
         WorkerState state = new WorkerState(DEFINITION);
         WorkerStatusPublisher publisher = new WorkerStatusPublisher(state, () -> { }, () -> { });
 
         publisher.workIn("dynamic.in");
         publisher.workOut("dynamic.out");
 
-        assertThat(state.inboundRoutes()).contains("in.queue", "dynamic.in");
-        assertThat(state.outboundRoutes()).contains("out.queue", "dynamic.out");
+        assertThat(state.inboundRoutes()).containsExactlyInAnyOrder("dynamic.in");
+        assertThat(state.outboundRoutes()).containsExactlyInAnyOrder("dynamic.out");
+    }
+
+    @Test
+    void workRouteHelpersRetainDefinitionWhenUnchanged() {
+        WorkerState state = new WorkerState(DEFINITION);
+        WorkerStatusPublisher publisher = new WorkerStatusPublisher(state, () -> { }, () -> { });
+
+        publisher.workIn("in.queue");
+        publisher.workOut("out.queue");
+
+        assertThat(state.inboundRoutes()).containsExactlyInAnyOrder("in.queue");
+        assertThat(state.outboundRoutes()).containsExactlyInAnyOrder("out.queue");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- replace default queue entries with runtime values when workers publish status
- extend WorkerStatusPublisher tests to cover overriding and retaining routes

## Testing
- mvn -pl common/worker-sdk test

------
https://chatgpt.com/codex/tasks/task_e_68e91845f4d88328a0c5674caef86bfe