### PR TITLE
Add PocketHive logo to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![PocketHive Logo](ui/assets/logo.svg)
+
 # PocketHive
 
 PocketHive is a RabbitMQ‑centric load & behavior simulator that orchestrates swarms of modular workers (“bees”) to generate traffic, transform data, and emit results and telemetry. It is useful for repeatable performance testing, scenario‑driven demos, and production‑like simulations for APIs and message‑driven systems (ISO‑8583, REST, SOAP, custom protocols).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,3 +1,5 @@
+![PocketHive Logo](../ui/assets/logo.svg)
+
 # PocketHive — ARCHITECTURE
 
 > **Status:** Authoritative architecture specification (reference for agents).  


### PR DESCRIPTION
## Summary
- add the PocketHive logo to the top of the main README
- include the same logo at the beginning of the architecture reference

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e99ace1fb48328a0f7268915e063ba