### PR TITLE
Increase EditorConfig max line length

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ indent_style = space
 indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
+max_line_length = 200
 
 [*.java]
 indent_size = 2


### PR DESCRIPTION
## Summary
- set the project-wide max_line_length to 200 in .editorconfig to reduce premature wrapping

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb8848af0883288057dfe6a7742780