### PR TITLE
Clarify env expectations in config migration plan

### DIFF
--- a/docs/ai/explicit-config-migration-plan.md
+++ b/docs/ai/explicit-config-migration-plan.md
@@ -32,7 +32,7 @@ Eliminate all implicit configuration fallbacks across PocketHive by moving orche
 2. **Enforce explicit identifiers**
    - Require container instance IDs and swarm identifiers to be provided via configuration (i.e. from Swarm-manager via env variables matching Spring properties from application.yml) or orchestrator/swarm-manager payloads. Only Orchestrator and SwarmManager might generate configration and pass them over, workers use values found via application.yml/spring.
 3. **Rework metrics/logging configuration**
-   - Drive Pushgateway and logging configuration through the new properties and purge `${ENV:...}` defaults from YAML/logback configs.
+   - Drive Pushgateway and logging configuration through the new properties while keeping `application.yml` entries as explicit `${ENV}` bindings with no fallbacks; Orchestrator supplies these values via container environment variables when it launches the controller, so do not introduce literal defaults in YAML/logback configs.
 4. **Adjust Docker integration**
    - Replace `resolveDockerHostOverride()` and similar helpers with property-based configuration that fails on missing values.
 5. **Refresh tests/docs**
@@ -46,7 +46,7 @@ Eliminate all implicit configuration fallbacks across PocketHive by moving orche
 2. **Tighten runtime context**
    - Modify `DefaultWorkerContextFactory` and related components to require configured identifiers or explicit message headers; remove any default value substitutions.
 3. **Update worker services**
-   - For each bee (`generator`, `moderator`, `processor`, `postprocessor`, `trigger`), replace `${ENV:...}` placeholders in `application.yml` and logging configs with literal defaults pointing to the new properties.
+   - For each bee (`generator`, `moderator`, `processor`, `postprocessor`, `trigger`), ensure `application.yml` and logging configs continue to read the required values from `${ENV}` placeholders (with no literal defaults), because SwarmController injects these environment variables when spawning worker containers.
    - Ensure `@RabbitListener` and outbound publisher configuration uses the bound properties only.
 4. **Revise tests/examples**
    - Adjust SDK tests, worker service tests, and documentation/examples to provide the necessary properties explicitly.


### PR DESCRIPTION
## Summary
- clarify that swarm-controller `application.yml` entries must remain explicit environment-backed properties because orchestrator injects the values at launch
- note that worker services should continue reading env-provided values passed from SwarmController when it spawns worker containers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f4cb445268832897afd2088ed6ad2e