### PR TITLE
Remove unused import from stompClient test

### DIFF
--- a/ui/src/lib/stompClient.test.ts
+++ b/ui/src/lib/stompClient.test.ts
@@ -6,7 +6,6 @@ import {
   subscribeTopology,
   upsertSyntheticComponent,
   removeSyntheticComponent,
-  setSwarmMetadataRefreshHandler,
 } from './stompClient'
 import { subscribeLogs, type LogEntry, resetLogs } from './logs'
 import { useUIStore } from '../store'


### PR DESCRIPTION
## Summary
- remove the unused setSwarmMetadataRefreshHandler import from the STOMP client test suite

## Testing
- npm run build (from ui)


------
https://chatgpt.com/codex/tasks/task_e_69036adc75d0832892b5a983d2135c34