### PR TITLE
Add status event parsing and control-plane helpers

### DIFF
--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -21,6 +21,23 @@ src/
     harness-skeleton.feature # Placeholder scenario tagged as @wip so it does not execute
 ```
 
+## Control-plane event helpers
+
+The `support` package exposes `ControlPlaneEvents`, a lightweight RabbitMQ consumer that aggregates both control-plane
+confirmations and worker status envelopes emitted on the `ev.status-*` routes. The helper offers the following
+capabilities for step definitions:
+
+- `statuses()` / `statusesForSwarm(swarmId)` expose the collected `StatusEvent` snapshots for ad-hoc inspection.
+- `latestStatusEvent(swarmId, role, instance)` returns the most recent status for a particular worker identity along with
+  `lastStatusSeenAt(...)` to retrieve the corresponding receive timestamp.
+- `assertWorkQueues(...)` and `assertControlQueues(...)` compare the advertised queue lists (`in`, `routes`, `out`) from
+  the snapshot against the expected values, throwing a descriptive `AssertionError` when they diverge. These assertions
+  are designed for Awaitility-driven steps that wait until the control plane publishes the desired topology.
+
+The status payloads are deserialised into the immutable `StatusEvent` DTO, which mirrors the schema produced by
+`StatusEnvelopeBuilder`. This keeps the test harness aligned with the production envelope format while still allowing the
+tests to focus on the relevant fields.
+
 ## Execution
 
 Run the suite once the PocketHive stack is deployed and the required environment variables are available. Helper

--- a/e2e-tests/src/main/java/io/pockethive/e2e/support/ControlPlaneEventParser.java
+++ b/e2e-tests/src/main/java/io/pockethive/e2e/support/ControlPlaneEventParser.java
@@ -1,6 +1,7 @@
 package io.pockethive.e2e.support;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -22,22 +23,26 @@ public final class ControlPlaneEventParser {
   }
 
   public ControlPlaneEventParser(ObjectMapper objectMapper) {
-    this.objectMapper = objectMapper;
+    this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper");
   }
 
-  public Confirmation parse(String routingKey, byte[] body) throws IOException {
+  public ParsedEvent parse(String routingKey, byte[] body) throws IOException {
     if (routingKey == null || body == null) {
-      return null;
+      return ParsedEvent.ignored();
     }
-    Class<? extends Confirmation> type;
     if (routingKey.startsWith("ev.ready.")) {
-      type = ReadyConfirmation.class;
-    } else if (routingKey.startsWith("ev.error.")) {
-      type = ErrorConfirmation.class;
-    } else {
-      return null;
+      Confirmation confirmation = objectMapper.readValue(body, ReadyConfirmation.class);
+      return ParsedEvent.confirmation(confirmation);
     }
-    return objectMapper.readValue(body, type);
+    if (routingKey.startsWith("ev.error.")) {
+      Confirmation confirmation = objectMapper.readValue(body, ErrorConfirmation.class);
+      return ParsedEvent.confirmation(confirmation);
+    }
+    if (routingKey.startsWith("ev.status-")) {
+      StatusEvent status = objectMapper.readValue(body, StatusEvent.class);
+      return ParsedEvent.status(status);
+    }
+    return ParsedEvent.ignored();
   }
 
   private static ObjectMapper createDefaultMapper() {
@@ -45,5 +50,28 @@ public final class ControlPlaneEventParser {
     mapper.registerModule(new JavaTimeModule());
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     return mapper;
+  }
+
+  public record ParsedEvent(Confirmation confirmation, StatusEvent status) {
+
+    public static ParsedEvent confirmation(Confirmation confirmation) {
+      return new ParsedEvent(confirmation, null);
+    }
+
+    public static ParsedEvent status(StatusEvent status) {
+      return new ParsedEvent(null, status);
+    }
+
+    public static ParsedEvent ignored() {
+      return new ParsedEvent(null, null);
+    }
+
+    public boolean hasConfirmation() {
+      return confirmation != null;
+    }
+
+    public boolean hasStatus() {
+      return status != null;
+    }
   }
 }

--- a/e2e-tests/src/main/java/io/pockethive/e2e/support/StatusEvent.java
+++ b/e2e-tests/src/main/java/io/pockethive/e2e/support/StatusEvent.java
@@ -1,0 +1,74 @@
+package io.pockethive.e2e.support;
+
+import java.time.Instant;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record StatusEvent(
+    String event,
+    String version,
+    String messageId,
+    Instant timestamp,
+    String location,
+    String kind,
+    String role,
+    String instance,
+    String origin,
+    String swarmId,
+    Boolean enabled,
+    String state,
+    Instant watermark,
+    Long maxStalenessSec,
+    Totals totals,
+    Map<String, Object> queueStats,
+    InQueue inQueue,
+    List<String> publishes,
+    Queues queues,
+    Map<String, Object> data,
+    String traffic) {
+
+  public StatusEvent {
+    queueStats = normaliseMap(queueStats);
+    publishes = publishes == null ? List.of() : List.copyOf(publishes);
+    queues = queues == null ? new Queues(null, null) : queues;
+    data = normaliseMap(data);
+  }
+
+  private static Map<String, Object> normaliseMap(Map<String, Object> source) {
+    if (source == null || source.isEmpty()) {
+      return Map.of();
+    }
+    return Collections.unmodifiableMap(new LinkedHashMap<>(source));
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record InQueue(String name, List<String> routingKeys) {
+
+    public InQueue {
+      routingKeys = routingKeys == null ? List.of() : List.copyOf(routingKeys);
+    }
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record Queues(QueueEndpoints work, QueueEndpoints control) {
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record QueueEndpoints(List<String> in, List<String> routes, List<String> out) {
+
+    public QueueEndpoints {
+      in = in == null ? List.of() : List.copyOf(in);
+      routes = routes == null ? List.of() : List.copyOf(routes);
+      out = out == null ? List.of() : List.copyOf(out);
+    }
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record Totals(int desired, int healthy, int running, int enabled) {
+  }
+}

--- a/e2e-tests/src/test/resources/fixtures/status-full.json
+++ b/e2e-tests/src/test/resources/fixtures/status-full.json
@@ -1,0 +1,49 @@
+{
+  "event": "status",
+  "version": "1.0",
+  "messageId": "msg-123",
+  "timestamp": "2024-07-01T12:34:56Z",
+  "location": "local",
+  "kind": "status-full",
+  "role": "processor",
+  "instance": "processor-1",
+  "origin": "worker-control",
+  "swarmId": "swarm-alpha",
+  "enabled": true,
+  "state": "Running",
+  "watermark": "2024-07-01T12:34:50Z",
+  "maxStalenessSec": 45,
+  "traffic": "traffic.exchange",
+  "totals": {
+    "desired": 3,
+    "healthy": 3,
+    "running": 3,
+    "enabled": 3
+  },
+  "queueStats": {
+    "processor.input": {
+      "depth": 0
+    }
+  },
+  "inQueue": {
+    "name": "processor.input",
+    "routingKeys": ["ev.ready.processor", "ev.error.processor"]
+  },
+  "publishes": ["traffic.results"],
+  "queues": {
+    "work": {
+      "in": ["processor.input"],
+      "routes": ["rk.alpha"],
+      "out": ["rk.beta"]
+    },
+    "control": {
+      "in": ["control.input"],
+      "routes": ["ev.status-full.swarm-alpha"],
+      "out": ["ev.status-delta.swarm-alpha"]
+    }
+  },
+  "data": {
+    "tps": 123,
+    "extra": "value"
+  }
+}


### PR DESCRIPTION
## Summary
- parse control-plane status messages into a typed StatusEvent DTO alongside confirmations
- add queue bindings plus lookup and queue assertion helpers on ControlPlaneEvents with documentation
- exercise the parser and helpers with fixture-backed unit tests

## Testing
- ./mvnw -pl e2e-tests test *(fails: Maven wrapper could not download due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68e97b4c3d748328b9c226892a3d12b0