### PR TITLE
Fix worker status scheduler properties bean registration

### DIFF
--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/autoconfigure/PocketHiveWorkerSdkAutoConfiguration.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/autoconfigure/PocketHiveWorkerSdkAutoConfiguration.java
@@ -35,7 +35,7 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -45,13 +45,19 @@ import org.springframework.context.annotation.Import;
  * opt-in by depending on the Worker SDK starter.
  */
 @Configuration(proxyBeanMethods = false)
-@EnableConfigurationProperties(WorkerStatusSchedulerProperties.class)
 @Import({
     ControlPlaneCommonAutoConfiguration.class,
     WorkerControlPlaneAutoConfiguration.class,
     ManagerControlPlaneAutoConfiguration.class
 })
 public class PocketHiveWorkerSdkAutoConfiguration {
+
+    @Bean
+    @ConfigurationProperties(prefix = "pockethive.worker.status")
+    @ConditionalOnMissingBean
+    WorkerStatusSchedulerProperties workerStatusSchedulerProperties() {
+        return new WorkerStatusSchedulerProperties();
+    }
 
     @Bean
     @ConditionalOnMissingBean

--- a/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerStatusSchedulerProperties.java
+++ b/common/worker-sdk/src/main/java/io/pockethive/worker/sdk/runtime/WorkerStatusSchedulerProperties.java
@@ -2,12 +2,10 @@ package io.pockethive.worker.sdk.runtime;
 
 import java.time.Duration;
 import java.util.Objects;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
  * Configuration properties controlling the cadence of status delta emissions for worker runtimes.
  */
-@ConfigurationProperties(prefix = "pockethive.worker.status")
 public class WorkerStatusSchedulerProperties {
 
     private Duration deltaInterval = Duration.ofSeconds(5);


### PR DESCRIPTION
## Summary
- expose WorkerStatusSchedulerProperties as a named bean so SpEL lookups succeed
- simplify the properties holder to rely on the new @Bean registration

## Testing
- ./mvnw -pl common/worker-sdk test *(fails: network unreachable while downloading Maven wrapper distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68f16deecad88328a2e9caab26bb88b0