### PR TITLE
Remove legacy inQueue from control-plane status contract

### DIFF
--- a/docs/sdk/worker-sdk-quickstart.md
+++ b/docs/sdk/worker-sdk-quickstart.md
@@ -52,6 +52,9 @@ class ProcessorWorkerImpl implements MessageWorker {
 
 Generator workers follow the same pattern but implement `GeneratorWorker` and omit `inQueue`.
 
+> **Status topology note**
+> The Worker SDK automatically mirrors the descriptor queues into the control-plane status payload via `statusPublisher().workIn(...)` and `statusPublisher().workOut(...)`. The legacy `inQueue` field in status events has been removed; consumers should rely on the richer `queues.work`/`queues.control` block instead.
+
 ## 3. Implement the worker interfaces
 
 The Stage 1 runtime discovers annotated beans and invokes the corresponding business interface:

--- a/docs/sdk/worker-sdk-stage0-design.md
+++ b/docs/sdk/worker-sdk-stage0-design.md
@@ -52,7 +52,7 @@ Declare worker metadata via annotation or configuration record. Stage 1 will pre
     outQueue = Topology.GEN_QUEUE
 )
 ```
-For message workers, specify `inQueue` and `outQueue`. Descriptor also references the control-plane descriptor by role (no per-service overrides needed).
+For message workers, specify `inQueue` and `outQueue`. The runtime mirrors these bindings into the status payload under `queues.work`, replacing the legacy `inQueue` status field. Descriptor also references the control-plane descriptor by role (no per-service overrides needed).
 
 ## Control-Plane Behaviour
 - Worker runtime owns a `ControlPlaneRuntime` component that:

--- a/docs/spec/asyncapi.yaml
+++ b/docs/spec/asyncapi.yaml
@@ -457,15 +457,6 @@ components:
           type: boolean
         traffic:
           type: string
-        inQueue:
-          type: object
-          properties:
-            name:
-              type: string
-            routingKeys:
-              type: array
-              items:
-                type: string
         publishes:
           type: array
           items:
@@ -490,9 +481,11 @@ components:
                 minimum: 0
         queues:
           type: object
+          description: Topology metadata grouped by work/control exchanges. This supersedes the legacy inQueue field.
           properties:
             work:
               type: object
+              description: Queues and routing keys bound to the worker traffic exchange.
               properties:
                 in:
                   type: array
@@ -508,6 +501,7 @@ components:
                     type: string
             control:
               type: object
+              description: Queues and routing keys bound to the worker control exchange.
               properties:
                 in:
                   type: array

--- a/docs/spec/control-events.schema.json
+++ b/docs/spec/control-events.schema.json
@@ -65,20 +65,6 @@
     "traffic": {
       "type": "string"
     },
-    "inQueue": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string"
-        },
-        "routingKeys": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
     "publishes": {
       "type": "array",
       "items": {
@@ -112,9 +98,11 @@
     },
     "queues": {
       "type": "object",
+      "description": "Topology metadata grouped by work/control exchanges. Producers and consumers must use these sections instead of the legacy inQueue field.",
       "properties": {
         "work": {
           "type": "object",
+          "description": "Queues and routing keys bound to the worker traffic exchange.",
           "properties": {
             "in": {
               "type": "array",
@@ -138,6 +126,7 @@
         },
         "control": {
           "type": "object",
+          "description": "Queues and routing keys bound to the control exchange for this worker.",
           "properties": {
             "in": {
               "type": "array",

--- a/e2e-tests/src/main/java/io/pockethive/e2e/support/StatusEvent.java
+++ b/e2e-tests/src/main/java/io/pockethive/e2e/support/StatusEvent.java
@@ -26,7 +26,6 @@ public record StatusEvent(
     Long maxStalenessSec,
     Totals totals,
     Map<String, Object> queueStats,
-    InQueue inQueue,
     List<String> publishes,
     Queues queues,
     Map<String, Object> data,
@@ -44,14 +43,6 @@ public record StatusEvent(
       return Map.of();
     }
     return Collections.unmodifiableMap(new LinkedHashMap<>(source));
-  }
-
-  @JsonIgnoreProperties(ignoreUnknown = true)
-  public record InQueue(String name, List<String> routingKeys) {
-
-    public InQueue {
-      routingKeys = routingKeys == null ? List.of() : List.copyOf(routingKeys);
-    }
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)

--- a/e2e-tests/src/test/java/io/pockethive/e2e/steps/SwarmLifecycleSteps.java
+++ b/e2e-tests/src/test/java/io/pockethive/e2e/steps/SwarmLifecycleSteps.java
@@ -325,18 +325,6 @@ public class SwarmLifecycleSteps {
     ControlQueueDescriptor controlQueueDescriptor = descriptor.controlQueue(instance)
         .orElseThrow(() -> new AssertionError("No control queue descriptor for role " + role));
 
-    String expectedInQueue = expectedInboundQueue(role);
-    StatusEvent.InQueue inQueue = status.inQueue();
-    if (expectedInQueue == null) {
-      if (inQueue != null && inQueue.name() != null && !inQueue.name().isBlank()) {
-        throw new AssertionError("Expected no inbound queue for role " + role + " but was " + inQueue.name());
-      }
-    } else {
-      assertNotNull(inQueue, () -> "Expected inbound queue for role " + role);
-      assertEquals(expectedInQueue, inQueue.name(),
-          () -> "Unexpected inbound queue for role " + role);
-    }
-
     StatusEvent.QueueEndpoints workQueues = status.queues().work();
     List<String> actualWorkIn = workQueues == null ? List.of() : workQueues.in();
     List<String> actualWorkOut = workQueues == null ? List.of() : workQueues.out();

--- a/e2e-tests/src/test/resources/fixtures/status-full.json
+++ b/e2e-tests/src/test/resources/fixtures/status-full.json
@@ -25,10 +25,6 @@
       "depth": 0
     }
   },
-  "inQueue": {
-    "name": "processor.input",
-    "routingKeys": ["ev.ready.processor", "ev.error.processor"]
-  },
   "publishes": ["traffic.results"],
   "queues": {
     "work": {

--- a/observability/src/main/java/io/pockethive/observability/StatusEnvelopeBuilder.java
+++ b/observability/src/main/java/io/pockethive/observability/StatusEnvelopeBuilder.java
@@ -20,7 +20,6 @@ public class StatusEnvelopeBuilder {
 
     private final Map<String, Object> root = new LinkedHashMap<>();
     private final Map<String, Object> data = new LinkedHashMap<>();
-    private final Map<String, Object> inQueue = new LinkedHashMap<>();
     private final List<String> publishes = new ArrayList<>();
     private final Map<String, Object> queues = new LinkedHashMap<>();
     private final Map<String, Object> work = new LinkedHashMap<>();
@@ -154,20 +153,6 @@ public class StatusEnvelopeBuilder {
     }
 
     /**
-     * Describe the queue this component consumes from and the routing keys
-     * bound to it.
-     */
-    public StatusEnvelopeBuilder inQueue(String name, String... routingKeys) {
-        if (name != null && !name.isBlank()) {
-            inQueue.put("name", name);
-            if (routingKeys != null && routingKeys.length > 0) {
-                inQueue.put("routingKeys", Arrays.asList(routingKeys));
-            }
-        }
-        return this;
-    }
-
-    /**
      * Topics used when publishing results downstream on the traffic
      * exchange.
      */
@@ -197,9 +182,6 @@ public class StatusEnvelopeBuilder {
      * Serialise the collected fields into a JSON document.
      */
     public String toJson() {
-        if (!inQueue.isEmpty()) {
-            root.put("inQueue", inQueue);
-        }
         if (!publishes.isEmpty()) {
             root.put("publishes", publishes);
         }

--- a/ui/src/lib/stompClient.ts
+++ b/ui/src/lib/stompClient.ts
@@ -250,17 +250,12 @@ export function setClient(newClient: Client | null, destination = controlDestina
             : undefined
         if (typeof aggregateEnabled === 'boolean') cfg.enabled = aggregateEnabled
         if (Object.keys(cfg).length > 0) comp.config = cfg
-        if (evt.queues || evt.inQueue) {
+        if (evt.queues) {
           const q: QueueInfo[] = []
-          if (evt.queues) {
-            q.push(...(evt.queues.work?.in?.map((n) => ({ name: n, role: 'consumer' as const })) ?? []))
-            q.push(...(evt.queues.work?.out?.map((n) => ({ name: n, role: 'producer' as const })) ?? []))
-            q.push(...(evt.queues.control?.in?.map((n) => ({ name: n, role: 'consumer' as const })) ?? []))
-            q.push(...(evt.queues.control?.out?.map((n) => ({ name: n, role: 'producer' as const })) ?? []))
-          }
-          if (evt.inQueue?.name) {
-            q.push({ name: evt.inQueue.name, role: 'consumer' })
-          }
+          q.push(...(evt.queues.work?.in?.map((n) => ({ name: n, role: 'consumer' as const })) ?? []))
+          q.push(...(evt.queues.work?.out?.map((n) => ({ name: n, role: 'producer' as const })) ?? []))
+          q.push(...(evt.queues.control?.in?.map((n) => ({ name: n, role: 'consumer' as const })) ?? []))
+          q.push(...(evt.queues.control?.out?.map((n) => ({ name: n, role: 'producer' as const })) ?? []))
           comp.queues = q
         }
         components[id] = comp

--- a/ui/src/pages/hive/TopologyView.test.tsx
+++ b/ui/src/pages/hive/TopologyView.test.tsx
@@ -31,13 +31,23 @@ interface RFEdge {
   style: { stroke: string; strokeWidth: number }
 }
 
+interface NodeComponentProps {
+  id: string
+  data: Record<string, unknown>
+  selected: boolean
+  dragging: boolean
+  isConnectable: boolean
+  xPos: number
+  yPos: number
+}
+
 interface RFProps {
   nodes: RFNode[]
   edges: RFEdge[]
   onNodeDragStop: (e: unknown, node: RFNode) => void
   onNodesChange: (changes: { id: string; position: { x: number; y: number } }[]) => void
   children?: ReactNode
-  nodeTypes?: Record<string, React.ComponentType<any>>
+  nodeTypes?: Record<string, React.ComponentType<NodeComponentProps>>
 }
 
 const data = {
@@ -112,9 +122,7 @@ vi.mock('@xyflow/react', () => {
     return (
       <div data-testid="react-flow">
         {nodes.map((node) => {
-          const NodeComponent = props.nodeTypes?.[node.type ?? ''] as
-            | React.ComponentType<any>
-            | undefined
+          const NodeComponent = props.nodeTypes?.[node.type ?? '']
           if (!NodeComponent) {
             return null
           }

--- a/ui/src/types/control.ts
+++ b/ui/src/types/control.ts
@@ -9,10 +9,6 @@ export interface ControlEvent {
   timestamp: string;
   enabled?: boolean;
   traffic?: string;
-  inQueue?: {
-    name: string;
-    routingKeys?: string[];
-  };
   publishes?: string[];
   queues?: {
     work?: {


### PR DESCRIPTION
## Summary
- drop the deprecated `inQueue` field from the control-plane status schema and async API docs in favour of the unified `queues` block and update related guides
- update fixtures, builders, and e2e assertions to rely solely on the `queues` topology metadata when building/validating status payloads
- simplify the UI control client/types to consume only `queues` data and tighten supporting test typings

## Testing
- mvn -pl observability test -Dtest=StatusEnvelopeBuilderTest
- mvn -pl e2e-tests test -DskipITs
- npm --prefix ui run lint

------
https://chatgpt.com/codex/tasks/task_e_68e9a1d503488328b82c4c86209de177