### PR TITLE
Align generator config schema with defaults

### DIFF
--- a/generator-service/src/main/java/io/pockethive/generator/GeneratorDefaults.java
+++ b/generator-service/src/main/java/io/pockethive/generator/GeneratorDefaults.java
@@ -1,6 +1,5 @@
 package io.pockethive.generator;
 
-import java.util.Map;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -37,33 +36,12 @@ class GeneratorDefaults {
         enabled,
         ratePerSec,
         false,
-        resolvePath(),
-        resolveMethod(),
-        resolveBody(),
-        resolveHeaders()
+        new GeneratorWorkerConfig.Message(
+            messageConfig.getPath(),
+            messageConfig.getMethod(),
+            messageConfig.getBody(),
+            messageConfig.getHeaders()
+        )
     );
-  }
-
-  private String resolvePath() {
-    String path = messageConfig.getPath();
-    return (path == null || path.isBlank()) ? "/" : path.trim();
-  }
-
-  private String resolveMethod() {
-    String method = messageConfig.getMethod();
-    return (method == null || method.isBlank()) ? "GET" : method.trim();
-  }
-
-  private String resolveBody() {
-    String body = messageConfig.getBody();
-    return body == null ? "" : body;
-  }
-
-  private Map<String, String> resolveHeaders() {
-    Map<String, String> headers = messageConfig.getHeaders();
-    if (headers == null || headers.isEmpty()) {
-      return Map.of();
-    }
-    return Map.copyOf(headers);
   }
 }

--- a/generator-service/src/main/java/io/pockethive/generator/GeneratorRuntimeAdapter.java
+++ b/generator-service/src/main/java/io/pockethive/generator/GeneratorRuntimeAdapter.java
@@ -157,10 +157,7 @@ class GeneratorRuntimeAdapter {
           resolvedEnabled,
           incoming.ratePerSec(),
           incoming.singleRequest(),
-          incoming.path(),
-          incoming.method(),
-          incoming.body(),
-          incoming.headers()
+          incoming.message()
       );
       this.config = updated;
       this.enabled = resolvedEnabled;

--- a/generator-service/src/main/java/io/pockethive/generator/GeneratorWorkerConfig.java
+++ b/generator-service/src/main/java/io/pockethive/generator/GeneratorWorkerConfig.java
@@ -7,31 +7,41 @@ public record GeneratorWorkerConfig(
     boolean enabled,
     double ratePerSec,
     boolean singleRequest,
-    String path,
-    String method,
-    String body,
-    Map<String, String> headers
+    Message message
 ) {
 
   public GeneratorWorkerConfig {
     ratePerSec = Double.isNaN(ratePerSec) || ratePerSec < 0 ? 0.0 : ratePerSec;
-    path = normalizePath(path);
-    method = normalizeMethod(method);
-    body = body == null ? "" : body;
-    headers = headers == null ? Map.of() : Map.copyOf(headers);
+    message = message == null ? Message.defaults() : message;
   }
 
-  private static String normalizePath(String value) {
-    if (value == null || value.isBlank()) {
-      return "/";
-    }
-    return value.trim();
-  }
+  public record Message(String path, String method, String body, Map<String, String> headers) {
 
-  private static String normalizeMethod(String value) {
-    if (value == null || value.isBlank()) {
-      return "GET";
+    private static final Message DEFAULT = new Message("/", "GET", "", Map.of());
+
+    public Message {
+      path = normalizePath(path);
+      method = normalizeMethod(method);
+      body = body == null ? "" : body;
+      headers = headers == null ? Map.of() : Map.copyOf(headers);
     }
-    return value.trim().toUpperCase(Locale.ROOT);
+
+    private static String normalizePath(String value) {
+      if (value == null || value.isBlank()) {
+        return "/";
+      }
+      return value.trim();
+    }
+
+    private static String normalizeMethod(String value) {
+      if (value == null || value.isBlank()) {
+        return "GET";
+      }
+      return value.trim().toUpperCase(Locale.ROOT);
+    }
+
+    static Message defaults() {
+      return DEFAULT;
+    }
   }
 }

--- a/generator-service/src/test/java/io/pockethive/generator/GeneratorTest.java
+++ b/generator-service/src/test/java/io/pockethive/generator/GeneratorTest.java
@@ -47,10 +47,12 @@ class GeneratorTest {
         true,
         10.0,
         false,
-        "/custom",
-        "put",
-        "{\"value\":42}",
-        Map.of("X-Custom", "yes")
+        new GeneratorWorkerConfig.Message(
+            "/custom",
+            "put",
+            "{\"value\":42}",
+            Map.of("X-Custom", "yes")
+        )
     );
 
     WorkResult result = worker.generate(new TestWorkerContext(config));


### PR DESCRIPTION
## Summary
- nest generator worker HTTP settings under a message object so runtime overrides match the defaults schema
- adapt the runtime adapter and worker implementation to use the nested message structure and update status publishing
- refresh generator tests to exercise the new configuration shape

## Testing
- mvn -pl generator-service test

------
https://chatgpt.com/codex/tasks/task_e_6902491ec6d883289eec023cfac1788b