### PR TITLE
Use signal constant for swarm-wide worker status binding

### DIFF
--- a/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/AbstractWorkerTopologyDescriptor.java
+++ b/common/control-plane-core/src/main/java/io/pockethive/controlplane/topology/AbstractWorkerTopologyDescriptor.java
@@ -41,7 +41,8 @@ abstract class AbstractWorkerTopologyDescriptor implements ControlPlaneTopologyD
         Set<String> statusSignals = Set.of(
             ControlPlaneRouting.signal(ControlPlaneSignals.STATUS_REQUEST, "ALL", role, "ALL"),
             ControlPlaneRouting.signal(ControlPlaneSignals.STATUS_REQUEST, Topology.SWARM_ID, role, "ALL"),
-            ControlPlaneRouting.signal(ControlPlaneSignals.STATUS_REQUEST, Topology.SWARM_ID, role, id)
+            ControlPlaneRouting.signal(ControlPlaneSignals.STATUS_REQUEST, Topology.SWARM_ID, role, id),
+            ControlPlaneRouting.signal(ControlPlaneSignals.STATUS_REQUEST, Topology.SWARM_ID, "ALL", "ALL")
         );
         LinkedHashSet<String> allSignals = new LinkedHashSet<>(configSignals);
         allSignals.addAll(statusSignals);
@@ -65,7 +66,8 @@ abstract class AbstractWorkerTopologyDescriptor implements ControlPlaneTopologyD
         Set<String> statusRoutes = Set.of(
             ControlPlaneRouting.signal(ControlPlaneSignals.STATUS_REQUEST, "ALL", role, "ALL"),
             ControlPlaneRouting.signal(ControlPlaneSignals.STATUS_REQUEST, Topology.SWARM_ID, role, "ALL"),
-            ControlPlaneRouting.signal(ControlPlaneSignals.STATUS_REQUEST, Topology.SWARM_ID, role, ControlPlaneRouteCatalog.INSTANCE_TOKEN)
+            ControlPlaneRouting.signal(ControlPlaneSignals.STATUS_REQUEST, Topology.SWARM_ID, role, ControlPlaneRouteCatalog.INSTANCE_TOKEN),
+            ControlPlaneRouting.signal(ControlPlaneSignals.STATUS_REQUEST, Topology.SWARM_ID, "ALL", "ALL")
         );
         return new ControlPlaneRouteCatalog(configRoutes, statusRoutes, Set.of(), Set.of(), Set.of(), Set.of());
     }

--- a/common/control-plane-core/src/test/java/io/pockethive/controlplane/topology/ControlPlaneTopologyDescriptorsTest.java
+++ b/common/control-plane-core/src/test/java/io/pockethive/controlplane/topology/ControlPlaneTopologyDescriptorsTest.java
@@ -254,7 +254,8 @@ class ControlPlaneTopologyDescriptorsTest {
         return Set.of(
             ControlPlaneRouting.signal(ControlPlaneSignals.STATUS_REQUEST, "ALL", role, "ALL"),
             ControlPlaneRouting.signal(ControlPlaneSignals.STATUS_REQUEST, Topology.SWARM_ID, role, "ALL"),
-            ControlPlaneRouting.signal(ControlPlaneSignals.STATUS_REQUEST, Topology.SWARM_ID, role, instanceSegment)
+            ControlPlaneRouting.signal(ControlPlaneSignals.STATUS_REQUEST, Topology.SWARM_ID, role, instanceSegment),
+            ControlPlaneRouting.signal(ControlPlaneSignals.STATUS_REQUEST, Topology.SWARM_ID, "ALL", "ALL")
         );
     }
 

--- a/common/control-plane-core/src/test/resources/io/pockethive/controlplane/topology/topology-descriptors.json
+++ b/common/control-plane-core/src/test/resources/io/pockethive/controlplane/topology/topology-descriptors.json
@@ -9,6 +9,7 @@
         "sig.config-update.default.processor.ALL",
         "sig.config-update.default.processor.inst",
         "sig.status-request.ALL.processor.ALL",
+        "sig.status-request.default.ALL.ALL",
         "sig.status-request.default.processor.ALL",
         "sig.status-request.default.processor.inst"
       ],
@@ -19,6 +20,7 @@
         "sig.config-update.default.processor.ALL",
         "sig.config-update.default.processor.inst",
         "sig.status-request.ALL.processor.ALL",
+        "sig.status-request.default.ALL.ALL",
         "sig.status-request.default.processor.ALL",
         "sig.status-request.default.processor.inst"
       ]
@@ -42,6 +44,7 @@
       "statusEvents": [],
       "statusSignals": [
         "sig.status-request.ALL.processor.ALL",
+        "sig.status-request.default.ALL.ALL",
         "sig.status-request.default.processor.ALL",
         "sig.status-request.default.processor.{instance}"
       ],
