### PR TITLE
Enforce explicit control plane identity configuration

### DIFF
--- a/orchestrator-service/src/main/java/io/pockethive/orchestrator/OrchestratorControlPlaneConfig.java
+++ b/orchestrator-service/src/main/java/io/pockethive/orchestrator/OrchestratorControlPlaneConfig.java
@@ -9,7 +9,6 @@ import io.pockethive.controlplane.spring.ControlPlaneTopologyDescriptorFactory;
 import io.pockethive.controlplane.topology.ControlPlaneTopologyDescriptor;
 import io.pockethive.controlplane.topology.ControlQueueDescriptor;
 import io.pockethive.controlplane.topology.QueueDescriptor;
-import io.pockethive.util.BeeNameGenerator;
 import java.util.Objects;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -20,29 +19,14 @@ import org.springframework.context.annotation.Configuration;
 class OrchestratorControlPlaneConfig {
 
     private static final String ROLE = "orchestrator";
-    private static final String BEE_NAME_PROPERTY = "bee.name";
     private static final String INSTANCE_ID_PROPERTY = "pockethive.control-plane.instance-id";
     private static final String SWARM_ID_PROPERTY = "pockethive.control-plane.swarm-id";
 
     @Bean
     String instanceId(ControlPlaneProperties properties) {
         Objects.requireNonNull(properties, "properties");
-        String resolved = normalise(properties.getInstanceId());
-        if (resolved == null) {
-            resolved = normalise(System.getProperty(INSTANCE_ID_PROPERTY));
-        }
-        if (resolved == null) {
-            resolved = normalise(System.getProperty(BEE_NAME_PROPERTY));
-        }
-        if (resolved == null) {
-            resolved = BeeNameGenerator.generate(ROLE, resolveSwarmId(properties));
-        }
-        if (resolved == null) {
-            throw new IllegalStateException("Manager instance id could not be resolved");
-        }
+        String resolved = requireText(properties.getInstanceId(), INSTANCE_ID_PROPERTY);
         properties.setInstanceId(resolved);
-        System.setProperty(BEE_NAME_PROPERTY, resolved);
-        System.setProperty(INSTANCE_ID_PROPERTY, resolved);
         return resolved;
     }
 
@@ -100,28 +84,10 @@ class OrchestratorControlPlaneConfig {
             .orElseThrow(() -> new IllegalStateException("Orchestrator status queue descriptor is missing"));
     }
 
-    private static String normalise(String value) {
-        if (value == null || value.isBlank()) {
-            return null;
-        }
-        return value;
-    }
-
     private static String requireText(String value, String property) {
         if (value == null || value.isBlank()) {
             throw new IllegalStateException(property + " must not be null or blank");
         }
         return value;
-    }
-
-    private static String resolveSwarmId(ControlPlaneProperties properties) {
-        String resolved = normalise(properties.getSwarmId());
-        if (resolved == null) {
-            resolved = normalise(System.getProperty(SWARM_ID_PROPERTY));
-        }
-        if (resolved == null) {
-            throw new IllegalStateException("Manager swarm id could not be resolved");
-        }
-        return resolved;
     }
 }

--- a/orchestrator-service/src/test/java/io/pockethive/orchestrator/OrchestratorControlPlaneConfigTest.java
+++ b/orchestrator-service/src/test/java/io/pockethive/orchestrator/OrchestratorControlPlaneConfigTest.java
@@ -1,0 +1,67 @@
+package io.pockethive.orchestrator;
+
+import io.pockethive.controlplane.ControlPlaneIdentity;
+import io.pockethive.controlplane.spring.ControlPlaneProperties;
+import io.pockethive.controlplane.spring.ControlPlaneTopologyDescriptorFactory;
+import io.pockethive.controlplane.topology.ControlPlaneTopologyDescriptor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OrchestratorControlPlaneConfigTest {
+
+    private OrchestratorControlPlaneConfig config;
+    private ControlPlaneProperties properties;
+    private ControlPlaneTopologyDescriptor descriptor;
+
+    @BeforeEach
+    void setUp() {
+        config = new OrchestratorControlPlaneConfig();
+        properties = new ControlPlaneProperties();
+        descriptor = ControlPlaneTopologyDescriptorFactory.forManagerRole("orchestrator");
+    }
+
+    @Test
+    void instanceIdReturnsConfiguredValue() {
+        properties.setInstanceId("orch-123");
+
+        String resolved = config.instanceId(properties);
+
+        assertThat(resolved).isEqualTo("orch-123");
+    }
+
+    @Test
+    void instanceIdFailsWhenConfigurationIsMissing() {
+        assertThatThrownBy(() -> config.instanceId(properties))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("pockethive.control-plane.instance-id");
+    }
+
+    @Test
+    void managerIdentityFailsWhenSwarmIdIsMissing() {
+        properties.setInstanceId("orch-123");
+
+        assertThatThrownBy(
+                () ->
+                    config.managerControlPlaneIdentity(
+                        properties, descriptor, config.instanceId(properties)))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("pockethive.control-plane.swarm-id");
+    }
+
+    @Test
+    void managerIdentityUsesConfiguredValues() {
+        properties.setInstanceId("orch-123");
+        properties.setSwarmId("swarm-7");
+
+        ControlPlaneIdentity identity =
+            config.managerControlPlaneIdentity(
+                properties, descriptor, config.instanceId(properties));
+
+        assertThat(identity.swarmId()).isEqualTo("swarm-7");
+        assertThat(identity.instanceId()).isEqualTo("orch-123");
+        assertThat(identity.role()).isEqualTo(descriptor.role());
+    }
+}


### PR DESCRIPTION
## Summary
- require the orchestrator instance and swarm identifiers to be provided via `ControlPlaneProperties`
- drop legacy fallbacks that read from system properties or generate bee names
- cover the new single-source requirement with unit tests for the orchestrator control plane config

## Testing
- `./mvnw -pl orchestrator-service test` *(fails: Maven wrapper cannot download dependencies in the offline sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68f22ad34d508328afccbbdc5c571554