### PR TITLE
Enforce explicit worker traffic exchange configuration

### DIFF
--- a/common/control-plane-spring/src/main/java/io/pockethive/controlplane/spring/WorkerControlPlaneProperties.java
+++ b/common/control-plane-spring/src/main/java/io/pockethive/controlplane/spring/WorkerControlPlaneProperties.java
@@ -19,7 +19,6 @@ public final class WorkerControlPlaneProperties {
 
     private final boolean enabled;
     private final boolean declareTopology;
-    private static final String TRAFFIC_EXCHANGE_ENV = "POCKETHIVE_CONTROL_PLANE_TRAFFIC_EXCHANGE";
 
     private final String exchange;
     private final String trafficExchange;
@@ -317,27 +316,19 @@ public final class WorkerControlPlaneProperties {
     }
 
     private static String resolveTrafficExchange(String value) {
-        String candidate = normalizeTrafficExchange(value);
-        if (candidate == null) {
-            candidate = normalizeTrafficExchange(System.getenv(TRAFFIC_EXCHANGE_ENV));
-        }
-        if (candidate == null) {
+        if (value == null) {
             throw new IllegalArgumentException(
                 "pockethive.control-plane.traffic-exchange must not be null or blank");
         }
-        return candidate;
-    }
-
-    private static String normalizeTrafficExchange(String value) {
-        if (value == null) {
-            return null;
-        }
         String trimmed = value.trim();
         if (trimmed.isEmpty()) {
-            return null;
+            throw new IllegalArgumentException(
+                "pockethive.control-plane.traffic-exchange must not be null or blank");
         }
-        if (trimmed.contains("${") || trimmed.contains("}")) {
-            return null;
+        if (trimmed.startsWith("${") && trimmed.endsWith("}")) {
+            throw new IllegalArgumentException(
+                "pockethive.control-plane.traffic-exchange must resolve to a concrete value, but was "
+                    + trimmed);
         }
         return trimmed;
     }

--- a/common/control-plane-spring/src/test/java/io/pockethive/controlplane/spring/WorkerControlPlaneAutoConfigurationTest.java
+++ b/common/control-plane-spring/src/test/java/io/pockethive/controlplane/spring/WorkerControlPlaneAutoConfigurationTest.java
@@ -119,7 +119,7 @@ class WorkerControlPlaneAutoConfigurationTest {
                 assertThat(failure).isInstanceOf(BeanCreationException.class);
                 assertThat(failure).hasRootCauseInstanceOf(IllegalArgumentException.class);
                 assertThat(failure).hasRootCauseMessage(
-                    "pockethive.control-plane.traffic-exchange must not be null or blank");
+                    "pockethive.control-plane.traffic-exchange must resolve to a concrete value, but was ${POCKETHIVE_CONTROL_PLANE_TRAFFIC_EXCHANGE}");
             });
     }
 

--- a/common/control-plane-spring/src/test/java/io/pockethive/controlplane/spring/WorkerControlPlanePropertiesTest.java
+++ b/common/control-plane-spring/src/test/java/io/pockethive/controlplane/spring/WorkerControlPlanePropertiesTest.java
@@ -1,0 +1,62 @@
+package io.pockethive.controlplane.spring;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class WorkerControlPlanePropertiesTest {
+
+    @Test
+    void rejectsNullTrafficExchange() {
+        assertThatThrownBy(() -> buildProperties(null))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("pockethive.control-plane.traffic-exchange must not be null or blank");
+    }
+
+    @Test
+    void rejectsPlaceholderTrafficExchange() {
+        String placeholder = "${POCKETHIVE_CONTROL_PLANE_TRAFFIC_EXCHANGE}";
+        assertThatThrownBy(() -> buildProperties(placeholder))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage(
+                "pockethive.control-plane.traffic-exchange must resolve to a concrete value, but was "
+                    + placeholder);
+    }
+
+    private static WorkerControlPlaneProperties buildProperties(String trafficExchange) {
+        Map<String, String> queues = Map.of("generator", "ph.swarm-alpha.generator");
+        WorkerControlPlaneProperties.Worker worker = new WorkerControlPlaneProperties.Worker(
+            true,
+            true,
+            "generator",
+            null,
+            true,
+            null);
+        WorkerControlPlaneProperties.SwarmController.Rabbit.Logging logging =
+            new WorkerControlPlaneProperties.SwarmController.Rabbit.Logging(false);
+        WorkerControlPlaneProperties.SwarmController.Rabbit rabbit =
+            new WorkerControlPlaneProperties.SwarmController.Rabbit("ph.logs", logging);
+        WorkerControlPlaneProperties.SwarmController.Metrics.Pushgateway pushgateway =
+            new WorkerControlPlaneProperties.SwarmController.Metrics.Pushgateway(
+                false,
+                "http://push:9091",
+                Duration.ofMinutes(1),
+                "DELETE");
+        WorkerControlPlaneProperties.SwarmController swarmController =
+            new WorkerControlPlaneProperties.SwarmController(
+                rabbit,
+                new WorkerControlPlaneProperties.SwarmController.Metrics(pushgateway));
+        return new WorkerControlPlaneProperties(
+            true,
+            true,
+            "ph.control",
+            trafficExchange,
+            "swarm-alpha",
+            "worker-1",
+            queues,
+            worker,
+            swarmController);
+    }
+}


### PR DESCRIPTION
## Summary
- remove the traffic exchange environment fallback from `WorkerControlPlaneProperties`
- tighten validation to reject unresolved placeholders and ensure tests configure explicit values
- add coverage confirming property binding fails when the traffic exchange is missing or unresolved

## Testing
- mvn -pl common/control-plane-spring test

------
https://chatgpt.com/codex/tasks/task_e_68f7fce680608328a9b6c8839dd763e0