### PR TITLE
refactor: centralize capability formatting helpers

### DIFF
--- a/ui/src/lib/capabilities.ts
+++ b/ui/src/lib/capabilities.ts
@@ -242,6 +242,25 @@ function parseImageReference(image: string): ImageReference | null {
   return { name, tag, digest }
 }
 
+export function formatCapabilityValue(value: unknown): string {
+  if (value === null || value === undefined) return ''
+  if (typeof value === 'string') return value
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return ''
+  }
+}
+
+export function inferCapabilityInputType(type: string | undefined): 'number' | 'text' {
+  const normalized = type?.trim().toLowerCase() ?? ''
+  if (normalized === 'int' || normalized === 'integer' || normalized === 'number') {
+    return 'number'
+  }
+  return 'text'
+}
+
 export function buildRoleAppearanceMap(manifests: CapabilityManifest[]): RoleAppearanceMap {
   const map: RoleAppearanceMap = {}
   manifests.forEach((manifest) => {

--- a/ui/src/pages/hive/ComponentDetail.tsx
+++ b/ui/src/pages/hive/ComponentDetail.tsx
@@ -6,6 +6,7 @@ import { heartbeatHealth, colorForHealth } from '../../lib/health'
 import WiremockPanel from './WiremockPanel'
 import { useCapabilities } from '../../contexts/CapabilitiesContext'
 import type { CapabilityConfigEntry } from '../../types/capabilities'
+import { formatCapabilityValue, inferCapabilityInputType } from '../../lib/capabilities'
 
 interface Props {
   component: Component
@@ -233,7 +234,7 @@ function renderConfigInput(
     )
   }
 
-  const inputType = inferInputType(normalizedType)
+  const inputType = inferCapabilityInputType(entry.type)
   const step = extractStep(entry)
   return (
     <input
@@ -246,11 +247,6 @@ function renderConfigInput(
       step={step}
     />
   )
-}
-
-function inferInputType(type: string) {
-  if (type === 'int' || type === 'integer' || type === 'number') return 'number'
-  return 'text'
 }
 
 function computeInitialValue(
@@ -291,18 +287,7 @@ function formatValueForInput(entry: CapabilityConfigEntry, value: unknown): Conf
     if (typeof value === 'string') return value
     return ''
   }
-  return stringifyValue(value)
-}
-
-function stringifyValue(value: unknown): string {
-  if (value === undefined || value === null) return ''
-  if (typeof value === 'string') return value
-  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
-  try {
-    return JSON.stringify(value, null, 2)
-  } catch {
-    return ''
-  }
+  return formatCapabilityValue(value)
 }
 
 function coerceBoolean(value: unknown): boolean {

--- a/ui/src/pages/hive/SwarmCreateModal.tsx
+++ b/ui/src/pages/hive/SwarmCreateModal.tsx
@@ -6,7 +6,11 @@ import type {
   CapabilityConfigEntry,
   CapabilityManifest,
 } from '../../types/capabilities'
-import { findManifestForImage } from '../../lib/capabilities'
+import {
+  findManifestForImage,
+  formatCapabilityValue,
+  inferCapabilityInputType,
+} from '../../lib/capabilities'
 import { useCapabilities } from '../../contexts/CapabilitiesContext'
 
 interface Props {
@@ -300,7 +304,7 @@ function normalizeBee(entry: unknown): ScenarioBee | null {
 }
 
 function renderConfigControl(entry: CapabilityConfigEntry) {
-  const value = formatDefaultValue(entry.default)
+  const value = formatCapabilityValue(entry.default)
   const normalizedType = entry.type ? entry.type.toLowerCase() : ''
   if (entry.multiline || normalizedType === 'text' || normalizedType === 'json') {
     return (
@@ -313,7 +317,7 @@ function renderConfigControl(entry: CapabilityConfigEntry) {
     )
   }
 
-  const inputType = inferInputType(entry.type)
+  const inputType = inferCapabilityInputType(entry.type)
   return (
     <input
       className="w-full rounded bg-white/10 px-2 py-1 text-white"
@@ -324,24 +328,6 @@ function renderConfigControl(entry: CapabilityConfigEntry) {
       max={entry.max}
     />
   )
-}
-
-function formatDefaultValue(value: unknown): string {
-  if (value === null || value === undefined) return ''
-  if (typeof value === 'string') return value
-  if (typeof value === 'number' || typeof value === 'boolean') return String(value)
-  try {
-    return JSON.stringify(value, null, 2)
-  } catch {
-    return ''
-  }
-}
-
-function inferInputType(type: string | undefined) {
-  const normalized = type?.toLowerCase() ?? ''
-  if (normalized === 'int' || normalized === 'integer' || normalized === 'number') return 'number'
-  if (normalized === 'boolean' || normalized === 'bool') return 'text'
-  return 'text'
 }
 
 function formatActionTooltip(action: CapabilityAction) {


### PR DESCRIPTION
## Summary
- add shared helpers for capability value formatting and input type detection
- update component detail and swarm create views to reuse the shared helpers

## Testing
- npm run lint *(fails: Missing @eslint/js package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_6900f2c62ce88328b1c560fdbb2e8530