### PR TITLE
Remove WireMock request count polling

### DIFF
--- a/ui/src/lib/stompClient.test.ts
+++ b/ui/src/lib/stompClient.test.ts
@@ -230,7 +230,7 @@ describe('swarm lifecycle', () => {
       role: 'wiremock',
       lastHeartbeat: Date.now(),
       queues: [],
-      config: { healthStatus: 'UP', requestCount: 5 },
+      config: { healthStatus: 'UP' },
     }
 
     upsertSyntheticComponent(component)

--- a/ui/src/lib/wiremockClient.test.ts
+++ b/ui/src/lib/wiremockClient.test.ts
@@ -26,7 +26,6 @@ describe('fetchWiremockComponent', () => {
   it('returns a populated component snapshot when metrics are available', async () => {
     const responses = new Map<string, Response>([
       ['http://localhost:8080/__admin/health', jsonResponse({ status: 'OK', version: '3.1.0' })],
-      ['http://localhost:8080/__admin/requests/count', jsonResponse({ count: 42 })],
       [
         'http://localhost:8080/__admin/requests?limit=25',
         jsonResponse({
@@ -71,7 +70,6 @@ describe('fetchWiremockComponent', () => {
       expect.objectContaining({
         healthStatus: 'OK',
         version: '3.1.0',
-        requestCount: 42,
         stubCount: 5,
         unmatchedCount: 1,
         scenarios: [expect.objectContaining({ name: 'Scenario', state: 'Started' })],
@@ -90,8 +88,6 @@ describe('fetchWiremockComponent', () => {
     expect(component.status).toBe('ALERT')
     const config = component.config as WiremockComponentConfig
     expect(config.healthStatus).toBe('UNKNOWN')
-    expect(config.requestCount).toBeUndefined()
-    expect(config.requestCountError).toBe(true)
     expect(config.stubCount).toBeUndefined()
     expect(config.stubCountError).toBe(true)
     expect(config.recentRequests).toEqual([])
@@ -105,7 +101,6 @@ describe('fetchWiremockComponent', () => {
   it('falls back to request meta totals and loggedDateString when counts are unavailable', async () => {
     const responses = new Map<string, Response>([
       ['http://localhost:8080/__admin/health', jsonResponse({ status: 'OK' })],
-      ['http://localhost:8080/__admin/requests/count', new Response(null, { status: 404 })],
       [
         'http://localhost:8080/__admin/requests?limit=25',
         jsonResponse({
@@ -136,8 +131,6 @@ describe('fetchWiremockComponent', () => {
     expect(component).not.toBeNull()
     if (!component) throw new Error('component missing')
     const config = component.config as WiremockComponentConfig
-    expect(config.requestCount).toBe(96)
-    expect(config.requestCountError).toBeUndefined()
     expect(config.recentRequests[0]).toEqual(
       expect.objectContaining({
         id: 'req-1',

--- a/ui/src/pages/hive/ComponentDetail.test.tsx
+++ b/ui/src/pages/hive/ComponentDetail.test.tsx
@@ -33,7 +33,6 @@ const baseTimestamp = Date.now()
 const wiremockConfig: WiremockComponentConfig = {
   healthStatus: 'OK',
   version: '3.0.0',
-  requestCount: 42,
   stubCount: 5,
   unmatchedCount: 1,
   recentRequests: [
@@ -87,8 +86,6 @@ describe('ComponentDetail wiremock panel', () => {
     expect(within(panel).getAllByText('OK').length).toBeGreaterThan(0)
     expect(within(panel).getByText('Stub count')).toBeInTheDocument()
     expect(within(panel).getByText('5')).toBeInTheDocument()
-    expect(within(panel).getByText('Total requests')).toBeInTheDocument()
-    expect(within(panel).getByText('42')).toBeInTheDocument()
     expect(within(panel).getByText('Unmatched total')).toBeInTheDocument()
     expect(within(panel).getByText('1')).toBeInTheDocument()
     expect(within(panel).getByText('Last heartbeat')).toBeInTheDocument()
@@ -119,7 +116,6 @@ describe('ComponentDetail wiremock panel', () => {
   it('allows triggering a refresh of wiremock metrics', async () => {
     const updatedConfig: WiremockComponentConfig = {
       ...wiremockConfig,
-      requestCount: 100,
       lastUpdatedTs: baseTimestamp,
     }
     vi.mocked(fetchWiremockComponent).mockResolvedValueOnce({
@@ -141,7 +137,7 @@ describe('ComponentDetail wiremock panel', () => {
       expect(upsertSyntheticComponent).toHaveBeenCalledWith(
         expect.objectContaining({
           id: 'wiremock',
-          config: expect.objectContaining({ requestCount: 100 }),
+          config: expect.objectContaining({ lastUpdatedTs: baseTimestamp }),
         }),
       )
     })
@@ -202,12 +198,16 @@ describe('ComponentDetail dynamic config', () => {
 
     await waitFor(() => expect(providerValue.ensureCapabilities).toHaveBeenCalled())
 
-    const rateInput = await screen.findByDisplayValue('5')
-    await user.clear(rateInput)
+    await user.click(screen.getByLabelText('Enable editing'))
+
+    const rateInput = (await screen.findByDisplayValue('5')) as HTMLInputElement
+    await user.click(rateInput)
+    await user.keyboard('{Control>}a{/Control}{Backspace}')
     await user.type(rateInput, '10')
 
-    const pathInput = screen.getByDisplayValue('/foo')
-    await user.clear(pathInput)
+    const pathInput = screen.getByDisplayValue('/foo') as HTMLInputElement
+    await user.click(pathInput)
+    await user.keyboard('{Control>}a{/Control}{Backspace}')
     await user.type(pathInput, '/new')
 
     await user.click(screen.getByRole('button', { name: 'Confirm' }))

--- a/ui/src/pages/hive/WiremockPanel.tsx
+++ b/ui/src/pages/hive/WiremockPanel.tsx
@@ -83,9 +83,6 @@ export default function WiremockPanel({ component }: Props) {
 
   const healthLabel = config.healthStatus || component.status || 'UNKNOWN'
   const versionLabel = config.version ?? '—'
-  const requestCountLabel = config.requestCountError
-    ? '—'
-    : formatNumber(config.requestCount)
   const stubCountLabel = config.stubCountError ? '—' : formatNumber(config.stubCount)
   const unmatchedLabel = formatNumber(config.unmatchedCount)
   const heartbeatLabel = formatRelative(component.lastHeartbeat)
@@ -122,7 +119,6 @@ export default function WiremockPanel({ component }: Props) {
       <div className="grid gap-3 sm:grid-cols-2">
         <WiremockStat label="Health" value={healthLabel} />
         <WiremockStat label="Version" value={versionLabel} />
-        <WiremockStat label="Total requests" value={requestCountLabel} error={config.requestCountError} />
         <WiremockStat label="Stub count" value={stubCountLabel} error={config.stubCountError} />
         <WiremockStat
           label="Unmatched total"


### PR DESCRIPTION
## Summary
- stop polling the WireMock requests/count endpoint and drop the unused request count metric from the panel
- update WireMock UI tests and client expectations to reflect the removed metric and keep interaction coverage working
- adjust the component detail capability test to unlock editing and type via keyboard shortcuts for compatibility

## Testing
- npx vitest run src/lib/wiremockClient.test.ts src/pages/hive/ComponentDetail.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_69024d022398832882aeceea5439b27b