### PR TITLE
Add defunct styling to topology view nodes

### DIFF
--- a/ui/src/pages/hive/TopologyView.css
+++ b/ui/src/pages/hive/TopologyView.css
@@ -89,6 +89,25 @@
   flex-shrink: 0;
 }
 
+.shape-node__icon-wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
+.shape-node__health {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  display: inline-flex;
+  pointer-events: none;
+}
+
+.shape-node__health .hal-eye {
+  width: 18px;
+  height: 18px;
+  pointer-events: none;
+}
+
 .shape-icon__strike {
   stroke: rgba(248, 113, 113, 0.95);
   stroke-width: 2;
@@ -225,9 +244,33 @@
   pointer-events: none;
 }
 
-.legend-icon--defunct {
-  stroke: rgba(248, 113, 113, 0.95);
-  fill: rgba(248, 113, 113, 0.1);
-  stroke-width: 2;
-  border-radius: 4px;
+.swarm-group__health {
+  width: 18px;
+  height: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+.swarm-group__health .hal-eye {
+  width: 18px;
+  height: 18px;
+}
+
+.legend-item--health {
+  gap: 8px;
+}
+
+.legend-health {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+}
+
+.legend-health .hal-eye {
+  width: 20px;
+  height: 20px;
 }

--- a/ui/src/pages/hive/TopologyView.test.tsx
+++ b/ui/src/pages/hive/TopologyView.test.tsx
@@ -296,6 +296,11 @@ test('defunct statuses decorate components and swarm icons', async () => {
     }),
   )
   expect(shapeContainer.querySelectorAll('.shape-icon__strike').length).toBeGreaterThan(0)
+  expect(
+    shapeContainer.querySelector(
+      '.shape-node__health .hal-eye[data-state="alert"]',
+    ),
+  ).not.toBeNull()
   unmountShape()
   const swarmNode = props.nodes.find((node) => node.id === 'sw1-swarm-controller')
   const swarmData = swarmNode?.data as
@@ -319,6 +324,11 @@ test('defunct statuses decorate components and swarm icons', async () => {
   )
   expect(swarmContainer.querySelectorAll('.swarm-group__icon--defunct').length).toBeGreaterThan(0)
   expect(swarmContainer.querySelectorAll('.swarm-group__icon-strike').length).toBeGreaterThan(0)
+  expect(
+    swarmContainer.querySelector(
+      '.swarm-group__health .hal-eye[data-state="alert"]',
+    ),
+  ).not.toBeNull()
   unmountSwarm()
 })
 


### PR DESCRIPTION
## Summary
- propagate component status into swarm group node data when building topology nodes
- decorate topology nodes and swarm group icons with offline/defunct styling cues and extend the legend
- add tests covering the offline rendering logic for standalone and grouped components

## Testing
- npm --prefix ui test -- TopologyView

------
https://chatgpt.com/codex/tasks/task_e_68fe34755564832884d4c84c25813866