### PR TITLE
Render component list inline with expanded swarm

### DIFF
--- a/ui/src/pages/hive/ComponentList.tsx
+++ b/ui/src/pages/hive/ComponentList.tsx
@@ -37,7 +37,7 @@ export default function ComponentList({ components, selectedId, onSelect }: Prop
     }
   }
   return (
-    <ul className="space-y-2 overflow-y-auto h-full">
+    <ul className="space-y-2">
       {components.map((c) => {
         const role = c.role.trim() || '—'
         const canToggle = supportsConfigToggle(c.role)

--- a/ui/src/pages/hive/HivePage.tsx
+++ b/ui/src/pages/hive/HivePage.tsx
@@ -140,40 +140,43 @@ export default function HivePage() {
               .filter(([id]) => !activeSwarm || id === activeSwarm)
               .map(([id, comps]) => {
                 const normalizedId = id === 'default' ? 'default' : id
+                const isExpanded = expandedSwarmId === id
                 return (
-                  <SwarmRow
-                    key={id}
-                    swarmId={id}
-                    isDefault={id === 'default'}
-                    isActive={activeSwarm === normalizedId}
-                    expanded={expandedSwarmId === id}
-                    onActivate={(swarm) =>
-                      !activeSwarm &&
-                      setActiveSwarm(swarm === 'default' ? 'default' : swarm)
-                    }
-                    onRemove={(swarm) => {
-                      setExpandedSwarmId((current) =>
-                        current === swarm ? null : current,
-                      )
-                      setActiveSwarm((current) =>
-                        current === (swarm === 'default' ? 'default' : swarm)
-                          ? null
-                          : current,
-                      )
-                    }}
-                    onToggleExpand={(swarm) =>
-                      setExpandedSwarmId((current) =>
-                        current === swarm ? null : swarm,
-                      )
-                    }
-                    dataTestId={`swarm-group-${id}`}
-                  >
-                    <ComponentList
-                      components={comps}
-                      onSelect={(c) => setSelected(c)}
-                      selectedId={selected?.id}
+                  <div key={id} className="space-y-2">
+                    <SwarmRow
+                      swarmId={id}
+                      isDefault={id === 'default'}
+                      isActive={activeSwarm === normalizedId}
+                      expanded={isExpanded}
+                      onActivate={(swarm) =>
+                        !activeSwarm &&
+                        setActiveSwarm(swarm === 'default' ? 'default' : swarm)
+                      }
+                      onRemove={(swarm) => {
+                        setExpandedSwarmId((current) =>
+                          current === swarm ? null : current,
+                        )
+                        setActiveSwarm((current) =>
+                          current === (swarm === 'default' ? 'default' : swarm)
+                            ? null
+                            : current,
+                        )
+                      }}
+                      onToggleExpand={(swarm) =>
+                        setExpandedSwarmId((current) =>
+                          current === swarm ? null : swarm,
+                        )
+                      }
+                      dataTestId={`swarm-group-${id}`}
                     />
-                  </SwarmRow>
+                    {isExpanded && (
+                      <ComponentList
+                        components={comps}
+                        onSelect={(c) => setSelected(c)}
+                        selectedId={selected?.id}
+                      />
+                    )}
+                  </div>
                 )
               })}
           </div>


### PR DESCRIPTION
## Summary
- render the hive component list only when its swarm is expanded by placing it directly under the row
- rely on the column container for scrolling by removing the inner overflow styling from the component list

## Testing
- npm --prefix ui run build *(fails: missing type definitions in the current workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68fc027c04848328aa7b9a651f75e296