@@ -59,6 +62,7 @@
         "sig.config-update.default.generator.ALL",
         "sig.config-update.default.generator.inst",
         "sig.status-request.ALL.generator.ALL",
+        "sig.status-request.default.ALL.ALL",
         "sig.status-request.default.generator.ALL",
         "sig.status-request.default.generator.inst"
       ],
@@ -69,6 +73,7 @@
         "sig.config-update.default.generator.ALL",
         "sig.config-update.default.generator.inst",
         "sig.status-request.ALL.generator.ALL",
+        "sig.status-request.default.ALL.ALL",
         "sig.status-request.default.generator.ALL",
         "sig.status-request.default.generator.inst"
       ]
@@ -85,6 +90,7 @@
       "statusEvents": [],
       "statusSignals": [
         "sig.status-request.ALL.generator.ALL",
+        "sig.status-request.default.ALL.ALL",
         "sig.status-request.default.generator.ALL",
         "sig.status-request.default.generator.{instance}"
       ],
@@ -102,6 +108,7 @@
         "sig.config-update.default.trigger.ALL",
         "sig.config-update.default.trigger.inst",
         "sig.status-request.ALL.trigger.ALL",
+        "sig.status-request.default.ALL.ALL",
         "sig.status-request.default.trigger.ALL",
         "sig.status-request.default.trigger.inst"
       ],
@@ -112,6 +119,7 @@
         "sig.config-update.default.trigger.ALL",
         "sig.config-update.default.trigger.inst",
         "sig.status-request.ALL.trigger.ALL",
+        "sig.status-request.default.ALL.ALL",
         "sig.status-request.default.trigger.ALL",
         "sig.status-request.default.trigger.inst"
       ]
@@ -128,6 +136,7 @@
       "statusEvents": [],
       "statusSignals": [
         "sig.status-request.ALL.trigger.ALL",
+        "sig.status-request.default.ALL.ALL",
         "sig.status-request.default.trigger.ALL",
         "sig.status-request.default.trigger.{instance}"
       ],
@@ -145,6 +154,7 @@
         "sig.config-update.default.moderator.ALL",
         "sig.config-update.default.moderator.inst",
         "sig.status-request.ALL.moderator.ALL",
+        "sig.status-request.default.ALL.ALL",
         "sig.status-request.default.moderator.ALL",
         "sig.status-request.default.moderator.inst"
       ],
@@ -155,6 +165,7 @@
         "sig.config-update.default.moderator.ALL",
         "sig.config-update.default.moderator.inst",
         "sig.status-request.ALL.moderator.ALL",
+        "sig.status-request.default.ALL.ALL",
         "sig.status-request.default.moderator.ALL",
         "sig.status-request.default.moderator.inst"
       ]
@@ -178,6 +189,7 @@
       "statusEvents": [],
       "statusSignals": [
         "sig.status-request.ALL.moderator.ALL",
+        "sig.status-request.default.ALL.ALL",
         "sig.status-request.default.moderator.ALL",
         "sig.status-request.default.moderator.{instance}"
       ],
@@ -195,6 +207,7 @@
         "sig.config-update.default.postprocessor.ALL",
         "sig.config-update.default.postprocessor.inst",
         "sig.status-request.ALL.postprocessor.ALL",
+        "sig.status-request.default.ALL.ALL",
         "sig.status-request.default.postprocessor.ALL",
         "sig.status-request.default.postprocessor.inst"
       ],
@@ -205,6 +218,7 @@
         "sig.config-update.default.postprocessor.ALL",
         "sig.config-update.default.postprocessor.inst",
         "sig.status-request.ALL.postprocessor.ALL",
+        "sig.status-request.default.ALL.ALL",
         "sig.status-request.default.postprocessor.ALL",
         "sig.status-request.default.postprocessor.inst"
       ]
@@ -228,6 +242,7 @@
       "statusEvents": [],
       "statusSignals": [
         "sig.status-request.ALL.postprocessor.ALL",
+        "sig.status-request.default.ALL.ALL",
         "sig.status-request.default.postprocessor.ALL",
         "sig.status-request.default.postprocessor.{instance}"
       ],


### PR DESCRIPTION
## Summary
- use the ControlPlaneSignals.STATUS_REQUEST constant for the swarm-wide worker binding
- align worker descriptor expectations with the constant-based route declaration

## Testing
- ./mvnw -pl common/control-plane-core -Dtest=ControlPlaneTopologyDescriptorsTest test *(fails: Maven wrapper cannot download the distribution in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eed8c87b208328bbdbc457bbacaf5d