### PR TITLE
refactor: centralize worker control queue listener

### DIFF
--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/autoconfigure/PocketHiveWorkerSdkAutoConfiguration.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/autoconfigure/PocketHiveWorkerSdkAutoConfiguration.java
@@ -124,6 +124,13 @@ public class PocketHiveWorkerSdkAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnBean(WorkerControlPlaneRuntime.class)
+    @ConditionalOnMissingBean(WorkerControlQueueListener.class)
+    WorkerControlQueueListener workerControlQueueListener(WorkerControlPlaneRuntime controlPlaneRuntime) {
+        return new WorkerControlQueueListener(controlPlaneRuntime);
+    }
+
+    @Bean
     @ConditionalOnMissingBean
     WorkerInvocationInterceptor workerObservabilityInterceptor() {
         return new WorkerObservabilityInterceptor();

--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/autoconfigure/WorkerControlQueueListener.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/autoconfigure/WorkerControlQueueListener.java
@@ -1,0 +1,50 @@
+package io.pockethive.worker.sdk.autoconfigure;
+
+import io.pockethive.observability.ObservabilityContext;
+import io.pockethive.observability.ObservabilityContextUtil;
+import io.pockethive.worker.sdk.runtime.WorkerControlPlaneRuntime;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.support.AmqpHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+
+/**
+ * Centralises consumption of the worker control-plane queue so individual services no longer need
+ * to duplicate the listener wiring. The component is only created when the worker control-plane
+ * runtime is available in the application context.
+ */
+public class WorkerControlQueueListener {
+
+    private static final Logger log = LoggerFactory.getLogger(WorkerControlQueueListener.class);
+
+    private final WorkerControlPlaneRuntime controlPlaneRuntime;
+
+    public WorkerControlQueueListener(WorkerControlPlaneRuntime controlPlaneRuntime) {
+        this.controlPlaneRuntime = Objects.requireNonNull(controlPlaneRuntime, "controlPlaneRuntime");
+    }
+
+    @RabbitListener(queues = "#{@workerControlQueueName}")
+    public void onControl(String payload,
+                          @Header(AmqpHeaders.RECEIVED_ROUTING_KEY) String routingKey,
+                          @Header(value = ObservabilityContextUtil.HEADER, required = false) String traceHeader) {
+        ObservabilityContext context = ObservabilityContextUtil.fromHeader(traceHeader);
+        ObservabilityContextUtil.populateMdc(context);
+        try {
+            if (routingKey == null || routingKey.isBlank()) {
+                throw new IllegalArgumentException("Control routing key must not be null or blank");
+            }
+            if (payload == null || payload.isBlank()) {
+                throw new IllegalArgumentException("Control payload must not be null or blank");
+            }
+            boolean handled = controlPlaneRuntime.handle(payload, routingKey);
+            if (!handled) {
+                log.debug("Ignoring control-plane payload on routing key {}", routingKey);
+            }
+        } finally {
+            MDC.clear();
+        }
+    }
+}

--- a/examples/worker-starter/processor-worker/src/main/java/io/pockethive/examples/starter/processor/ProcessorWorkerRuntimeAdapter.java
+++ b/examples/worker-starter/processor-worker/src/main/java/io/pockethive/examples/starter/processor/ProcessorWorkerRuntimeAdapter.java
@@ -2,7 +2,6 @@ package io.pockethive.examples.starter.processor;
 
 import io.pockethive.TopologyDefaults;
 import io.pockethive.controlplane.ControlPlaneIdentity;
-import io.pockethive.observability.ObservabilityContextUtil;
 import io.pockethive.worker.sdk.config.WorkerType;
 import io.pockethive.worker.sdk.runtime.WorkerControlPlaneRuntime;
 import io.pockethive.worker.sdk.runtime.WorkerDefinition;
@@ -16,10 +15,8 @@ import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistry;
-import org.springframework.amqp.support.AmqpHeaders;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
-import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -74,13 +71,6 @@ class ProcessorWorkerRuntimeAdapter implements ApplicationListener<ContextRefres
   @Scheduled(fixedRate = 5000)
   public void emitStatusDelta() {
     delegate.emitStatusDelta();
-  }
-
-  @RabbitListener(queues = "#{@workerControlQueueName}")
-  public void onControl(String payload,
-                        @Header(AmqpHeaders.RECEIVED_ROUTING_KEY) String routingKey,
-                        @Header(value = ObservabilityContextUtil.HEADER, required = false) String traceHeader) {
-    delegate.onControl(payload, routingKey, traceHeader);
   }
 
   @Override

--- a/generator-service/src/main/java/io/pockethive/generator/GeneratorRuntimeAdapter.java
+++ b/generator-service/src/main/java/io/pockethive/generator/GeneratorRuntimeAdapter.java
@@ -2,8 +2,6 @@ package io.pockethive.generator;
 
 import io.pockethive.Topology;
 import io.pockethive.controlplane.ControlPlaneIdentity;
-import io.pockethive.observability.ObservabilityContext;
-import io.pockethive.observability.ObservabilityContextUtil;
 import io.pockethive.worker.sdk.api.WorkMessage;
 import io.pockethive.worker.sdk.api.WorkResult;
 import io.pockethive.worker.sdk.config.WorkerType;
@@ -20,12 +18,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
 import org.springframework.amqp.core.Message;
-import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.amqp.support.AmqpHeaders;
-import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -90,28 +84,6 @@ class GeneratorRuntimeAdapter {
   @Scheduled(fixedRate = 5000)
   public void emitStatusDelta() {
     controlPlaneRuntime.emitStatusDelta();
-  }
-
-  @RabbitListener(queues = "#{@workerControlQueueName}")
-  public void onControl(String payload,
-                        @Header(AmqpHeaders.RECEIVED_ROUTING_KEY) String routingKey,
-                        @Header(value = ObservabilityContextUtil.HEADER, required = false) String traceHeader) {
-    ObservabilityContext context = ObservabilityContextUtil.fromHeader(traceHeader);
-    ObservabilityContextUtil.populateMdc(context);
-    try {
-      if (routingKey == null || routingKey.isBlank()) {
-        throw new IllegalArgumentException("Control routing key must not be null or blank");
-      }
-      if (payload == null || payload.isBlank()) {
-        throw new IllegalArgumentException("Control payload must not be null or blank");
-      }
-      boolean handled = controlPlaneRuntime.handle(payload, routingKey);
-      if (!handled) {
-        log.debug("Ignoring control-plane payload on routing key {}", routingKey);
-      }
-    } finally {
-      MDC.clear();
-    }
   }
 
   private void initialiseStateListeners() {

--- a/moderator-service/src/main/java/io/pockethive/moderator/ModeratorRuntimeAdapter.java
+++ b/moderator-service/src/main/java/io/pockethive/moderator/ModeratorRuntimeAdapter.java
@@ -2,7 +2,6 @@ package io.pockethive.moderator;
 
 import io.pockethive.TopologyDefaults;
 import io.pockethive.controlplane.ControlPlaneIdentity;
-import io.pockethive.observability.ObservabilityContextUtil;
 import io.pockethive.worker.sdk.config.WorkerType;
 import io.pockethive.worker.sdk.runtime.WorkerControlPlaneRuntime;
 import io.pockethive.worker.sdk.runtime.WorkerDefinition;
@@ -17,10 +16,8 @@ import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistry;
-import org.springframework.amqp.support.AmqpHeaders;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
-import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -84,13 +81,6 @@ class ModeratorRuntimeAdapter implements ApplicationListener<ContextRefreshedEve
   @Scheduled(fixedRate = 5000)
   public void emitStatusDelta() {
     delegate.emitStatusDelta();
-  }
-
-  @RabbitListener(queues = "#{@workerControlQueueName}")
-  public void onControl(String payload,
-                        @Header(AmqpHeaders.RECEIVED_ROUTING_KEY) String routingKey,
-                        @Header(value = ObservabilityContextUtil.HEADER, required = false) String traceHeader) {
-    delegate.onControl(payload, routingKey, traceHeader);
   }
 
   @Override

--- a/postprocessor-service/src/main/java/io/pockethive/postprocessor/PostProcessorRuntimeAdapter.java
+++ b/postprocessor-service/src/main/java/io/pockethive/postprocessor/PostProcessorRuntimeAdapter.java
@@ -2,7 +2,6 @@ package io.pockethive.postprocessor;
 
 import io.pockethive.TopologyDefaults;
 import io.pockethive.controlplane.ControlPlaneIdentity;
-import io.pockethive.observability.ObservabilityContextUtil;
 import io.pockethive.worker.sdk.config.WorkerType;
 import io.pockethive.worker.sdk.runtime.WorkerControlPlaneRuntime;
 import io.pockethive.worker.sdk.runtime.WorkerDefinition;
@@ -16,10 +15,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistry;
-import org.springframework.amqp.support.AmqpHeaders;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
-import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -80,13 +77,6 @@ class PostProcessorRuntimeAdapter implements ApplicationListener<ContextRefreshe
   @Scheduled(fixedRate = 5000)
   public void emitStatusDelta() {
     delegate.emitStatusDelta();
-  }
-
-  @RabbitListener(queues = "#{@workerControlQueueName}")
-  public void onControl(String payload,
-                        @Header(AmqpHeaders.RECEIVED_ROUTING_KEY) String routingKey,
-                        @Header(value = ObservabilityContextUtil.HEADER, required = false) String traceHeader) {
-    delegate.onControl(payload, routingKey, traceHeader);
   }
 
   @Override

--- a/processor-service/src/main/java/io/pockethive/processor/ProcessorRuntimeAdapter.java
+++ b/processor-service/src/main/java/io/pockethive/processor/ProcessorRuntimeAdapter.java
@@ -2,7 +2,6 @@ package io.pockethive.processor;
 
 import io.pockethive.TopologyDefaults;
 import io.pockethive.controlplane.ControlPlaneIdentity;
-import io.pockethive.observability.ObservabilityContextUtil;
 import io.pockethive.worker.sdk.config.WorkerType;
 import io.pockethive.worker.sdk.runtime.WorkerControlPlaneRuntime;
 import io.pockethive.worker.sdk.runtime.WorkerDefinition;
@@ -17,10 +16,8 @@ import org.springframework.amqp.core.Message;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistry;
-import org.springframework.amqp.support.AmqpHeaders;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
-import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -87,13 +84,6 @@ class ProcessorRuntimeAdapter implements ApplicationListener<ContextRefreshedEve
   @Scheduled(fixedRate = 5000)
   public void emitStatusDelta() {
     delegate.emitStatusDelta();
-  }
-
-  @RabbitListener(queues = "#{@workerControlQueueName}")
-  public void onControl(String payload,
-                        @Header(AmqpHeaders.RECEIVED_ROUTING_KEY) String routingKey,
-                        @Header(value = ObservabilityContextUtil.HEADER, required = false) String traceHeader) {
-    delegate.onControl(payload, routingKey, traceHeader);
   }
 
   @Override

--- a/processor-service/src/test/java/io/pockethive/processor/ProcessorTest.java
+++ b/processor-service/src/test/java/io/pockethive/processor/ProcessorTest.java
@@ -14,6 +14,7 @@ import io.pockethive.worker.sdk.api.WorkMessage;
 import io.pockethive.worker.sdk.api.WorkResult;
 import io.pockethive.worker.sdk.api.WorkerContext;
 import io.pockethive.worker.sdk.api.WorkerInfo;
+import io.pockethive.worker.sdk.autoconfigure.WorkerControlQueueListener;
 import io.pockethive.worker.sdk.config.WorkerType;
 import io.pockethive.worker.sdk.runtime.WorkerControlPlaneRuntime;
 import io.pockethive.worker.sdk.runtime.WorkerDefinition;
@@ -251,14 +252,16 @@ class ProcessorTest {
 
         adapter.initialiseStateListener();
 
-        adapter.onControl("{}", "processor.control", null);
+        WorkerControlQueueListener listener = new WorkerControlQueueListener(controlPlaneRuntime);
+
+        listener.onControl("{}", "processor.control", null);
         verify(controlPlaneRuntime).handle("{}", "processor.control");
 
-        assertThatThrownBy(() -> adapter.onControl(" ", "processor.control", null))
+        assertThatThrownBy(() -> listener.onControl(" ", "processor.control", null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("payload");
 
-        assertThatThrownBy(() -> adapter.onControl("{}", " ", null))
+        assertThatThrownBy(() -> listener.onControl("{}", " ", null))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("routing key");
 

--- a/trigger-service/src/main/java/io/pockethive/trigger/TriggerRuntimeAdapter.java
+++ b/trigger-service/src/main/java/io/pockethive/trigger/TriggerRuntimeAdapter.java
@@ -1,8 +1,6 @@
 package io.pockethive.trigger;
 
 import io.pockethive.controlplane.ControlPlaneIdentity;
-import io.pockethive.observability.ObservabilityContext;
-import io.pockethive.observability.ObservabilityContextUtil;
 import io.pockethive.worker.sdk.api.WorkMessage;
 import io.pockethive.worker.sdk.api.WorkResult;
 import io.pockethive.worker.sdk.config.WorkerType;
@@ -19,10 +17,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.slf4j.MDC;
-import org.springframework.amqp.rabbit.annotation.RabbitListener;
-import org.springframework.amqp.support.AmqpHeaders;
-import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -94,28 +88,6 @@ class TriggerRuntimeAdapter {
   @Scheduled(fixedRate = 5000)
   public void emitStatusDelta() {
     controlPlaneRuntime.emitStatusDelta();
-  }
-
-  @RabbitListener(queues = "#{@workerControlQueueName}")
-  public void onControl(String payload,
-                        @Header(AmqpHeaders.RECEIVED_ROUTING_KEY) String routingKey,
-                        @Header(value = ObservabilityContextUtil.HEADER, required = false) String traceHeader) {
-    ObservabilityContext context = ObservabilityContextUtil.fromHeader(traceHeader);
-    ObservabilityContextUtil.populateMdc(context);
-    try {
-      if (routingKey == null || routingKey.isBlank()) {
-        throw new IllegalArgumentException("Control routing key must not be null or blank");
-      }
-      if (payload == null || payload.isBlank()) {
-        throw new IllegalArgumentException("Control payload must not be null or blank");
-      }
-      boolean handled = controlPlaneRuntime.handle(payload, routingKey);
-      if (!handled) {
-        log.debug("Ignoring control-plane payload on routing key {}", routingKey);
-      }
-    } finally {
-      MDC.clear();
-    }
   }
 
   private void initialiseStateListeners() {


### PR DESCRIPTION
## Summary
- add a WorkerControlQueueListener bean to the worker SDK auto-configuration so applications share a single control-plane queue listener
- remove the duplicated @RabbitListener onControl methods from generator, trigger, moderator, post-processor, and processor runtime adapters (including the example starter) and update the related tests to exercise the shared listener component

## Testing
- `mvn -pl common/worker-sdk test -DskipITs`
- `mvn -pl generator-service test -DskipITs`
- `mvn -pl trigger-service test -DskipITs`
- `mvn -pl processor-service test -DskipITs`
- `mvn -pl moderator-service test -DskipITs`
- `mvn -pl postprocessor-service test -DskipITs`


------
https://chatgpt.com/codex/tasks/task_e_68f13a56d5e48328b84cb58ed9beffe0