### PR TITLE
Add bundles diagnostics feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.15.16]
+Timestamp: 2026-04-13T00:00:00Z
+
+- Scenario Manager: reload is now fault-isolated — a bad bundle is caught per-file and recorded as a load failure; other bundles continue loading unaffected.
+- Scenario Manager: `ScenarioSummary` gains `defunct` and `defunctReason` fields with plain-English reasons covering all failure categories (missing id, no template, missing image, unresolvable capability manifest).
+- Scenario Manager: new `GET /scenarios/failures` endpoint returns bundles that could not be parsed at all (malformed YAML/JSON, duplicate scenario id).
+- Scenario Manager: `GET /api/templates` now includes defunct scenarios with `defunct` and `defunctReason` fields so the UI can show them as unavailable rather than silently hiding them.
+- UI v2 (Scenarios page): collapsible warning banner lists all bundle load failures with plain-English reasons; defunct bundles show a red `DEFUNCT` badge; selecting a defunct bundle shows the failure reason in the details panel.
+- UI v2 (Create Swarm modal): defunct templates appear greyed out and non-selectable with the failure reason shown on hover; submitting a defunct template is blocked with a clear error message.
+- UI v1 (Create Swarm modal): defunct entries are filtered from the template list to preserve existing behaviour.
+- Tests: 8 new unit tests in `ScenarioServiceTest`, 5 new integration tests in `ScenarioControllerTest`, and 2 updated tests in `CapabilityCatalogueControllerTest` covering all failure categories, reload isolation, and the new endpoint.
+- Docs: `SCENARIO_MANAGER_BUNDLE_REST.md` and `scenario-manager-service/README.md` updated with bundle diagnostics guide, failure cause table, and new endpoint documentation.
+
 ## [0.15.15]
 Timestamp: 2026-04-09T15:46:49Z
 

--- a/docs/inProgress/bundle-diagnostics/README.md
+++ b/docs/inProgress/bundle-diagnostics/README.md
@@ -1,0 +1,57 @@
+# Bundle Diagnostics — Implementation Spec
+
+## Status
+`IMPLEMENTED`
+
+## User Story
+As a PocketHive operator, I want to see which scenario bundles failed to load and why, directly in the UI, so that I can quickly identify and fix broken bundles without needing access to server logs.
+
+## Contents
+
+| File | Description |
+|---|---|
+| [failure-catalogue.md](./failure-catalogue.md) | All 6 failure categories with causes and user-facing messages |
+| [backend.md](./backend.md) | Scenario Manager changes — data model, reload hardening, new endpoint |
+| [api-contract.md](./api-contract.md) | Full API contract for new and changed endpoints |
+| [frontend.md](./frontend.md) | UI v2 changes — ScenariosPage, CreateSwarmModal, new component |
+| [wireframes.md](./wireframes.md) | ASCII wireframes for all affected surfaces |
+| [flows.md](./flows.md) | End-to-end flow diagrams |
+| [docs-changes.md](./docs-changes.md) | Documentation files to update |
+
+## Scope
+
+**In scope:**
+- `scenario-manager-service` — reload hardening, defunct reason, new failures endpoint
+- `ui-v2` — ScenariosPage, CreateSwarmModal, new BundleFailuresBanner component
+- API docs and Scenario Manager README
+
+**Out of scope:**
+- `ui` (v1) — no changes
+- Orchestrator, Swarm Controller, worker services — no changes
+- Scenario authoring, variables, SUT, template editing workflows — no changes
+- New infrastructure, queues, or databases
+
+## Key files touched
+
+### Backend
+| File | Change |
+|---|---|
+| `scenario-manager-service/src/main/java/io/pockethive/scenarios/ScenarioService.java` | Reload hardening, defunct reason, load failures map |
+| `scenario-manager-service/src/main/java/io/pockethive/scenarios/ScenarioSummary.java` | Add `defunct`, `defunctReason` fields |
+| `scenario-manager-service/src/main/java/io/pockethive/scenarios/ScenarioController.java` | New `GET /scenarios/failures` endpoint |
+| `scenario-manager-service/src/main/java/io/pockethive/capabilities/api/CapabilityCatalogueController.java` | Include defunct + reason in `GET /api/templates` |
+
+### Frontend
+| File | Change |
+|---|---|
+| `ui-v2/src/lib/scenariosApi.ts` | Updated types, new `listBundleFailures()` function |
+| `ui-v2/src/pages/ScenariosPage.tsx` | Defunct badge, reason panel, failures banner |
+| `ui-v2/src/pages/hive/CreateSwarmModal.tsx` | Defunct templates greyed out with tooltip |
+| `ui-v2/src/components/scenarios/BundleFailuresBanner.tsx` | New component |
+| `ui/src/pages/hive/SwarmCreateModal.tsx` | One-line fix — filter defunct entries from ui-v1 template list |
+
+### Docs
+| File | Change |
+|---|---|
+| `docs/scenarios/SCENARIO_MANAGER_BUNDLE_REST.md` | New endpoint, updated response shapes |
+| `scenario-manager-service/README.md` | Defunct causes and resolution guide |

--- a/docs/inProgress/bundle-diagnostics/api-contract.md
+++ b/docs/inProgress/bundle-diagnostics/api-contract.md
@@ -12,16 +12,16 @@ Query param `includeDefunct` (default `false`) behaviour unchanged. Response sha
 ```json
 [
   {
-    "id": "local-rest",
-    "name": "Local REST",
+    "id": "my-scenario",
+    "name": "My Scenario",
     "folderPath": null,
     "defunct": false,
     "defunctReason": null
   },
   {
-    "id": "ctap-iso8583-request-builder-demo",
-    "name": "CTAP ISO8583 Request Builder Demo",
-    "folderPath": "bundles/ctap-iso8583-rbuilder-scenario",
+    "id": "my-broken-scenario",
+    "name": "My Broken Scenario",
+    "folderPath": "bundles/my-broken-scenario",
     "defunct": true,
     "defunctReason": "No capability manifest found for image 'io.pockethive/generator:0.15.11' (bee: generator). Check that this image version is installed."
   }
@@ -44,10 +44,10 @@ Used by `CreateSwarmModal`. Previously only returned available (non-defunct) sce
 ```json
 [
   {
-    "id": "local-rest",
-    "name": "Local REST",
+    "id": "my-scenario",
+    "name": "My Scenario",
     "folderPath": null,
-    "description": "Simple local REST swarm",
+    "description": "A simple swarm scenario",
     "controllerImage": "swarm-controller:latest",
     "bees": [
       { "role": "generator", "image": "generator:latest" }
@@ -56,13 +56,13 @@ Used by `CreateSwarmModal`. Previously only returned available (non-defunct) sce
     "defunctReason": null
   },
   {
-    "id": "ctap-iso8583-request-builder-demo",
-    "name": "CTAP ISO8583",
-    "folderPath": "bundles/ctap-iso8583-rbuilder-scenario",
+    "id": "my-broken-scenario",
+    "name": "My Broken Scenario",
+    "folderPath": "bundles/my-broken-scenario",
     "description": null,
-    "controllerImage": "swarm-controller:0.15.11",
+    "controllerImage": "io.pockethive/swarm-controller:0.15.11",
     "bees": [
-      { "role": "generator", "image": "generator:0.15.11" }
+      { "role": "generator", "image": "io.pockethive/generator:0.15.11" }
     ],
     "defunct": true,
     "defunctReason": "No capability manifest found for image 'io.pockethive/generator:0.15.11' (bee: generator). Check that this image version is installed."
@@ -87,7 +87,7 @@ Returns bundles that could not be loaded at all during the last `reload()`. Thes
   },
   {
     "bundlePath": "bundles/old-duplicate",
-    "reason": "Duplicate scenario id 'local-rest' — another bundle at 'bundles/local-rest' was loaded instead"
+    "reason": "Duplicate scenario id 'my-scenario' — another bundle at 'bundles/my-scenario-copy' was loaded instead"
   }
 ]
 ```

--- a/docs/inProgress/bundle-diagnostics/api-contract.md
+++ b/docs/inProgress/bundle-diagnostics/api-contract.md
@@ -1,0 +1,150 @@
+# API Contract
+
+All endpoints are served by `scenario-manager-service` and proxied via nginx at `/scenario-manager/`.
+
+---
+
+## Changed: `GET /scenarios`
+
+Query param `includeDefunct` (default `false`) behaviour unchanged. Response shape gains two new fields on each item.
+
+### Response (200)
+```json
+[
+  {
+    "id": "local-rest",
+    "name": "Local REST",
+    "folderPath": null,
+    "defunct": false,
+    "defunctReason": null
+  },
+  {
+    "id": "ctap-iso8583-request-builder-demo",
+    "name": "CTAP ISO8583 Request Builder Demo",
+    "folderPath": "bundles/ctap-iso8583-rbuilder-scenario",
+    "defunct": true,
+    "defunctReason": "No capability manifest found for image 'io.pockethive/generator:0.15.11' (bee: generator). Check that this image version is installed."
+  }
+]
+```
+
+New fields:
+- `defunct` (boolean, always present) — `true` if the bundle loaded but cannot be used to create a swarm
+- `defunctReason` (string or null) — plain-English reason; null when `defunct` is false
+
+---
+
+## Changed: `GET /api/templates`
+
+Used by `CreateSwarmModal`. Previously only returned available (non-defunct) scenarios. Now returns all scenarios including defunct, with reason.
+
+> **Behaviour change note:** This endpoint previously filtered out defunct scenarios. It now includes them with `defunct: true`. The only current consumer is `CreateSwarmModal` in ui-v2, which is updated as part of this feature. If any other consumer is added in future it must handle the `defunct` flag. ui-v1 does not call this endpoint.
+
+### Response (200)
+```json
+[
+  {
+    "id": "local-rest",
+    "name": "Local REST",
+    "folderPath": null,
+    "description": "Simple local REST swarm",
+    "controllerImage": "swarm-controller:latest",
+    "bees": [
+      { "role": "generator", "image": "generator:latest" }
+    ],
+    "defunct": false,
+    "defunctReason": null
+  },
+  {
+    "id": "ctap-iso8583-request-builder-demo",
+    "name": "CTAP ISO8583",
+    "folderPath": "bundles/ctap-iso8583-rbuilder-scenario",
+    "description": null,
+    "controllerImage": "swarm-controller:0.15.11",
+    "bees": [
+      { "role": "generator", "image": "generator:0.15.11" }
+    ],
+    "defunct": true,
+    "defunctReason": "No capability manifest found for image 'io.pockethive/generator:0.15.11' (bee: generator). Check that this image version is installed."
+  }
+]
+```
+
+New fields: same as `/scenarios` above.
+
+---
+
+## New: `GET /scenarios/failures`
+
+Returns bundles that could not be loaded at all during the last `reload()`. These bundles have no scenario id and cannot appear in the scenarios list.
+
+### Response (200)
+```json
+[
+  {
+    "bundlePath": "bundles/my-broken-scenario",
+    "reason": "Could not read scenario file: mapping values are not allowed here at line 5, column 8"
+  },
+  {
+    "bundlePath": "bundles/old-duplicate",
+    "reason": "Duplicate scenario id 'local-rest' — another bundle at 'bundles/local-rest' was loaded instead"
+  }
+]
+```
+
+Fields:
+- `bundlePath` (string) — path relative to the scenarios root, using forward slashes
+- `reason` (string) — plain-English reason
+
+Returns empty array `[]` when all bundles loaded successfully. Never returns 4xx/5xx for normal operation.
+
+---
+
+## Unchanged endpoints
+
+The following endpoints are not changed by this feature:
+
+- `GET /scenarios/defunct` — still works, now also returns `defunct` and `defunctReason` fields
+- `GET /scenarios/{id}` — unchanged
+- `POST /scenarios/reload` — unchanged, still triggers a full reload; failures map is repopulated
+- All bundle editing endpoints (`/variables`, `/suts`, `/templates`, etc.) — unchanged
+
+---
+
+## Backwards compatibility
+
+### All API changes are additive
+
+`GET /scenarios` and `GET /api/templates` gain two new fields — `defunct` and `defunctReason`. Existing consumers that do not read these fields are unaffected.
+
+### Full consumer inventory
+
+| Consumer | Endpoint | Impact |
+|---|---|---|
+| `ui-v2/src/pages/hive/CreateSwarmModal.tsx` | `GET /api/templates` | Updated as part of this feature |
+| `ui/src/pages/hive/SwarmCreateModal.tsx` | `GET /api/templates` | **Requires one-line fix — see below** |
+| `ui/src/lib/scenarioManagerApi.ts` | `GET /scenarios` | Safe — `normalizeSummary()` only reads `id`, `name`, `folderPath`, ignores new fields |
+| `ui-v2/src/lib/scenariosApi.ts` | `GET /scenarios` | Updated as part of this feature |
+| Orchestrator | `GET /scenarios/{id}`, `POST /scenarios/{id}/runtime` | Not changed |
+| VSCode extension `vscode-pockethive/src/api.ts` | Generic fetch wrapper only | Does not call these endpoints directly — safe |
+
+---
+
+## ui-v1 SwarmCreateModal — required one-line fix
+
+`ui/src/pages/hive/SwarmCreateModal.tsx` calls `GET /api/templates`. After the backend change, defunct templates appear in the response. The current `normalizeTemplate()` does not read `defunct`, so defunct entries would silently appear as selectable options in ui-v1's Create Swarm modal — a user could select one and get a confusing failure at the orchestrator.
+
+**Fix:** Add one line to `normalizeTemplate()` in `ui/src/pages/hive/SwarmCreateModal.tsx`:
+
+```typescript
+function normalizeTemplate(entry: unknown): ScenarioTemplate | null {
+  if (!entry || typeof entry !== 'object') return null
+  const value = entry as Record<string, unknown>
+  if (value.defunct === true) return null   // ← add this line
+  // ... rest unchanged
+}
+```
+
+This preserves existing ui-v1 behaviour exactly — defunct templates remain invisible in ui-v1, identical to today.
+
+This fix must be included in the same PR as the backend change.

--- a/docs/inProgress/bundle-diagnostics/backend.md
+++ b/docs/inProgress/bundle-diagnostics/backend.md
@@ -1,0 +1,238 @@
+# Backend Changes — Scenario Manager
+
+## Overview
+
+All changes are isolated to `scenario-manager-service`. No other services are touched.
+
+---
+
+## 1. New record: `BundleLoadFailure`
+
+Add as a public record inside `ScenarioService`:
+
+```java
+public record BundleLoadFailure(
+    String bundlePath,   // relative path e.g. "bundles/my-scenario"
+    String reason        // human-readable plain English
+) {}
+```
+
+Add a concurrent map alongside the existing `scenarios` map:
+
+```java
+private final Map<String, BundleLoadFailure> loadFailures = new ConcurrentHashMap<>();
+```
+
+The key is the relative bundle path string. This map is cleared and repopulated on every `reload()`.
+
+---
+
+## 2. New record: `DefunctResult`
+
+Replace the `boolean` return type of `determineDefunct()` with a result record:
+
+```java
+private record DefunctResult(boolean defunct, String reason) {
+    static DefunctResult ok() { return new DefunctResult(false, null); }
+    static DefunctResult because(String reason) { return new DefunctResult(true, reason); }
+}
+```
+
+Update `determineDefunct()` to return `DefunctResult` and produce a human-readable reason for each failure category (see [failure-catalogue.md](./failure-catalogue.md)).
+
+---
+
+## 3. Updated `ScenarioRecord`
+
+Add `defunctReason` field:
+
+```java
+private record ScenarioRecord(
+    Scenario scenario,
+    Format format,
+    boolean defunct,
+    String defunctReason,   // ← new, null when not defunct
+    Path descriptorFile,
+    Path bundleDir,
+    String folderPath
+) {}
+```
+
+Update `recordForLoaded()` to populate `defunctReason` from `DefunctResult`.
+
+---
+
+## 4. Updated `ScenarioSummary`
+
+```java
+public record ScenarioSummary(
+    String id,
+    String name,
+    String folderPath,
+    boolean defunct,          // ← new
+    String defunctReason      // ← new, null when not defunct
+) {}
+```
+
+Update `toSummary()` to populate both new fields from `ScenarioRecord`.
+
+---
+
+## 5. Harden `reload()` — per-bundle error isolation
+
+### `loadFromBundles()`
+
+Wrap the per-file block in a try/catch:
+
+```java
+try {
+    Format format = detectFormat(path);
+    Scenario scenario = read(path, format);
+    ScenarioRecord record = recordForLoaded(scenario, format, path, path.getParent());
+    ScenarioRecord previous = target.put(scenario.getId(), record);
+    if (previous != null) {
+        // Category 6 — duplicate id
+        String loserPath = relativeBundlePath(path.getParent());
+        String winnerPath = relativeBundlePath(previous.bundleDir());
+        loadFailures.put(loserPath, new BundleLoadFailure(
+            loserPath,
+            "Duplicate scenario id '" + scenario.getId() + "' — another bundle at '" + winnerPath + "' was loaded instead"
+        ));
+        logger.warn("Duplicate scenario id '{}' found while loading {}; keeping latest", scenario.getId(), path);
+    }
+} catch (Exception e) {
+    // Category 1 — parse failure
+    String relPath = relativeBundlePath(path.getParent());
+    String reason = cleanParseError(e.getMessage());
+    loadFailures.put(relPath, new BundleLoadFailure(relPath, "Could not read scenario file: " + reason));
+    logger.warn("Failed to load bundle at {}: {}", path, e.getMessage());
+}
+```
+
+Apply the same pattern to `loadFromDirectory()`.
+
+### `reload()` — clear failures at start
+
+```java
+public synchronized void reload() throws IOException {
+    Map<String, ScenarioRecord> loaded = new HashMap<>();
+    loadFailures.clear();   // ← add this
+    // ... rest unchanged
+}
+```
+
+### Helper: `cleanParseError(String message)`
+
+Strip Java class names and stack noise from Jackson messages:
+
+```java
+private static String cleanParseError(String message) {
+    if (message == null) return "unknown parse error";
+    // Remove "com.fasterxml..." prefixes
+    String cleaned = message.replaceAll("\\(com\\.fasterxml[^)]*\\)", "").trim();
+    // Truncate at 200 chars
+    return cleaned.length() > 200 ? cleaned.substring(0, 200) + "…" : cleaned;
+}
+```
+
+### Helper: `relativeBundlePath(Path dir)`
+
+```java
+private String relativeBundlePath(Path dir) {
+    if (dir == null) return "unknown";
+    try {
+        return bundleRootDir.toAbsolutePath().normalize()
+            .relativize(dir.toAbsolutePath().normalize())
+            .toString().replace('\\', '/');
+    } catch (Exception e) {
+        return dir.toString().replace('\\', '/');
+    }
+}
+```
+
+---
+
+## 6. New public method: `listLoadFailures()`
+
+```java
+public List<BundleLoadFailure> listLoadFailures() {
+    return loadFailures.values().stream()
+        .sorted(Comparator.comparing(BundleLoadFailure::bundlePath))
+        .toList();
+}
+```
+
+---
+
+## 7. New endpoint: `GET /scenarios/failures`
+
+Add to `ScenarioController`:
+
+```java
+@GetMapping(value = "/failures", produces = MediaType.APPLICATION_JSON_VALUE)
+public List<BundleLoadFailureView> failures() {
+    log.info("[REST] GET /scenarios/failures");
+    List<BundleLoadFailureView> result = service.listLoadFailures().stream()
+        .map(f -> new BundleLoadFailureView(f.bundlePath(), f.reason()))
+        .toList();
+    log.info("[REST] GET /scenarios/failures -> {} items", result.size());
+    return result;
+}
+
+public record BundleLoadFailureView(String bundlePath, String reason) {}
+```
+
+---
+
+## 8. Updated `GET /api/templates`
+
+In `CapabilityCatalogueController`, change `templates()` to use `listAllSummaries()` instead of `list()` so defunct scenarios are included. Add `defunct` and `defunctReason` to `ScenarioTemplateView`:
+
+```java
+public record ScenarioTemplateView(
+    String id,
+    String name,
+    String folderPath,
+    String description,
+    String controllerImage,
+    List<BeeImage> bees,
+    boolean defunct,          // ← new
+    String defunctReason      // ← new
+) {}
+```
+
+Update `buildScenarioTemplate()` to populate from the summary's `defunct` and `defunctReason`.
+
+---
+
+## 9. `determineDefunct()` — human-readable reasons per category
+
+```java
+private DefunctResult determineDefunct(Scenario scenario) {
+    String scenarioId = scenario.getId();
+    if (scenarioId == null || scenarioId.isBlank()) {
+        return DefunctResult.because("Scenario is missing a required 'id' field");
+    }
+    SwarmTemplate template = scenario.getTemplate();
+    if (template == null) {
+        return DefunctResult.because("Scenario has no swarm template defined");
+    }
+
+    List<String> reasons = new ArrayList<>();
+    checkImageReference(scenarioId, "controller", template.image(), reasons);
+    if (template.bees() != null) {
+        for (Bee bee : template.bees()) {
+            checkImageReference(scenarioId, "bee '" + bee.role() + "'", bee.image(), reasons);
+        }
+    }
+    if (!reasons.isEmpty()) {
+        return DefunctResult.because(String.join("; ", reasons));
+    }
+    return DefunctResult.ok();
+}
+```
+
+Update `checkImageReference()` to add human-readable strings to the `reasons` list:
+
+- Missing image: `"Controller image is not defined"` / `"Bee 'generator' has no image defined"`
+- No manifest: `"No capability manifest found for image 'io.pockethive/generator:0.15.11' (bee: generator). Check that this image version is installed."`

--- a/docs/inProgress/bundle-diagnostics/docs-changes.md
+++ b/docs/inProgress/bundle-diagnostics/docs-changes.md
@@ -1,0 +1,96 @@
+# Documentation Changes
+
+The following documentation files must be updated as part of this feature. Changes should be made alongside the code, not after.
+
+---
+
+## 1. `docs/scenarios/SCENARIO_MANAGER_BUNDLE_REST.md`
+
+### Add new section: `GET /scenarios/failures`
+
+Add after the existing `GET /scenarios/defunct` section:
+
+```markdown
+### List bundle load failures
+
+`GET /scenarios/failures` → `application/json`
+
+Returns bundles that could not be loaded at all during the last reload. These are
+distinct from defunct scenarios — they have no scenario id and cannot appear in
+the scenarios list.
+
+Response (200):
+\`\`\`json
+[
+  {
+    "bundlePath": "bundles/my-broken-scenario",
+    "reason": "Could not read scenario file: mapping values are not allowed here at line 5"
+  }
+]
+\`\`\`
+
+Returns `[]` when all bundles loaded successfully.
+```
+
+### Update `GET /scenarios` section
+
+Add note about new `defunct` and `defunctReason` fields:
+
+```markdown
+Each item now includes:
+- `defunct` (boolean) — `true` if the bundle loaded but cannot be used to create a swarm
+- `defunctReason` (string or null) — plain-English reason; null when not defunct
+```
+
+---
+
+## 2. `scenario-manager-service/README.md`
+
+### Add new section: `Bundle diagnostics`
+
+Add after the existing `Scenario schema` section:
+
+```markdown
+## Bundle diagnostics
+
+When the Scenario Manager loads bundles at startup (or on reload), it validates
+each one. Bundles that fail validation are marked as **defunct** and excluded from
+the template picker. Bundles that cannot be parsed at all are recorded as
+**load failures**.
+
+### Why a bundle may be defunct
+
+| Reason | How to fix |
+|---|---|
+| Missing `id` field | Add `id:` to `scenario.yaml` |
+| No `template:` block | Add a `template:` section with `image:` and `bees:` |
+| Controller or bee has no `image:` | Add the missing `image:` field |
+| Image tag has no matching capability manifest | Add a capability manifest YAML to `capabilities/` or update the scenario to use an installed tag |
+
+### Why a bundle may fail to load entirely
+
+| Reason | How to fix |
+|---|---|
+| Malformed YAML or JSON | Fix the syntax error at the reported line/column |
+| Two bundles share the same `id` | Rename the `id` in one of the conflicting `scenario.yaml` files |
+
+### Viewing failures
+
+- **UI**: The Scenarios page shows a warning banner listing all load failures and
+  marks defunct bundles with a red badge. The details panel shows the exact reason.
+- **API**: `GET /scenarios/failures` returns load failures. `GET /scenarios?includeDefunct=true`
+  returns all scenarios including defunct ones with `defunct` and `defunctReason` fields.
+- **Reload**: After fixing a file on disk, call `POST /scenarios/reload` or restart
+  the service to pick up the changes.
+```
+
+---
+
+## 3. No other documentation changes required
+
+The following files do not need changes:
+- `docs/scenarios/SCENARIO_CONTRACT.md` — contract is unchanged
+- `docs/scenarios/SCENARIO_VARIABLES.md` — unchanged
+- `docs/scenarios/SCENARIO_PATTERNS.md` — unchanged
+- `common/worker-sdk/README.md` — unchanged
+- Any orchestrator or swarm controller docs — unchanged

--- a/docs/inProgress/bundle-diagnostics/failure-catalogue.md
+++ b/docs/inProgress/bundle-diagnostics/failure-catalogue.md
@@ -1,0 +1,118 @@
+# Bundle Failure Catalogue
+
+Every reason a bundle can silently disappear from the scenario list, with the exact code location, cause, and user-facing message.
+
+---
+
+## Category 1 — Parse failure
+
+**Where:** `loadFromBundles()` / `loadFromDirectory()` → `read(path, format)`
+
+**Cause:** The `scenario.yaml` / `scenario.json` file contains malformed YAML or JSON that Jackson cannot parse. Currently this exception propagates and aborts the entire `reload()`, potentially hiding all other bundles.
+
+**Fix required:** Catch `IOException` / `JsonProcessingException` per file, store as `BundleLoadFailure`, continue loading remaining bundles.
+
+**User-facing message:**
+```
+Could not read scenario file: <trimmed Jackson message, class names stripped>
+```
+
+**Example:**
+```
+Could not read scenario file: mapping values are not allowed here at line 5, column 8
+```
+
+**Surfaces in UI:** `BundleFailuresBanner` on ScenariosPage (these bundles have no id so cannot appear in the list).
+
+---
+
+## Category 2 — Missing scenario id
+
+**Where:** `determineDefunct()` → `if (scenarioId == null) return true`
+
+**Cause:** The file parsed successfully but has no `id:` field or the field is blank.
+
+**User-facing message:**
+```
+Scenario is missing a required 'id' field
+```
+
+**Surfaces in UI:** Defunct badge in scenario list + reason in details panel.
+
+---
+
+## Category 3 — No swarm template
+
+**Where:** `determineDefunct()` → `if (template == null) return true`
+
+**Cause:** The scenario YAML has no `template:` block.
+
+**User-facing message:**
+```
+Scenario has no swarm template defined
+```
+
+**Surfaces in UI:** Defunct badge in scenario list + reason in details panel.
+
+---
+
+## Category 4 — Missing image on a component
+
+**Where:** `checkImageReference()` → `if (imageReference == null || imageReference.isBlank())`
+
+**Cause:** A bee or the controller has a blank or missing `image:` field.
+
+**User-facing messages:**
+```
+Controller image is not defined
+Bee 'generator' has no image defined
+```
+
+**Surfaces in UI:** Defunct badge in scenario list + reason in details panel.
+
+---
+
+## Category 5 — Unresolvable capability manifest
+
+**Where:** `checkImageReference()` → `capabilities.findByImageReference(imageReference).isEmpty()`
+
+**Cause:** The image reference is present but no capability manifest in `scenario-manager-service/capabilities/` matches it. Most common cause is a version tag mismatch (e.g. image uses `0.15.11` but only `latest` manifest is installed).
+
+**User-facing message:**
+```
+No capability manifest found for image 'io.pockethive/generator:0.15.11' (bee: generator). Check that this image version is installed.
+```
+
+**Surfaces in UI:** Defunct badge in scenario list + reason in details panel + greyed entry in CreateSwarmModal template picker.
+
+**How to fix:** Add or update the capability manifest YAML in `scenario-manager-service/capabilities/` to include the image tag in use, or update the scenario to reference an installed tag.
+
+---
+
+## Category 6 — Duplicate scenario id
+
+**Where:** `loadFromBundles()` / `loadFromDirectory()` → `target.put(scenario.getId(), record)` silently overwrites
+
+**Cause:** Two bundles on disk have the same `id:` value in their `scenario.yaml`. The second one wins and the first disappears with only a server-side `logger.warn`.
+
+**Fix required:** When `target.put()` returns a non-null previous record, store a `BundleLoadFailure` for the losing bundle's path.
+
+**User-facing message:**
+```
+Duplicate scenario id — another bundle at 'bundles/other-folder/my-scenario' was loaded instead
+```
+
+**Surfaces in UI:** `BundleFailuresBanner` on ScenariosPage.
+
+---
+
+## Summary table
+
+| # | Category | Defunct flag | Surfaces in list | Surfaces in banner |
+|---|---|---|---|---|
+| 1 | Parse failure | — (no id) | ✗ | ✓ |
+| 2 | Missing id | ✓ | ✓ | ✗ |
+| 3 | No template | ✓ | ✓ | ✗ |
+| 4 | Missing image | ✓ | ✓ | ✗ |
+| 5 | No capability manifest | ✓ | ✓ + modal | ✗ |
+| 6 | Duplicate id | — (no id for loser) | ✗ | ✓ |

--- a/docs/inProgress/bundle-diagnostics/flows.md
+++ b/docs/inProgress/bundle-diagnostics/flows.md
@@ -1,0 +1,140 @@
+# Flow Diagrams
+
+---
+
+## 1. Bundle loading flow (after fix)
+
+```
+ScenarioService.reload()
+│
+├── loadFailures.clear()
+│
+├── loadFromDirectory(storageDir)
+│   └── for each *.yaml / *.json file
+│       ├── try
+│       │   ├── read(path, format)          ← parse YAML/JSON
+│       │   ├── recordForLoaded()
+│       │   │   ├── applyDefaultImageTag()
+│       │   │   └── determineDefunct()
+│       │   │       ├── id missing?         → DefunctResult.because("Scenario is missing a required 'id' field")
+│       │   │       ├── template missing?   → DefunctResult.because("Scenario has no swarm template defined")
+│       │   │       ├── image missing?      → DefunctResult.because("Controller image is not defined")
+│       │   │       ├── no capability?      → DefunctResult.because("No capability manifest found for image '...'")
+│       │   │       └── all ok              → DefunctResult.ok()
+│       │   └── target.put(id, record)
+│       │       └── duplicate?              → loadFailures.put(path, "Duplicate scenario id...")
+│       └── catch Exception
+│           └── loadFailures.put(path, "Could not read scenario file: ...")
+│
+├── loadFromBundles(bundleRootDir)          ← same pattern as above
+│
+├── scenarios.clear()
+├── scenarios.putAll(loaded)
+└── log: "Loaded N scenario(s) (M available)"
+```
+
+---
+
+## 2. API call flow — ScenariosPage load
+
+```
+Browser (ScenariosPage)
+│
+├── reload() called on mount / Refresh button
+│   │
+│   ├── GET /scenario-manager/scenarios?includeDefunct=true
+│   │   └── ScenarioController.list(includeDefunct=true)
+│   │       └── ScenarioService.listAllSummaries()
+│   │           └── returns all ScenarioRecords mapped to ScenarioSummary
+│   │               (includes defunct=true/false + defunctReason)
+│   │
+│   ├── GET /scenario-manager/scenarios/folders
+│   │   └── ScenarioController.listBundleFolders()
+│   │
+│   └── GET /scenario-manager/scenarios/failures        ← new
+│       └── ScenarioController.failures()
+│           └── ScenarioService.listLoadFailures()
+│               └── returns loadFailures map values
+│
+├── setItems(list)
+├── setFolders(folderList)
+└── setFailures(failureList)
+    │
+    ├── failures.length > 0 → render BundleFailuresBanner
+    └── items with defunct=true → render DEFUNCT pill + reason card
+```
+
+---
+
+## 3. API call flow — CreateSwarmModal load
+
+```
+Browser (CreateSwarmModal)
+│
+├── loadTemplates() called when modal opens
+│   │
+│   ├── GET /scenario-manager/api/templates
+│   │   └── CapabilityCatalogueController.templates()
+│   │       └── availableScenarios.listAll()          ← changed from list()
+│   │           └── returns ALL scenarios including defunct
+│   │               with defunct=true/false + defunctReason
+│   │
+│   └── GET /scenario-manager/network-profiles
+│
+├── setTemplates(normalizeTemplates(payload))
+│   └── defunct templates included with defunct=true
+│
+└── render template list
+    ├── defunct entries: opacity 0.45, not clickable, reason shown
+    └── available entries: normal, clickable
+```
+
+---
+
+## 4. User flow — operator diagnoses a broken bundle
+
+```
+Operator opens Scenarios page
+│
+├── Sees BundleFailuresBanner: "2 bundles failed to load"
+│   └── Clicks "Show details"
+│       └── Reads: "bundles/my-broken-scenario — Could not read scenario file: ..."
+│           └── Action: fixes the YAML syntax error in the file
+│               └── Clicks Refresh → banner disappears
+│
+├── Sees scenario "CTAP ISO8583" with [DEFUNCT] badge
+│   └── Clicks on it
+│       └── Reads in details panel:
+│           "No capability manifest found for image 'io.pockethive/generator:0.15.11'
+│            (bee: generator). Check that this image version is installed."
+│           └── Action: adds capability manifest for 0.15.11
+│               OR updates scenario.yaml to use :latest
+│               └── Clicks Refresh → DEFUNCT badge disappears
+│
+└── Opens Create Swarm modal
+    └── Sees "CTAP ISO8583" greyed out with DEFUNCT pill
+        └── Hovers → tooltip shows reason
+            └── Cannot click / select it
+```
+
+---
+
+## 5. Reload flow — operator fixes a file on disk
+
+```
+Operator fixes scenario.yaml on disk
+│
+└── POST /scenario-manager/scenarios/reload
+    └── ScenarioService.reload()
+        ├── loadFailures.clear()
+        ├── re-scans all bundle directories
+        └── fixed bundle now loads successfully
+            └── GET /scenarios/failures → empty array
+                └── BundleFailuresBanner disappears on next UI refresh
+```
+
+Note: The UI Refresh button on ScenariosPage re-fetches all three endpoints
+(`/scenarios`, `/scenarios/folders`, `/scenarios/failures`) but does NOT
+trigger a server-side reload. To pick up files changed on disk, an operator
+must either restart the service or call `POST /scenarios/reload` directly.
+This is existing behaviour and is not changed by this feature.

--- a/docs/inProgress/bundle-diagnostics/frontend.md
+++ b/docs/inProgress/bundle-diagnostics/frontend.md
@@ -1,0 +1,322 @@
+# Frontend Changes — UI v2
+
+All changes are in `ui-v2`. No changes to `ui` (v1).
+
+---
+
+## 1. `ui-v2/src/lib/scenariosApi.ts`
+
+### Updated type: `ScenarioSummary`
+
+```typescript
+export type ScenarioSummary = {
+  id: string
+  name: string
+  folderPath: string | null
+  defunct: boolean        // new
+  defunctReason: string | null  // new
+}
+```
+
+### New type: `BundleLoadFailure`
+
+```typescript
+export type BundleLoadFailure = {
+  bundlePath: string
+  reason: string
+}
+```
+
+### Updated `normalizeScenarioSummary()`
+
+```typescript
+function normalizeScenarioSummary(input: unknown): ScenarioSummary | null {
+  if (!isRecord(input)) return null
+  const id = asString(input['id'])
+  if (!id) return null
+  const name = asString(input['name']) ?? id
+  const folderPath = asString(input['folderPath'])
+  const defunct = input['defunct'] === true
+  const defunctReason = asString(input['defunctReason'])
+  return { id, name, folderPath, defunct, defunctReason }
+}
+```
+
+### New function: `listBundleFailures()`
+
+```typescript
+export async function listBundleFailures(): Promise<BundleLoadFailure[]> {
+  const response = await fetch('/scenario-manager/scenarios/failures', {
+    headers: { Accept: 'application/json' },
+  })
+  await ensureOk(response, 'Failed to load bundle failures')
+  try {
+    const payload = (await response.json()) as unknown
+    if (!Array.isArray(payload)) return []
+    return payload
+      .map((entry) => {
+        if (!isRecord(entry)) return null
+        const bundlePath = asString(entry['bundlePath'])
+        const reason = asString(entry['reason'])
+        if (!bundlePath || !reason) return null
+        return { bundlePath, reason }
+      })
+      .filter((entry): entry is BundleLoadFailure => entry !== null)
+  } catch {
+    return []
+  }
+}
+```
+
+---
+
+## 2. New component: `ui-v2/src/components/scenarios/BundleFailuresBanner.tsx`
+
+Collapsible warning banner shown when `listBundleFailures()` returns a non-empty array.
+
+```typescript
+import { useState } from 'react'
+import type { BundleLoadFailure } from '../../lib/scenariosApi'
+
+export function BundleFailuresBanner({ failures }: { failures: BundleLoadFailure[] }) {
+  const [expanded, setExpanded] = useState(false)
+  if (failures.length === 0) return null
+
+  return (
+    <div className="card" style={{
+      borderColor: 'rgba(255, 193, 7, 0.4)',
+      background: 'rgba(255, 193, 7, 0.08)',
+      marginBottom: 12
+    }}>
+      <div className="row between">
+        <div className="row" style={{ gap: 8 }}>
+          <span className="pill pillWarn">⚠ {failures.length} bundle{failures.length > 1 ? 's' : ''} failed to load</span>
+          <span className="muted">These bundles are not available for use.</span>
+        </div>
+        <button
+          type="button"
+          className="actionButton actionButtonGhost"
+          onClick={() => setExpanded((prev) => !prev)}
+        >
+          {expanded ? 'Hide details' : 'Show details'}
+        </button>
+      </div>
+
+      {expanded && (
+        <div style={{ marginTop: 12, display: 'grid', gap: 10 }}>
+          {failures.map((failure) => (
+            <div key={failure.bundlePath} style={{
+              borderTop: '1px solid rgba(255,255,255,0.08)',
+              paddingTop: 10
+            }}>
+              <div className="h2" style={{ fontSize: 12 }}>{failure.bundlePath}</div>
+              <div className="muted" style={{ marginTop: 4 }}>{failure.reason}</div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+```
+
+---
+
+## 3. `ui-v2/src/pages/ScenariosPage.tsx`
+
+### Changes summary
+- Fetch `listBundleFailures()` alongside `listScenarios()` in `reload()`
+- Render `<BundleFailuresBanner>` at the top of the page
+- Add defunct badge to `renderScenarioButton()`
+- Add defunct reason card to the details panel
+
+### Updated `reload()` callback
+
+```typescript
+const [failures, setFailures] = useState<BundleLoadFailure[]>([])
+
+const reload = useCallback(async () => {
+  setLoading(true)
+  setError(null)
+  try {
+    const [list, folderList, failureList] = await Promise.all([
+      listScenarios({ includeDefunct: true }),
+      listScenarioFolders(),
+      listBundleFailures(),   // new
+    ])
+    setItems(list)
+    setFolders(folderList)
+    setFailures(failureList)  // new
+    setSelectedId((current) => {
+      if (list.length === 0) return null
+      if (current && list.some((entry) => entry.id === current)) return current
+      return list[0].id
+    })
+  } catch (e) {
+    setError(e instanceof Error ? e.message : 'Failed to load scenarios')
+  } finally {
+    setLoading(false)
+  }
+}, [])
+```
+
+### Updated `renderScenarioButton()` — defunct badge
+
+```typescript
+const renderScenarioButton = useCallback(
+  (entry: ScenarioSummary) => {
+    const active = entry.id === selectedId
+    return (
+      <button
+        key={entry.id}
+        type="button"
+        className={active ? 'swarmCard swarmCardSelected' : 'swarmCard'}
+        onClick={() => setSelectedId(entry.id)}
+        style={{ textAlign: 'left', opacity: entry.defunct ? 0.75 : 1 }}
+      >
+        <div className="row between">
+          <div className="h2">{entry.name}</div>
+          <div className="row" style={{ gap: 6 }}>
+            {entry.defunct && <div className="pill pillBad">DEFUNCT</div>}
+            <div className="pill pillInfo">{folderLabel(entry)}</div>
+          </div>
+        </div>
+        <div className="muted" style={{ marginTop: 6 }}>{entry.id}</div>
+      </button>
+    )
+  },
+  [selectedId],
+)
+```
+
+### Updated details panel — defunct reason card
+
+Add this block above the action buttons in the details panel, when `selected.defunct` is true:
+
+```tsx
+{selected.defunct && (
+  <div className="card" style={{
+    borderColor: 'rgba(255, 95, 95, 0.35)',
+    background: 'rgba(255, 95, 95, 0.08)',
+    marginTop: 12
+  }}>
+    <div className="row" style={{ gap: 8, marginBottom: 8 }}>
+      <span className="pill pillBad">DEFUNCT</span>
+      <span className="h2" style={{ fontSize: 13 }}>This bundle cannot be used to create a swarm</span>
+    </div>
+    <div className="muted">
+      {selected.defunctReason ?? 'Reason unknown — check server logs or reload.'}
+    </div>
+  </div>
+)}
+```
+
+### Updated JSX — add banner at top of page
+
+```tsx
+<BundleFailuresBanner failures={failures} />
+```
+
+Place this immediately after the error card and before the `swarmViewGrid`.
+
+---
+
+## 4. `ui-v2/src/pages/hive/CreateSwarmModal.tsx`
+
+### Updated `normalizeTemplates()`
+
+Add `defunct` and `defunctReason` to `ScenarioTemplate` type and normalization:
+
+```typescript
+type ScenarioTemplate = {
+  id: string
+  name: string
+  folderPath: string | null
+  description: string | null
+  controllerImage: string | null
+  bees: BeeSummary[]
+  defunct: boolean          // new
+  defunctReason: string | null  // new
+}
+```
+
+In `normalizeTemplates()`:
+```typescript
+const defunct = value.defunct === true
+const defunctReason =
+  typeof value.defunctReason === 'string' && value.defunctReason.trim().length > 0
+    ? value.defunctReason.trim()
+    : null
+return { id, name, folderPath, description, controllerImage, bees, defunct, defunctReason }
+```
+
+### Updated `renderTemplateButton()` — defunct entries
+
+```tsx
+const renderTemplateButton = (template: ScenarioTemplate) => (
+  <button
+    key={template.id}
+    type="button"
+    className={template.id === templateId ? 'swarmTemplateItem swarmTemplateItemSelected' : 'swarmTemplateItem'}
+    onClick={() => {
+      if (template.defunct) return  // not selectable
+      setTemplateId(template.id)
+    }}
+    aria-label={template.name}
+    title={template.defunct ? (template.defunctReason ?? 'This template is unavailable') : undefined}
+    style={template.defunct ? { opacity: 0.45, cursor: 'not-allowed' } : undefined}
+  >
+    <div className="row between">
+      <div className="swarmTemplateTitle">{template.name}</div>
+      {template.defunct && <span className="pill pillBad" style={{ fontSize: 10 }}>DEFUNCT</span>}
+    </div>
+    <div className="swarmTemplateId">
+      {template.folderPath ? `${template.folderPath}/${template.id}` : template.id}
+    </div>
+    <div className="swarmTemplateDesc">
+      {template.defunct
+        ? (template.defunctReason ?? 'This template is unavailable')
+        : (template.description ?? 'No description')}
+    </div>
+  </button>
+)
+```
+
+### Defunct count notice
+
+Add above the template list body when any defunct templates exist:
+
+```tsx
+{templates.some((t) => t.defunct) && (
+  <div className="muted" style={{ fontSize: 11, padding: '4px 0' }}>
+    {templates.filter((t) => t.defunct).length} template(s) unavailable — hover for details
+  </div>
+)}
+```
+
+### Guard: prevent submitting a defunct template
+
+In `handleCreate()`, add after the existing required-field check:
+
+```typescript
+const selectedTpl = templates.find((t) => t.id === trimmedTemplateId)
+if (selectedTpl?.defunct) {
+  setError(`Template '${trimmedTemplateId}' is unavailable: ${selectedTpl.defunctReason ?? 'unknown reason'}`)
+  return
+}
+```
+
+---
+
+## 5. `ui/src/pages/hive/SwarmCreateModal.tsx` (ui-v1)
+
+One-line fix to prevent defunct templates appearing as selectable in ui-v1. Must ship in the same PR as the backend change.
+
+```typescript
+function normalizeTemplate(entry: unknown): ScenarioTemplate | null {
+  if (!entry || typeof entry !== 'object') return null
+  const value = entry as Record<string, unknown>
+  if (value.defunct === true) return null   // ← add this line
+  // ... rest unchanged
+}
+```

--- a/docs/inProgress/bundle-diagnostics/wireframes.md
+++ b/docs/inProgress/bundle-diagnostics/wireframes.md
@@ -34,7 +34,7 @@ ASCII wireframes for all affected UI surfaces. Uses existing CSS classes from `u
 │ │ Scenarios              [8]   │  │ │          used to create a swarm  │ │  │    pillBad border
 │ │                              │  │ │                                  │ │  │
 │ │ ▶ bundles (4)                │  │ │ No capability manifest found for │ │  │
-│ │   ▶ demo (1)                 │  │ │ image 'io.pockethive/generator:0.15.11'           │ │  │
+│ │   ▶ demo (1)                 │  │ │ image 'generator:0.15.11'        │ │  │
 │ │   │  [my-broken] [DEFUNCT]   │  │ │ (bee: generator). Check that     │ │  │
 │ │   ▶ perf (2)                 │  │ │ this image version is installed. │ │  │
 │ │   │  [perf-scenario-a]       │  │ └──────────────────────────────────┘ │  │

--- a/docs/inProgress/bundle-diagnostics/wireframes.md
+++ b/docs/inProgress/bundle-diagnostics/wireframes.md
@@ -18,32 +18,31 @@ ASCII wireframes for all affected UI surfaces. Uses existing CSS classes from `u
 │ │ Could not read scenario file: mapping values are not allowed here        │ │
 │ │ at line 5, column 8                                                      │ │
 │ │ ─────────────────────────────────────────────────────────────────────── │ │
-│ │ bundles/old-duplicate                                                    │ │
-│ │ Duplicate scenario id 'local-rest' — another bundle at                   │ │
-│ │ 'bundles/local-rest' was loaded instead                                  │ │
+│ │ bundles/my-scenario-copy                                                 │ │
+│ │ Duplicate scenario id 'my-scenario' — another bundle at                  │ │
+│ │ 'bundles/my-scenario' was loaded instead                                 │ │
 │ └─────────────────────────────────────────────────────────────────────────┘ │
 │                                                                               │
 │ ┌──────────────────────────────┐  ┌──────────────────────────────────────┐  │
 │ │ Folders          [Refresh]   │  │ Details                  [SELECTED]  │  │
 │ │                              │  │                                      │  │
-│ │ Filter: [All folders    ▼]   │  │ ID      ctap-iso8583-request-builder │  │
+│ │ Filter: [All folders    ▼]   │  │ ID      my-broken-scenario           │  │
 │ │ New folder: [          ]     │  │ Folder  bundles                      │  │
 │ │ [Add] [Delete (empty only)]  │  │                                      │  │
 │ │                              │  │ ┌──────────────────────────────────┐ │  │
 │ ├──────────────────────────────┤  │ │ DEFUNCT  This bundle cannot be   │ │  │  ← pillBad card
-│ │ Scenarios              [16]  │  │ │          used to create a swarm  │ │  │    pillBad border
+│ │ Scenarios              [8]   │  │ │          used to create a swarm  │ │  │    pillBad border
 │ │                              │  │ │                                  │ │  │
-│ │ ▶ bundles (12)               │  │ │ No capability manifest found for │ │  │
-│ │   ▶ ctap (1)                 │  │ │ image 'io.pockethive/generator:  │ │  │
-│ │   │  [ctap-iso8583] [DEFUNCT]│  │ │ 0.15.11' (bee: generator).      │ │  │
-│ │   ▶ webauth (4)              │  │ │ Check that this image version    │ │  │
-│ │   │  [webauth-balance-redis] │  │ │ is installed.                    │ │  │
-│ │   │  [webauth-loop-redis]    │  │ └──────────────────────────────────┘ │  │
-│ │   │  ...                     │  │                                      │  │
-│ │ ▶ (root) (4)                 │  │ Move to folder: [root          ▼]   │  │
-│ │   [local-rest]               │  │                                      │  │
-│ │   [local-rest-topology]      │  │ [Move] [Download bundle]             │  │
-│ │   ...                        │  │ [Delete bundle]                      │  │
+│ │ ▶ bundles (4)                │  │ │ No capability manifest found for │ │  │
+│ │   ▶ demo (1)                 │  │ │ image 'io.pockethive/generator:0.15.11'           │ │  │
+│ │   │  [my-broken] [DEFUNCT]   │  │ │ (bee: generator). Check that     │ │  │
+│ │   ▶ perf (2)                 │  │ │ this image version is installed. │ │  │
+│ │   │  [perf-scenario-a]       │  │ └──────────────────────────────────┘ │  │
+│ │   │  [perf-scenario-b]       │  │                                      │  │
+│ │ ▶ (root) (2)                 │  │ Move to folder: [root          ▼]   │  │
+│ │   [my-scenario]              │  │                                      │  │
+│ │   [my-scenario-2]            │  │ [Move] [Download bundle]             │  │
+│ │                              │  │ [Delete bundle]                      │  │
 │ └──────────────────────────────┘  └──────────────────────────────────────┘  │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
@@ -90,19 +89,19 @@ ASCII wireframes for all affected UI surfaces. Uses existing CSS classes from `u
 │ │ 1 template(s) unavailable —      │  │                                  │  │
 │ │ hover for details                │  │                                  │  │
 │ │ ─────────────────────────────── │  │                                  │  │
-│ │ ▶ bundles (12)                   │  │                                  │  │
-│ │   ▶ ctap (1)                     │  │                                  │  │
+│ │ ▶ bundles (4)                    │  │                                  │  │
+│ │   ▶ demo (1)                     │  │                                  │  │
 │ │   │                              │  │                                  │  │
 │ │   │  ┌───────────────────────┐   │  │                                  │  │
-│ │   │  │ CTAP ISO8583   DEFUNCT│   │  │  ← opacity 0.45, cursor:not-    │  │
-│ │   │  │ bundles/ctap/ctap-... │   │  │    allowed, title=reason        │  │
+│ │   │  │ My Broken   DEFUNCT   │   │  │  ← opacity 0.45, cursor:not-    │  │
+│ │   │  │ bundles/demo/my-bro.. │   │  │    allowed, title=reason        │  │
 │ │   │  │ No capability manifest│   │  │                                  │  │
 │ │   │  │ found for image...    │   │  │                                  │  │
 │ │   │  └───────────────────────┘   │  │                                  │  │
-│ │   ▶ webauth (4)                  │  │                                  │  │
+│ │   ▶ perf (2)                     │  │                                  │  │
 │ │   │  ┌───────────────────────┐   │  │                                  │  │
-│ │   │  │ WebAuth Balance Redis │   │  │                                  │  │
-│ │   │  │ bundles/webauth/...   │   │  │                                  │  │
+│ │   │  │ Perf Scenario A       │   │  │                                  │  │
+│ │   │  │ bundles/perf/...      │   │  │                                  │  │
 │ │   │  │ No description        │   │  │                                  │  │
 │ │   │  └───────────────────────┘   │  │                                  │  │
 │ └──────────────────────────────────┘  └──────────────────────────────────┘  │

--- a/docs/inProgress/bundle-diagnostics/wireframes.md
+++ b/docs/inProgress/bundle-diagnostics/wireframes.md
@@ -1,0 +1,136 @@
+# Wireframes
+
+ASCII wireframes for all affected UI surfaces. Uses existing CSS classes from `ui-v2/src/styles.css`.
+
+---
+
+## 1. ScenariosPage — with failures banner (expanded)
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ Scenarios                                          [Upload bundle]           │
+├─────────────────────────────────────────────────────────────────────────────┤
+│ ┌─────────────────────────────────────────────────────────────────────────┐ │
+│ │ ⚠ 2 bundles failed to load                        [Hide details]        │ │  ← BundleFailuresBanner
+│ │ These bundles are not available for use.                                 │ │    card with pillWarn border
+│ │ ─────────────────────────────────────────────────────────────────────── │ │
+│ │ bundles/my-broken-scenario                                               │ │
+│ │ Could not read scenario file: mapping values are not allowed here        │ │
+│ │ at line 5, column 8                                                      │ │
+│ │ ─────────────────────────────────────────────────────────────────────── │ │
+│ │ bundles/old-duplicate                                                    │ │
+│ │ Duplicate scenario id 'local-rest' — another bundle at                   │ │
+│ │ 'bundles/local-rest' was loaded instead                                  │ │
+│ └─────────────────────────────────────────────────────────────────────────┘ │
+│                                                                               │
+│ ┌──────────────────────────────┐  ┌──────────────────────────────────────┐  │
+│ │ Folders          [Refresh]   │  │ Details                  [SELECTED]  │  │
+│ │                              │  │                                      │  │
+│ │ Filter: [All folders    ▼]   │  │ ID      ctap-iso8583-request-builder │  │
+│ │ New folder: [          ]     │  │ Folder  bundles                      │  │
+│ │ [Add] [Delete (empty only)]  │  │                                      │  │
+│ │                              │  │ ┌──────────────────────────────────┐ │  │
+│ ├──────────────────────────────┤  │ │ DEFUNCT  This bundle cannot be   │ │  │  ← pillBad card
+│ │ Scenarios              [16]  │  │ │          used to create a swarm  │ │  │    pillBad border
+│ │                              │  │ │                                  │ │  │
+│ │ ▶ bundles (12)               │  │ │ No capability manifest found for │ │  │
+│ │   ▶ ctap (1)                 │  │ │ image 'io.pockethive/generator:  │ │  │
+│ │   │  [ctap-iso8583] [DEFUNCT]│  │ │ 0.15.11' (bee: generator).      │ │  │
+│ │   ▶ webauth (4)              │  │ │ Check that this image version    │ │  │
+│ │   │  [webauth-balance-redis] │  │ │ is installed.                    │ │  │
+│ │   │  [webauth-loop-redis]    │  │ └──────────────────────────────────┘ │  │
+│ │   │  ...                     │  │                                      │  │
+│ │ ▶ (root) (4)                 │  │ Move to folder: [root          ▼]   │  │
+│ │   [local-rest]               │  │                                      │  │
+│ │   [local-rest-topology]      │  │ [Move] [Download bundle]             │  │
+│ │   ...                        │  │ [Delete bundle]                      │  │
+│ └──────────────────────────────┘  └──────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Notes:**
+- `[DEFUNCT]` pill uses `pillBad` class (red)
+- Defunct scenario button has `opacity: 0.75`
+- Defunct reason card uses `pillBad` border + background
+- Action buttons (Move, Download, Delete) remain enabled for defunct bundles
+- Banner is collapsed by default, expanded on click
+
+---
+
+## 2. ScenariosPage — no failures (healthy state)
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ Scenarios                                          [Upload bundle]           │
+├─────────────────────────────────────────────────────────────────────────────┤
+│  ← no banner shown                                                           │
+│                                                                               │
+│ ┌──────────────────────────────┐  ┌──────────────────────────────────────┐  │
+│ │ Folders          [Refresh]   │  │ Details                  [SELECTED]  │  │
+│ │ ...                          │  │ ...                                  │  │
+│ └──────────────────────────────┘  └──────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Notes:** When `failures.length === 0`, `BundleFailuresBanner` renders nothing. No visual change to the healthy state.
+
+---
+
+## 3. CreateSwarmModal — template picker with defunct entries
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ Create swarm                                                      [Close]    │
+│ Provision a controller from a scenario template.                             │
+├─────────────────────────────────────────────────────────────────────────────┤
+│ Swarm ID: [demo                    ]   Network mode: [Direct          ▼]    │
+│                                                                               │
+│ ┌──────────────────────────────────┐  ┌──────────────────────────────────┐  │
+│ │ Templates    [Filter...        ] │  │ (select a template)              │  │
+│ │ 1 template(s) unavailable —      │  │                                  │  │
+│ │ hover for details                │  │                                  │  │
+│ │ ─────────────────────────────── │  │                                  │  │
+│ │ ▶ bundles (12)                   │  │                                  │  │
+│ │   ▶ ctap (1)                     │  │                                  │  │
+│ │   │                              │  │                                  │  │
+│ │   │  ┌───────────────────────┐   │  │                                  │  │
+│ │   │  │ CTAP ISO8583   DEFUNCT│   │  │  ← opacity 0.45, cursor:not-    │  │
+│ │   │  │ bundles/ctap/ctap-... │   │  │    allowed, title=reason        │  │
+│ │   │  │ No capability manifest│   │  │                                  │  │
+│ │   │  │ found for image...    │   │  │                                  │  │
+│ │   │  └───────────────────────┘   │  │                                  │  │
+│ │   ▶ webauth (4)                  │  │                                  │  │
+│ │   │  ┌───────────────────────┐   │  │                                  │  │
+│ │   │  │ WebAuth Balance Redis │   │  │                                  │  │
+│ │   │  │ bundles/webauth/...   │   │  │                                  │  │
+│ │   │  │ No description        │   │  │                                  │  │
+│ │   │  └───────────────────────┘   │  │                                  │  │
+│ └──────────────────────────────────┘  └──────────────────────────────────┘  │
+│                                                                               │
+│ [ ] Pull images on create                                        [Create]    │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Notes:**
+- Defunct template item: `opacity: 0.45`, `cursor: not-allowed`, not clickable
+- `DEFUNCT` pill (red) shown inline in the template button header
+- Description area shows the `defunctReason` text instead of the scenario description
+- `title` attribute on the button shows the reason on hover
+- Notice line "N template(s) unavailable — hover for details" shown above the list when any defunct exist
+- Clicking a defunct entry does nothing (early return in onClick)
+- If somehow a defunct template id ends up selected and user clicks Create, a validation error is shown
+
+---
+
+## 4. Pill and card styles reference
+
+All styles use existing classes from `ui-v2/src/styles.css`:
+
+| Element | Class | Colour |
+|---|---|---|
+| DEFUNCT pill | `pill pillBad` | Red border + background |
+| Defunct reason card border | inline style `rgba(255, 95, 95, 0.35)` | Red |
+| Defunct reason card background | inline style `rgba(255, 95, 95, 0.08)` | Red tint |
+| Failures banner pill | `pill pillWarn` | Amber |
+| Failures banner card border | inline style `rgba(255, 193, 7, 0.4)` | Amber |
+| Failures banner card background | inline style `rgba(255, 193, 7, 0.08)` | Amber tint |

--- a/docs/scenarios/SCENARIO_MANAGER_BUNDLE_REST.md
+++ b/docs/scenarios/SCENARIO_MANAGER_BUNDLE_REST.md
@@ -51,16 +51,16 @@ Example response (mixed):
 ```json
 [
   {
-    "id": "local-rest",
-    "name": "Local REST",
+    "id": "my-scenario",
+    "name": "My Scenario",
     "folderPath": null,
     "defunct": false,
     "defunctReason": null
   },
   {
-    "id": "ctap-iso8583-request-builder-demo",
-    "name": "CTAP ISO8583 Request Builder Demo",
-    "folderPath": "bundles/ctap-iso8583-rbuilder-scenario",
+    "id": "my-broken-scenario",
+    "name": "My Broken Scenario",
+    "folderPath": "bundles/my-broken-scenario",
     "defunct": true,
     "defunctReason": "No capability manifest found for image 'io.pockethive/generator:0.15.11' (bee 'generator'). Check that this image version is installed."
   }
@@ -97,7 +97,7 @@ Example response:
   },
   {
     "bundlePath": "bundles/old-duplicate",
-    "reason": "Duplicate scenario id 'local-rest' — another bundle at 'bundles/local-rest' was loaded instead"
+    "reason": "Duplicate scenario id 'my-scenario' — another bundle at 'bundles/my-scenario-copy' was loaded instead"
   }
 ]
 ```

--- a/docs/scenarios/SCENARIO_MANAGER_BUNDLE_REST.md
+++ b/docs/scenarios/SCENARIO_MANAGER_BUNDLE_REST.md
@@ -5,8 +5,6 @@ scenario bundle files that live under:
 
 `scenarios/**/<scenarioId>/`
 
-It intentionally covers only the **bundle editing surface** (variables + bundle-local SUTs).
-
 Related docs:
 - Scenario YAML contract: `docs/scenarios/SCENARIO_CONTRACT.md`
 - Scenario Variables contract: `docs/scenarios/SCENARIO_VARIABLES.md`
@@ -22,6 +20,124 @@ The UI reaches Scenario Manager via the reverse proxy:
 The service itself exposes the routes under:
 
 - `/scenarios/...`
+
+---
+
+## Bundle diagnostics
+
+Scenario Manager validates every bundle at startup and on every reload. Bundles that fail
+validation are marked **defunct** and excluded from the template picker. Bundles that cannot
+be parsed at all are recorded as **load failures**.
+
+### List scenarios (with defunct status)
+
+`GET /scenarios` → `application/json`
+
+Query params:
+- `includeDefunct=false` (default) — returns only available scenarios
+- `includeDefunct=true` — returns all scenarios including defunct
+
+Each item in the response now includes:
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | string | Scenario id |
+| `name` | string | Human-readable name |
+| `folderPath` | string \| null | Folder path within the scenarios root |
+| `defunct` | boolean | `true` if the bundle loaded but cannot be used to create a swarm |
+| `defunctReason` | string \| null | Plain-English reason; `null` when `defunct` is `false` |
+
+Example response (mixed):
+```json
+[
+  {
+    "id": "local-rest",
+    "name": "Local REST",
+    "folderPath": null,
+    "defunct": false,
+    "defunctReason": null
+  },
+  {
+    "id": "ctap-iso8583-request-builder-demo",
+    "name": "CTAP ISO8583 Request Builder Demo",
+    "folderPath": "bundles/ctap-iso8583-rbuilder-scenario",
+    "defunct": true,
+    "defunctReason": "No capability manifest found for image 'io.pockethive/generator:0.15.11' (bee 'generator'). Check that this image version is installed."
+  }
+]
+```
+
+### List defunct scenarios only
+
+`GET /scenarios/defunct` → `application/json`
+
+Returns only defunct scenarios. Response shape is identical to `GET /scenarios` above,
+including the `defunct` and `defunctReason` fields.
+
+### List bundle load failures
+
+`GET /scenarios/failures` → `application/json`
+
+Returns bundles that could not be loaded at all during the last reload. These are distinct
+from defunct scenarios — they have no scenario id and cannot appear in the scenarios list.
+
+Returns `[]` when all bundles loaded successfully. Never returns 4xx/5xx for normal operation.
+
+| Field | Type | Description |
+|---|---|---|
+| `bundlePath` | string | Path relative to the scenarios root, using forward slashes |
+| `reason` | string | Plain-English reason |
+
+Example response:
+```json
+[
+  {
+    "bundlePath": "bundles/my-broken-scenario",
+    "reason": "Could not read scenario file: mapping values are not allowed here at line 5"
+  },
+  {
+    "bundlePath": "bundles/old-duplicate",
+    "reason": "Duplicate scenario id 'local-rest' — another bundle at 'bundles/local-rest' was loaded instead"
+  }
+]
+```
+
+### Templates endpoint (used by Create Swarm modal)
+
+`GET /api/templates` → `application/json`
+
+Returns **all** scenarios including defunct, with `defunct` and `defunctReason` fields.
+The UI uses this to show defunct templates as greyed-out, non-selectable entries with a
+tooltip explaining why they cannot be used.
+
+> **Note:** Prior to this change, this endpoint only returned available (non-defunct)
+> scenarios. Consumers that do not handle the `defunct` field should filter entries where
+> `defunct === true` to preserve previous behaviour.
+
+---
+
+## Why a bundle may be defunct
+
+| Reason | `defunctReason` contains | How to fix |
+|---|---|---|
+| Missing `id` field | `missing a required 'id' field` | Add `id:` to `scenario.yaml` |
+| No `template:` block | `no swarm template defined` | Add a `template:` section |
+| Controller has no `image:` | `Controller image is not defined` | Add `image:` under `template:` |
+| Bee has no `image:` | `bee 'X' has no image defined` | Add `image:` to the bee |
+| Image tag not in capability manifests | `No capability manifest found for image '...'` | Add a capability manifest YAML or update the scenario to use an installed tag |
+
+## Why a bundle may fail to load entirely
+
+| Reason | `reason` contains | How to fix |
+|---|---|---|
+| Malformed YAML or JSON | `Could not read scenario file:` + parse error location | Fix the syntax error at the reported line/column |
+| Two bundles share the same `id` | `Duplicate scenario id` | Rename the `id` in one of the conflicting `scenario.yaml` files |
+
+## Triggering a reload
+
+After fixing a file on disk, call `POST /scenarios/reload` or restart the service to pick
+up the changes. The UI Refresh button re-fetches the scenarios and failures lists but does
+**not** trigger a server-side reload.
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <packaging>pom</packaging>
     <properties>
     <!-- Flatten plugin resolves this CI-friendly revision into published POMs; see build plugins below. -->
-    <revision>0.15.15</revision>
+    <revision>0.15.16</revision>
     <logstash.logback.version>8.1</logstash.logback.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/scenario-manager-service/README.md
+++ b/scenario-manager-service/README.md
@@ -23,3 +23,67 @@ config:
 The Scenario Manager merges those maps into `SwarmPlan.bees[*].config`, and the Swarm Controller immediately emits the
 corresponding `config-update` signals when the swarm starts. No environment variables are required for logical worker
 settings—the scenario (or the service defaults under `pockethive.worker.*`) is the single source of truth.
+
+---
+
+## Bundle diagnostics
+
+At startup and on every reload, Scenario Manager validates every bundle it finds on disk.
+Failures are surfaced via the REST API and the UI — no server logs required.
+
+### Why a bundle may be defunct
+
+A bundle loads successfully but is marked **defunct** when it cannot be used to create a swarm.
+The `defunctReason` field on the scenario summary explains why.
+
+| Cause | Reason shown |
+|---|---|
+| Missing `id` field in `scenario.yaml` | `Scenario is missing a required 'id' field` |
+| No `template:` block | `Scenario has no swarm template defined` |
+| Controller has no `image:` | `Controller image is not defined` |
+| A bee has no `image:` | `Bee 'X' has no image defined` |
+| Image tag not in capability manifests | `No capability manifest found for image '...' (bee 'X'). Check that this image version is installed.` |
+
+**How to fix:** correct the `scenario.yaml` or add the missing capability manifest YAML to
+`scenario-manager-service/capabilities/`, then call `POST /scenarios/reload` or restart the service.
+
+### Why a bundle may fail to load entirely
+
+A bundle fails to load when it cannot be parsed at all. These failures appear in
+`GET /scenarios/failures` and in the UI warning banner.
+
+| Cause | Reason shown |
+|---|---|
+| Malformed YAML or JSON | `Could not read scenario file: <parse error location>` |
+| Two bundles share the same `id` | `Duplicate scenario id 'X' — another bundle at '...' was loaded instead` |
+
+A load failure in one bundle does **not** prevent other bundles from loading.
+
+### Viewing failures
+
+- **UI (Scenarios page):** a collapsible warning banner lists all load failures. Defunct bundles
+  show a red `DEFUNCT` badge; selecting one shows the reason in the details panel.
+- **UI (Create Swarm modal):** defunct templates appear greyed out with a tooltip showing the reason.
+  They cannot be selected.
+- **API:** `GET /scenarios/failures` returns load failures. `GET /scenarios?includeDefunct=true`
+  returns all scenarios including defunct ones with `defunct` and `defunctReason` fields.
+
+### Triggering a reload
+
+After fixing a file on disk, call `POST /scenarios/reload` or restart the service. The UI
+Refresh button re-fetches the lists but does **not** trigger a server-side reload.
+
+---
+
+## REST API reference
+
+Full endpoint documentation: [`docs/scenarios/SCENARIO_MANAGER_BUNDLE_REST.md`](../docs/scenarios/SCENARIO_MANAGER_BUNDLE_REST.md)
+
+Key endpoints added by the bundle diagnostics feature:
+
+| Endpoint | Description |
+|---|---|
+| `GET /scenarios?includeDefunct=true` | All scenarios with `defunct` + `defunctReason` fields |
+| `GET /scenarios/defunct` | Defunct scenarios only |
+| `GET /scenarios/failures` | Bundles that failed to load entirely |
+| `GET /api/templates` | All scenarios for the Create Swarm modal, including defunct |

--- a/scenario-manager-service/src/main/java/io/pockethive/capabilities/api/CapabilityCatalogueController.java
+++ b/scenario-manager-service/src/main/java/io/pockethive/capabilities/api/CapabilityCatalogueController.java
@@ -4,6 +4,7 @@ import io.pockethive.capabilities.CapabilityCatalogueService;
 import io.pockethive.capabilities.CapabilityManifest;
 import io.pockethive.scenarios.AvailableScenarioRegistry;
 import io.pockethive.scenarios.Scenario;
+import io.pockethive.scenarios.ScenarioService;
 import io.pockethive.scenarios.ScenarioSummary;
 import io.pockethive.swarm.model.SwarmTemplate;
 import org.springframework.http.HttpStatus;
@@ -25,17 +26,20 @@ public class CapabilityCatalogueController {
 
     private final AvailableScenarioRegistry availableScenarios;
     private final CapabilityCatalogueService catalogue;
+    private final ScenarioService scenarioService;
 
     public CapabilityCatalogueController(AvailableScenarioRegistry availableScenarios,
-                                         CapabilityCatalogueService catalogue) {
+                                         CapabilityCatalogueService catalogue,
+                                         ScenarioService scenarioService) {
         this.availableScenarios = availableScenarios;
         this.catalogue = catalogue;
+        this.scenarioService = scenarioService;
     }
 
     @GetMapping(value = "/templates", produces = MediaType.APPLICATION_JSON_VALUE)
     public List<ScenarioTemplateView> templates() {
-        return availableScenarios.list().stream()
-                .map(summary -> buildScenarioTemplate(summary, availableScenarios.find(summary.id()).orElse(null)))
+        return scenarioService.listAllSummaries().stream()
+                .map(summary -> buildScenarioTemplate(summary, scenarioService.find(summary.id()).orElse(null)))
                 .toList();
     }
 
@@ -71,7 +75,7 @@ public class CapabilityCatalogueController {
                 .toList();
         return new ScenarioTemplateView(summary.id(), summary.name(), summary.folderPath(),
                 scenario != null ? scenario.getDescription() : null,
-                controllerImage, bees);
+                controllerImage, bees, summary.defunct(), summary.defunctReason());
     }
 
     private boolean hasText(String value) {
@@ -91,7 +95,9 @@ public class CapabilityCatalogueController {
                                        String folderPath,
                                        String description,
                                        String controllerImage,
-                                       List<BeeImage> bees) { }
+                                       List<BeeImage> bees,
+                                       boolean defunct,
+                                       String defunctReason) { }
 
     public record BeeImage(String role, String image) { }
 }

--- a/scenario-manager-service/src/main/java/io/pockethive/scenarios/ScenarioController.java
+++ b/scenario-manager-service/src/main/java/io/pockethive/scenarios/ScenarioController.java
@@ -68,6 +68,16 @@ public class ScenarioController {
         return summaries;
     }
 
+    @GetMapping(value = "/failures", produces = MediaType.APPLICATION_JSON_VALUE)
+    public List<BundleLoadFailureView> failures() {
+        log.info("[REST] GET /scenarios/failures");
+        List<BundleLoadFailureView> result = service.listLoadFailures().stream()
+                .map(f -> new BundleLoadFailureView(f.bundlePath(), f.reason()))
+                .toList();
+        log.info("[REST] GET /scenarios/failures -> {} items", result.size());
+        return result;
+    }
+
     @GetMapping(value = "/folders", produces = MediaType.APPLICATION_JSON_VALUE)
     public List<String> listBundleFolders() throws IOException {
         log.info("[REST] GET /scenarios/folders");
@@ -566,5 +576,8 @@ public class ScenarioController {
     }
 
     public record FolderRequest(String path) {
+    }
+
+    public record BundleLoadFailureView(String bundlePath, String reason) {
     }
 }

--- a/scenario-manager-service/src/main/java/io/pockethive/scenarios/ScenarioService.java
+++ b/scenario-manager-service/src/main/java/io/pockethive/scenarios/ScenarioService.java
@@ -40,6 +40,7 @@ public class ScenarioService {
     private final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
     private final CapabilityCatalogueService capabilities;
     private final Map<String, ScenarioRecord> scenarios = new ConcurrentHashMap<>();
+    private final Map<String, BundleLoadFailure> loadFailures = new ConcurrentHashMap<>();
     private final String defaultImageTag;
     private final Object variablesLock = new Object();
 
@@ -96,20 +97,23 @@ public class ScenarioService {
         reload();
     }
 
-	    public synchronized void reload() throws IOException {
-	        Map<String, ScenarioRecord> loaded = new HashMap<>();
+    public synchronized void reload() throws IOException {
+        Map<String, ScenarioRecord> loaded = new HashMap<>();
+        Map<String, BundleLoadFailure> failures = new HashMap<>();
 
-	        loadFromDirectory(storageDir, loaded);
-	        if (showTestScenarios && Files.isDirectory(testStorageDir)) {
-	            loadFromDirectory(testStorageDir, loaded);
-	        }
-	        loadFromBundles(bundleRootDir, loaded);
-	        if (showTestScenarios && Files.isDirectory(testStorageDir)) {
-	            loadFromBundles(testStorageDir, loaded);
-	        }
+        loadFromDirectory(storageDir, loaded, failures);
+        if (showTestScenarios && Files.isDirectory(testStorageDir)) {
+            loadFromDirectory(testStorageDir, loaded, failures);
+        }
+        loadFromBundles(bundleRootDir, loaded, failures);
+        if (showTestScenarios && Files.isDirectory(testStorageDir)) {
+            loadFromBundles(testStorageDir, loaded, failures);
+        }
 
-	        scenarios.clear();
-	        scenarios.putAll(loaded);
+        scenarios.clear();
+        scenarios.putAll(loaded);
+        loadFailures.clear();
+        loadFailures.putAll(failures);
 
         long available = loaded.values().stream().filter(record -> !record.defunct()).count();
         logger.info("Loaded {} scenario(s) from {}{} ({} available)",
@@ -166,11 +170,11 @@ public class ScenarioService {
 
     public Scenario create(Scenario scenario, Format format) throws IOException {
         Scenario resolved = applyDefaultImageTag(scenario);
-        boolean defunct = determineDefunct(resolved);
+        DefunctResult defunctResult = determineDefunct(resolved);
         String id = resolved.getId();
         Path bundleDir = bundleDir(id);
         Path descriptor = descriptorFile(bundleDir, format);
-        ScenarioRecord record = new ScenarioRecord(resolved, format, defunct, descriptor, bundleDir, folderPath(bundleDir));
+        ScenarioRecord record = new ScenarioRecord(resolved, format, defunctResult.defunct(), defunctResult.reason(), descriptor, bundleDir, folderPath(bundleDir));
 
         if (scenarios.putIfAbsent(id, record) != null) {
             throw new IllegalArgumentException("Scenario already exists");
@@ -189,11 +193,11 @@ public class ScenarioService {
     public Scenario update(String id, Scenario scenario, Format format) throws IOException {
         scenario.setId(id);
         Scenario resolved = applyDefaultImageTag(scenario);
-        boolean defunct = determineDefunct(resolved);
+        DefunctResult defunctResult = determineDefunct(resolved);
         ScenarioRecord existing = scenarios.get(id);
         Path bundleDir = existing != null && existing.bundleDir() != null ? existing.bundleDir() : bundleDir(id);
         Path descriptor = descriptorFile(bundleDir, format);
-        ScenarioRecord record = new ScenarioRecord(resolved, format, defunct, descriptor, bundleDir, folderPath(bundleDir));
+        ScenarioRecord record = new ScenarioRecord(resolved, format, defunctResult.defunct(), defunctResult.reason(), descriptor, bundleDir, folderPath(bundleDir));
         ScenarioRecord previous = scenarios.put(id, record);
 
         try {
@@ -382,34 +386,33 @@ public class ScenarioService {
 	        return runtimeRoot != null && runtimeRoot.startsWith(root) && normalized.startsWith(runtimeRoot);
 	    }
 
-    private boolean determineDefunct(Scenario scenario) {
+    private DefunctResult determineDefunct(Scenario scenario) {
         String scenarioId = scenario.getId();
-        if (scenarioId == null) {
-            return true;
+        if (scenarioId == null || scenarioId.isBlank()) {
+            return DefunctResult.because("Scenario is missing a required 'id' field");
         }
 
         SwarmTemplate template = scenario.getTemplate();
         if (template == null) {
             logger.warn("Scenario '{}' has no swarm template defined; marking as defunct", scenarioId);
-            return true;
+            return DefunctResult.because("Scenario has no swarm template defined");
         }
 
-        List<String> missingReferences = new ArrayList<>();
-
-        checkImageReference(scenarioId, "swarm controller", template.image(), missingReferences);
-
+        List<String> reasons = new ArrayList<>();
+        checkImageReference(scenarioId, "controller", template.image(), reasons);
         if (template.bees() != null) {
             for (Bee bee : template.bees()) {
-                checkImageReference(scenarioId, "bee '" + bee.role() + "'", bee.image(), missingReferences);
+                checkImageReference(scenarioId, "bee '" + bee.role() + "'", bee.image(), reasons);
             }
         }
 
-        if (!missingReferences.isEmpty()) {
-            logger.warn("Scenario '{}' marked as defunct; missing capability manifests for {}", scenarioId, missingReferences);
-            return true;
+        if (!reasons.isEmpty()) {
+            String reason = String.join("; ", reasons);
+            logger.warn("Scenario '{}' marked as defunct: {}", scenarioId, reason);
+            return DefunctResult.because(reason);
         }
 
-        return false;
+        return DefunctResult.ok();
     }
 
     private Scenario applyDefaultImageTag(Scenario scenario) {
@@ -501,10 +504,11 @@ public class ScenarioService {
     private void checkImageReference(String scenarioId,
                                      String component,
                                      String imageReference,
-                                     List<String> missingReferences) {
+                                     List<String> reasons) {
         if (imageReference == null || imageReference.isBlank()) {
             logger.warn("Scenario '{}' {} image reference is missing", scenarioId, component);
-            missingReferences.add(component + " (missing image)");
+            String label = component.startsWith("bee") ? component + " has no image defined" : "Controller image is not defined";
+            reasons.add(label);
             return;
         }
 
@@ -515,18 +519,14 @@ public class ScenarioService {
             if (matched.fallbackUsed()) {
                 logger.warn(
                         "Scenario '{}' {} image '{}' is using fallback capability manifest tag '{}' instead of requested tag '{}'",
-                        scenarioId,
-                        component,
-                        imageReference,
-                        matched.resolvedTag(),
-                        matched.requestedTag());
+                        scenarioId, component, imageReference, matched.resolvedTag(), matched.requestedTag());
             }
             return;
         }
 
         if (capabilities.findByImageReference(imageReference).isEmpty()) {
             logger.warn("Scenario '{}' missing capability manifest for {} image '{}'", scenarioId, component, imageReference);
-            missingReferences.add(component + " -> " + imageReference);
+            reasons.add("No capability manifest found for image '" + imageReference + "' (" + component + "). Check that this image version is installed.");
         }
     }
 
@@ -557,9 +557,16 @@ public class ScenarioService {
             .writeValue(descriptor.toFile(), scenario);
     }
 
+    public List<BundleLoadFailure> listLoadFailures() {
+        return loadFailures.values().stream()
+                .sorted(Comparator.comparing(BundleLoadFailure::bundlePath))
+                .toList();
+    }
+
     private ScenarioSummary toSummary(ScenarioRecord record) {
         Scenario scenario = record.scenario();
-        return new ScenarioSummary(scenario.getId(), scenario.getName(), record.folderPath());
+        return new ScenarioSummary(scenario.getId(), scenario.getName(), record.folderPath(),
+                record.defunct(), record.defunctReason());
     }
 
     Path bundleDir(String id) {
@@ -607,10 +614,10 @@ public class ScenarioService {
 
     private ScenarioRecord recordForLoaded(Scenario scenario, Format format, Path descriptorFile, Path bundleDir) {
         Scenario resolved = applyDefaultImageTag(scenario);
-        boolean defunct = determineDefunct(resolved);
+        DefunctResult defunctResult = determineDefunct(resolved);
         Path descriptor = descriptorFile != null ? descriptorFile.toAbsolutePath().normalize() : null;
         Path bundle = bundleDir != null ? bundleDir.toAbsolutePath().normalize() : null;
-        return new ScenarioRecord(resolved, format, defunct, descriptor, bundle, folderPath(bundle));
+        return new ScenarioRecord(resolved, format, defunctResult.defunct(), defunctResult.reason(), descriptor, bundle, folderPath(bundle));
     }
 
     Path runtimeDir(String swarmId) {
@@ -680,61 +687,88 @@ public class ScenarioService {
         }
     }
 
-    private void loadFromDirectory(Path directory, Map<String, ScenarioRecord> target) throws IOException {
+    private void loadFromDirectory(Path directory, Map<String, ScenarioRecord> target, Map<String, BundleLoadFailure> failures) throws IOException {
         if (!Files.isDirectory(directory)) {
             return;
         }
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(directory, "*.{json,yaml,yml}")) {
             for (Path path : stream) {
-                Format format = detectFormat(path);
-                Scenario scenario = read(path, format);
-                ScenarioRecord record = recordForLoaded(scenario, format, path, null);
-                ScenarioRecord previous = target.put(scenario.getId(), record);
-                if (previous != null) {
-                    logger.warn("Duplicate scenario id '{}' found while loading {}; keeping latest", scenario.getId(), path);
+                try {
+                    Format format = detectFormat(path);
+                    Scenario scenario = read(path, format);
+                    ScenarioRecord record = recordForLoaded(scenario, format, path, null);
+                    ScenarioRecord previous = target.put(scenario.getId(), record);
+                    if (previous != null) {
+                        String loserPath = relativeBundlePath(path.getParent());
+                        String winnerPath = relativeBundlePath(previous.bundleDir());
+                        failures.put(loserPath, new BundleLoadFailure(loserPath,
+                                "Duplicate scenario id '" + scenario.getId() + "' — another bundle at '" + winnerPath + "' was loaded instead"));
+                        logger.warn("Duplicate scenario id '{}' found while loading {}; keeping latest", scenario.getId(), path);
+                    }
+                } catch (Exception e) {
+                    String relPath = relativeBundlePath(path.getParent());
+                    failures.put(relPath, new BundleLoadFailure(relPath, "Could not read scenario file: " + cleanParseError(e.getMessage())));
+                    logger.warn("Failed to load scenario at {}: {}", path, e.getMessage());
                 }
             }
         }
     }
 
-	    private void loadFromBundles(Path bundleRoot, Map<String, ScenarioRecord> target) throws IOException {
-	        if (!Files.isDirectory(bundleRoot)) {
-	            return;
-	        }
-	        Path normalizedRoot = bundleRoot.toAbsolutePath().normalize();
-	        Path normalizedStorageDir = storageDir.toAbsolutePath().normalize();
-	        Path normalizedTestDir = testStorageDir.toAbsolutePath().normalize();
-	        Path normalizedRuntimeRoot = runtimeRootDir.toAbsolutePath().normalize();
-	        boolean isMainScan = normalizedRoot.equals(normalizedStorageDir);
-	        boolean runtimeUnderRoot = normalizedRuntimeRoot.startsWith(normalizedRoot);
-	        try (Stream<Path> stream = Files.walk(bundleRoot)) {
-	            for (Path path : (Iterable<Path>) stream::iterator) {
-	                Path normalized = path.toAbsolutePath().normalize();
-	                if (runtimeUnderRoot && normalized.startsWith(normalizedRuntimeRoot)) {
-	                    continue;
-	                }
-	                if (isMainScan && normalized.startsWith(normalizedTestDir)) {
-	                    continue;
-	                }
-	                if (!Files.isRegularFile(path)) {
-	                    continue;
-	                }
-	                String name = path.getFileName().toString();
-	                if (!name.equals("scenario.yaml")
-	                    && !name.equals("scenario.yml")
-	                    && !name.equals("scenario.json")) {
-	                    continue;
-	                }
-	                Format format = detectFormat(path);
-	                Scenario scenario = read(path, format);
-	                ScenarioRecord record = recordForLoaded(scenario, format, path, path.getParent());
-	                ScenarioRecord previous = target.put(scenario.getId(), record);
-	                if (previous != null) {
-	                    logger.warn("Duplicate scenario id '{}' found while loading {}; keeping latest", scenario.getId(), path);
-	                }
-	            }
-	        }
-	    }
+    private void loadFromBundles(Path bundleRoot, Map<String, ScenarioRecord> target, Map<String, BundleLoadFailure> failures) throws IOException {
+        if (!Files.isDirectory(bundleRoot)) {
+            return;
+        }
+        Path normalizedRoot = bundleRoot.toAbsolutePath().normalize();
+        Path normalizedStorageDir = storageDir.toAbsolutePath().normalize();
+        Path normalizedTestDir = testStorageDir.toAbsolutePath().normalize();
+        Path normalizedRuntimeRoot = runtimeRootDir.toAbsolutePath().normalize();
+        boolean isMainScan = normalizedRoot.equals(normalizedStorageDir);
+        boolean runtimeUnderRoot = normalizedRuntimeRoot.startsWith(normalizedRoot);
+        try (Stream<Path> stream = Files.walk(bundleRoot)) {
+            for (Path path : (Iterable<Path>) stream::iterator) {
+                Path normalized = path.toAbsolutePath().normalize();
+                if (runtimeUnderRoot && normalized.startsWith(normalizedRuntimeRoot)) continue;
+                if (isMainScan && normalized.startsWith(normalizedTestDir)) continue;
+                if (!Files.isRegularFile(path)) continue;
+                String name = path.getFileName().toString();
+                if (!name.equals("scenario.yaml") && !name.equals("scenario.yml") && !name.equals("scenario.json")) continue;
+                try {
+                    Format format = detectFormat(path);
+                    Scenario scenario = read(path, format);
+                    ScenarioRecord record = recordForLoaded(scenario, format, path, path.getParent());
+                    ScenarioRecord previous = target.put(scenario.getId(), record);
+                    if (previous != null) {
+                        String loserPath = relativeBundlePath(path.getParent());
+                        String winnerPath = relativeBundlePath(previous.bundleDir());
+                        failures.put(loserPath, new BundleLoadFailure(loserPath,
+                                "Duplicate scenario id '" + scenario.getId() + "' — another bundle at '" + winnerPath + "' was loaded instead"));
+                        logger.warn("Duplicate scenario id '{}' found while loading {}; keeping latest", scenario.getId(), path);
+                    }
+                } catch (Exception e) {
+                    String relPath = relativeBundlePath(path.getParent());
+                    failures.put(relPath, new BundleLoadFailure(relPath, "Could not read scenario file: " + cleanParseError(e.getMessage())));
+                    logger.warn("Failed to load bundle at {}: {}", path, e.getMessage());
+                }
+            }
+        }
+    }
+
+    private String relativeBundlePath(Path dir) {
+        if (dir == null) return "unknown";
+        try {
+            return bundleRootDir.toAbsolutePath().normalize()
+                    .relativize(dir.toAbsolutePath().normalize())
+                    .toString().replace('\\', '/');
+        } catch (Exception e) {
+            return dir.toString().replace('\\', '/');
+        }
+    }
+
+    private static String cleanParseError(String message) {
+        if (message == null) return "unknown parse error";
+        String cleaned = message.replaceAll("\\(com\\.fasterxml[^)]*\\)", "").trim();
+        return cleaned.length() > 200 ? cleaned.substring(0, 200) + "…" : cleaned;
+    }
 
     private Path pathFor(String id, Format format) {
         String fileName = sanitize(id) + (format == Format.JSON ? ".json" : ".yaml");
@@ -1733,10 +1767,18 @@ public class ScenarioService {
         Scenario scenario,
         Format format,
         boolean defunct,
+        String defunctReason,
         Path descriptorFile,
         Path bundleDir,
         String folderPath
     ) { }
+
+    public record BundleLoadFailure(String bundlePath, String reason) { }
+
+    private record DefunctResult(boolean defunct, String reason) {
+        static DefunctResult ok() { return new DefunctResult(false, null); }
+        static DefunctResult because(String reason) { return new DefunctResult(true, reason); }
+    }
 
     private record ScenarioDescriptor(Scenario scenario, Path rootDir) { }
 

--- a/scenario-manager-service/src/main/java/io/pockethive/scenarios/ScenarioSummary.java
+++ b/scenario-manager-service/src/main/java/io/pockethive/scenarios/ScenarioSummary.java
@@ -1,3 +1,3 @@
 package io.pockethive.scenarios;
 
-public record ScenarioSummary(String id, String name, String folderPath) {}
+public record ScenarioSummary(String id, String name, String folderPath, boolean defunct, String defunctReason) {}

--- a/scenario-manager-service/src/test/java/io/pockethive/capabilities/api/CapabilityCatalogueControllerTest.java
+++ b/scenario-manager-service/src/test/java/io/pockethive/capabilities/api/CapabilityCatalogueControllerTest.java
@@ -4,6 +4,7 @@ import io.pockethive.capabilities.CapabilityCatalogueService;
 import io.pockethive.capabilities.CapabilityManifest;
 import io.pockethive.scenarios.AvailableScenarioRegistry;
 import io.pockethive.scenarios.Scenario;
+import io.pockethive.scenarios.ScenarioService;
 import io.pockethive.scenarios.ScenarioSummary;
 import io.pockethive.swarm.model.Bee;
 import io.pockethive.swarm.model.SwarmTemplate;
@@ -38,20 +39,50 @@ class CapabilityCatalogueControllerTest {
     @MockBean
     CapabilityCatalogueService catalogue;
 
+    @MockBean
+    ScenarioService scenarioService;
+
     @Test
-    void templatesEndpointReturnsAvailableScenariosWithImages() throws Exception {
+    void templatesEndpointReturnsAllScenariosIncludingDefunct() throws Exception {
+        Scenario available = new Scenario("alpha", "Alpha", "A test scenario",
+                new SwarmTemplate("controller:v1", List.of(
+                        new Bee("worker", "worker:v2", Work.ofDefaults("in", "out"), Map.of()))));
+        Scenario defunct = new Scenario("broken", "Broken", null,
+                new SwarmTemplate("missing:v1", List.of()));
+
+        given(scenarioService.listAllSummaries()).willReturn(List.of(
+                new ScenarioSummary("alpha", "Alpha", null, false, null),
+                new ScenarioSummary("broken", "Broken", null, true, "No capability manifest found for image 'missing:v1' (controller)")
+        ));
+        given(scenarioService.find("alpha")).willReturn(Optional.of(available));
+        given(scenarioService.find("broken")).willReturn(Optional.of(defunct));
+
+        mvc.perform(get("/api/templates").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value("alpha"))
+                .andExpect(jsonPath("$[0].defunct").value(false))
+                .andExpect(jsonPath("$[0].defunctReason").doesNotExist())
+                .andExpect(jsonPath("$[1].id").value("broken"))
+                .andExpect(jsonPath("$[1].defunct").value(true))
+                .andExpect(jsonPath("$[1].defunctReason").value(org.hamcrest.Matchers.containsString("missing:v1")));
+    }
+
+    @Test
+    void templatesEndpointAvailableScenarioHasDefunctFalse() throws Exception {
         Scenario scenario = new Scenario("alpha", "Alpha", "A test scenario",
                 new SwarmTemplate("controller:v1", List.of(
                         new Bee("worker", "worker:v2", Work.ofDefaults("in", "out"), Map.of()))));
-        given(scenarios.list()).willReturn(List.of(new ScenarioSummary("alpha", "Alpha", null)));
-        given(scenarios.find("alpha")).willReturn(Optional.of(scenario));
+        given(scenarioService.listAllSummaries()).willReturn(
+                List.of(new ScenarioSummary("alpha", "Alpha", null, false, null)));
+        given(scenarioService.find("alpha")).willReturn(Optional.of(scenario));
 
         mvc.perform(get("/api/templates").accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$[0].id").value("alpha"))
                 .andExpect(jsonPath("$[0].controllerImage").value("controller:v1"))
                 .andExpect(jsonPath("$[0].bees[0].role").value("worker"))
-                .andExpect(jsonPath("$[0].bees[0].image").value("worker:v2"));
+                .andExpect(jsonPath("$[0].bees[0].image").value("worker:v2"))
+                .andExpect(jsonPath("$[0].defunct").value(false));
     }
 
     @Test

--- a/scenario-manager-service/src/test/java/io/pockethive/scenarios/ScenarioControllerTest.java
+++ b/scenario-manager-service/src/test/java/io/pockethive/scenarios/ScenarioControllerTest.java
@@ -366,6 +366,95 @@ class ScenarioControllerTest {
     }
 
     @Test
+    void listScenariosIncludesDefunctFieldAndReason() throws Exception {
+        Path bundle = Files.createDirectories(scenariosDir.resolve("defunct-bundle"));
+        Files.writeString(bundle.resolve("scenario.yaml"), """
+                id: defunct-bundle
+                name: Defunct Bundle
+                template:
+                  image: missing-ctrl:latest
+                  bees: []
+                """);
+
+        mvc.perform(post("/scenarios/reload")).andExpect(status().isNoContent());
+
+        mvc.perform(get("/scenarios").param("includeDefunct", "true").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.id=='defunct-bundle')].defunct").value(true))
+                .andExpect(jsonPath("$[?(@.id=='defunct-bundle')].defunctReason").isNotEmpty());
+    }
+
+    @Test
+    void listScenariosAvailableHasDefunctFalse() throws Exception {
+        String body = """
+                {
+                  "id": "available-check",
+                  "name": "Available Check",
+                  "template": {
+                    "image": "ctrl-image:latest",
+                    "bees": []
+                  }
+                }
+                """;
+        mvc.perform(post("/scenarios").contentType(MediaType.APPLICATION_JSON).content(body))
+                .andExpect(status().isCreated());
+
+        mvc.perform(get("/scenarios").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[?(@.id=='available-check')].defunct").value(false))
+                .andExpect(jsonPath("$[?(@.id=='available-check')].defunctReason").value(org.hamcrest.Matchers.contains(org.hamcrest.Matchers.nullValue())));
+    }
+
+    @Test
+    void failuresEndpointReturnsEmptyWhenAllBundlesLoad() throws Exception {
+        mvc.perform(get("/scenarios/failures").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$").isEmpty());
+    }
+
+    @Test
+    void failuresEndpointReturnsMalformedBundleWithReason() throws Exception {
+        Path bundle = Files.createDirectories(scenariosDir.resolve("bad-bundle"));
+        Files.writeString(bundle.resolve("scenario.yaml"), "id: [not valid yaml");
+
+        mvc.perform(post("/scenarios/reload")).andExpect(status().isNoContent());
+
+        mvc.perform(get("/scenarios/failures").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].bundlePath").isNotEmpty())
+                .andExpect(jsonPath("$[0].reason").value(org.hamcrest.Matchers.startsWith("Could not read scenario file")));
+    }
+
+    @Test
+    void failuresEndpointReturnsDuplicateIdWithReason() throws Exception {
+        Path bundleA = Files.createDirectories(scenariosDir.resolve("folder-a").resolve("dup"));
+        Files.writeString(bundleA.resolve("scenario.yaml"), """
+                id: dup
+                name: Dup A
+                template:
+                  image: ctrl-image:latest
+                  bees: []
+                """);
+        Path bundleB = Files.createDirectories(scenariosDir.resolve("folder-b").resolve("dup"));
+        Files.writeString(bundleB.resolve("scenario.yaml"), """
+                id: dup
+                name: Dup B
+                template:
+                  image: ctrl-image:latest
+                  bees: []
+                """);
+
+        mvc.perform(post("/scenarios/reload")).andExpect(status().isNoContent());
+
+        mvc.perform(get("/scenarios/failures").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(1)))
+                .andExpect(jsonPath("$[0].reason").value(org.hamcrest.Matchers.containsString("Duplicate scenario id")));
+    }
+
+    @Test
     void validationFailure() throws Exception {
         mvc.perform(post("/scenarios").contentType(MediaType.APPLICATION_JSON)
                         .content("{\"id\":\"\",\"name\":\"\"}"))

--- a/scenario-manager-service/src/test/java/io/pockethive/scenarios/ScenarioServiceTest.java
+++ b/scenario-manager-service/src/test/java/io/pockethive/scenarios/ScenarioServiceTest.java
@@ -476,6 +476,233 @@ class ScenarioServiceTest {
                 .hasMessageContaining("must be an object");
     }
 
+    @Test
+    void defunctSummaryIncludesReason() throws IOException {
+        writeManifest("ctrl", "ctrl-image");
+        capabilities.reload();
+
+        writeScenario("defunct.yaml", """
+                id: defunct
+                name: Defunct Scenario
+                template:
+                  image: ctrl-image:latest
+                  bees:
+                    - role: worker
+                      image: missing-image:latest
+                      work:
+                        in:
+                          in: a
+                        out:
+                          out: b
+                """);
+
+        service.reload();
+
+        assertThat(service.listDefunctSummaries())
+                .extracting(ScenarioSummary::defunct)
+                .containsExactly(true);
+        assertThat(service.listDefunctSummaries())
+                .extracting(ScenarioSummary::defunctReason)
+                .first().asString()
+                .contains("missing-image:latest")
+                .contains("bee 'worker'");
+    }
+
+    @Test
+    void availableSummaryHasDefunctFalseAndNullReason() throws IOException {
+        writeManifest("ctrl", "ctrl-image");
+        writeManifest("worker", "worker-image");
+        capabilities.reload();
+
+        writeScenario("available.yaml", """
+                id: available
+                name: Available
+                template:
+                  image: ctrl-image:latest
+                  bees:
+                    - role: worker
+                      image: worker-image:latest
+                      work:
+                        in:
+                          in: a
+                        out:
+                          out: b
+                """);
+
+        service.reload();
+
+        ScenarioSummary summary = service.listAvailableSummaries().get(0);
+        assertThat(summary.defunct()).isFalse();
+        assertThat(summary.defunctReason()).isNull();
+    }
+
+    @Test
+    void missingTemplateMarksDefunctWithReason() throws IOException {
+        writeScenario("no-template.yaml", """
+                id: no-template
+                name: No Template
+                """);
+
+        service.reload();
+
+        assertThat(service.listDefunctSummaries())
+                .extracting(ScenarioSummary::defunctReason)
+                .first().asString()
+                .contains("no swarm template");
+    }
+
+    @Test
+    void missingControllerImageMarksDefunctWithReason() throws IOException {
+        writeScenario("no-ctrl-image.yaml", """
+                id: no-ctrl-image
+                name: No Controller Image
+                template:
+                  image:
+                  bees: []
+                """);
+
+        service.reload();
+
+        assertThat(service.listDefunctSummaries())
+                .extracting(ScenarioSummary::defunctReason)
+                .first().asString()
+                .contains("Controller image is not defined");
+    }
+
+    @Test
+    void malformedYamlIsIsolatedAsBundleLoadFailure() throws IOException {
+        writeScenario("broken.yaml", "id: [this is: not valid yaml: [");
+        writeManifest("ctrl", "ctrl-image");
+        writeManifest("worker", "worker-image");
+        capabilities.reload();
+        writeScenario("healthy.yaml", """
+                id: healthy
+                name: Healthy
+                template:
+                  image: ctrl-image:latest
+                  bees:
+                    - role: worker
+                      image: worker-image:latest
+                      work:
+                        in:
+                          in: a
+                        out:
+                          out: b
+                """);
+
+        service.reload();
+
+        // healthy bundle still loads
+        assertThat(service.listAvailableSummaries())
+                .extracting(ScenarioSummary::id)
+                .containsExactly("healthy");
+
+        // broken bundle recorded as failure
+        assertThat(service.listLoadFailures()).hasSize(1);
+        assertThat(service.listLoadFailures().get(0).reason())
+                .contains("Could not read scenario file");
+    }
+
+    @Test
+    void malformedBundleYamlIsIsolatedAndOtherBundlesLoad() throws IOException {
+        writeManifest("ctrl", "ctrl-image");
+        writeManifest("worker", "worker-image");
+        capabilities.reload();
+
+        // broken bundle
+        Path brokenBundle = Files.createDirectories(scenariosDir.resolve("broken-bundle"));
+        Files.writeString(brokenBundle.resolve("scenario.yaml"), "id: [not valid");
+
+        // healthy bundle
+        Path healthyBundle = Files.createDirectories(scenariosDir.resolve("healthy-bundle"));
+        Files.writeString(healthyBundle.resolve("scenario.yaml"), """
+                id: healthy-bundle
+                name: Healthy Bundle
+                template:
+                  image: ctrl-image:latest
+                  bees:
+                    - role: worker
+                      image: worker-image:latest
+                      work:
+                        in:
+                          in: a
+                        out:
+                          out: b
+                """);
+
+        service.reload();
+
+        assertThat(service.listAvailableSummaries())
+                .extracting(ScenarioSummary::id)
+                .containsExactly("healthy-bundle");
+        assertThat(service.listLoadFailures()).hasSize(1);
+        assertThat(service.listLoadFailures().get(0).bundlePath())
+                .contains("broken-bundle");
+        assertThat(service.listLoadFailures().get(0).reason())
+                .startsWith("Could not read scenario file");
+    }
+
+    @Test
+    void duplicateBundleIdRecordsLoadFailureForLoser() throws IOException {
+        writeManifest("ctrl", "ctrl-image");
+        capabilities.reload();
+
+        Path bundleA = Files.createDirectories(scenariosDir.resolve("folder-a").resolve("dup-scenario"));
+        Files.writeString(bundleA.resolve("scenario.yaml"), """
+                id: dup-scenario
+                name: Dup A
+                template:
+                  image: ctrl-image:latest
+                  bees: []
+                """);
+
+        Path bundleB = Files.createDirectories(scenariosDir.resolve("folder-b").resolve("dup-scenario"));
+        Files.writeString(bundleB.resolve("scenario.yaml"), """
+                id: dup-scenario
+                name: Dup B
+                template:
+                  image: ctrl-image:latest
+                  bees: []
+                """);
+
+        service.reload();
+
+        // one wins, one is recorded as failure
+        assertThat(service.listAllSummaries())
+                .extracting(ScenarioSummary::id)
+                .containsExactly("dup-scenario");
+        assertThat(service.listLoadFailures()).hasSize(1);
+        assertThat(service.listLoadFailures().get(0).reason())
+                .contains("Duplicate scenario id")
+                .contains("dup-scenario");
+    }
+
+    @Test
+    void loadFailuresClearedOnReload() throws IOException {
+        writeScenario("broken.yaml", "id: [not valid");
+        service.reload();
+        assertThat(service.listLoadFailures()).hasSize(1);
+
+        // fix the file
+        writeManifest("ctrl", "ctrl-image");
+        capabilities.reload();
+        Files.delete(scenariosDir.resolve("broken.yaml"));
+        writeScenario("broken.yaml", """
+                id: fixed
+                name: Fixed
+                template:
+                  image: ctrl-image:latest
+                  bees: []
+                """);
+
+        service.reload();
+
+        assertThat(service.listLoadFailures()).isEmpty();
+        assertThat(service.listAvailableSummaries())
+                .extracting(ScenarioSummary::id)
+                .containsExactly("fixed");
+    }
+
     private void writeManifest(String prefix, String imageName) throws IOException {
         writeManifest(prefix, imageName, "latest");
     }

--- a/ui-v2/src/components/scenarios/BundleFailuresBanner.tsx
+++ b/ui-v2/src/components/scenarios/BundleFailuresBanner.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react'
+import type { BundleLoadFailure } from '../../lib/scenariosApi'
+
+export function BundleFailuresBanner({ failures }: { failures: BundleLoadFailure[] }) {
+  const [expanded, setExpanded] = useState(false)
+  if (failures.length === 0) return null
+
+  return (
+    <div
+      className="card"
+      style={{
+        borderColor: 'rgba(255, 193, 7, 0.4)',
+        background: 'rgba(255, 193, 7, 0.08)',
+        marginBottom: 12,
+      }}
+    >
+      <div className="row between">
+        <div className="row" style={{ gap: 8 }}>
+          <span className="pill pillWarn">
+            ⚠ {failures.length} bundle{failures.length > 1 ? 's' : ''} failed to load
+          </span>
+          <span className="muted">These bundles are not available for use.</span>
+        </div>
+        <button
+          type="button"
+          className="actionButton actionButtonGhost"
+          onClick={() => setExpanded((prev) => !prev)}
+        >
+          {expanded ? 'Hide details' : 'Show details'}
+        </button>
+      </div>
+
+      {expanded && (
+        <div style={{ marginTop: 12, display: 'grid', gap: 10 }}>
+          {failures.map((failure) => (
+            <div
+              key={failure.bundlePath}
+              style={{ borderTop: '1px solid rgba(255,255,255,0.08)', paddingTop: 10 }}
+            >
+              <div className="h2" style={{ fontSize: 12 }}>{failure.bundlePath}</div>
+              <div className="muted" style={{ marginTop: 4 }}>{failure.reason}</div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui-v2/src/lib/scenariosApi.ts
+++ b/ui-v2/src/lib/scenariosApi.ts
@@ -28,6 +28,13 @@ export type ScenarioSummary = {
   id: string
   name: string
   folderPath: string | null
+  defunct: boolean
+  defunctReason: string | null
+}
+
+export type BundleLoadFailure = {
+  bundlePath: string
+  reason: string
 }
 
 export type BundleDownload = {
@@ -41,7 +48,9 @@ function normalizeScenarioSummary(input: unknown): ScenarioSummary | null {
   if (!id) return null
   const name = asString(input['name']) ?? id
   const folderPath = asString(input['folderPath'])
-  return { id, name, folderPath }
+  const defunct = input['defunct'] === true
+  const defunctReason = asString(input['defunctReason'])
+  return { id, name, folderPath, defunct, defunctReason }
 }
 
 export async function listScenarios(opts?: { includeDefunct?: boolean }): Promise<ScenarioSummary[]> {
@@ -150,4 +159,26 @@ export async function deleteScenarioBundle(scenarioId: string): Promise<void> {
     method: 'DELETE',
   })
   await ensureOk(response, 'Failed to delete scenario bundle')
+}
+
+export async function listBundleFailures(): Promise<BundleLoadFailure[]> {
+  const response = await fetch('/scenario-manager/scenarios/failures', {
+    headers: { Accept: 'application/json' },
+  })
+  await ensureOk(response, 'Failed to load bundle failures')
+  try {
+    const payload = (await response.json()) as unknown
+    if (!Array.isArray(payload)) return []
+    return payload
+      .map((entry) => {
+        if (!isRecord(entry)) return null
+        const bundlePath = asString(entry['bundlePath'])
+        const reason = asString(entry['reason'])
+        if (!bundlePath || !reason) return null
+        return { bundlePath, reason }
+      })
+      .filter((entry): entry is BundleLoadFailure => entry !== null)
+  } catch {
+    return []
+  }
 }

--- a/ui-v2/src/pages/ScenariosPage.tsx
+++ b/ui-v2/src/pages/ScenariosPage.tsx
@@ -5,12 +5,15 @@ import {
   deleteScenarioBundle,
   deleteScenarioFolder,
   downloadScenarioBundle,
+  listBundleFailures,
   listScenarioFolders,
   listScenarios,
   moveScenarioToFolder,
+  type BundleLoadFailure,
   type ScenarioSummary,
   uploadScenarioBundle,
 } from '../lib/scenariosApi'
+import { BundleFailuresBanner } from '../components/scenarios/BundleFailuresBanner'
 
 type FolderFilter = { kind: 'all' } | { kind: 'root' } | { kind: 'folder'; path: string }
 type ScenarioFolderNode = {
@@ -88,6 +91,7 @@ export function ScenariosPage() {
   const [error, setError] = useState<string | null>(null)
   const [folders, setFolders] = useState<string[]>([])
   const [items, setItems] = useState<ScenarioSummary[]>([])
+  const [failures, setFailures] = useState<BundleLoadFailure[]>([])
   const [filter, setFilter] = useState<FolderFilter>({ kind: 'all' })
   const [selectedId, setSelectedId] = useState<string | null>(null)
 
@@ -111,9 +115,14 @@ export function ScenariosPage() {
     setLoading(true)
     setError(null)
     try {
-      const [list, folderList] = await Promise.all([listScenarios({ includeDefunct: true }), listScenarioFolders()])
+      const [list, folderList, failureList] = await Promise.all([
+        listScenarios({ includeDefunct: true }),
+        listScenarioFolders(),
+        listBundleFailures(),
+      ])
       setItems(list)
       setFolders(folderList)
+      setFailures(failureList)
       setSelectedId((current) => {
         if (list.length === 0) return null
         if (current && list.some((entry) => entry.id === current)) return current
@@ -280,11 +289,14 @@ export function ScenariosPage() {
           type="button"
           className={active ? 'swarmCard swarmCardSelected' : 'swarmCard'}
           onClick={() => setSelectedId(entry.id)}
-          style={{ textAlign: 'left' }}
+          style={{ textAlign: 'left', opacity: entry.defunct ? 0.75 : 1 }}
         >
           <div className="row between">
             <div className="h2">{entry.name}</div>
-            <div className="pill pillInfo">{folderLabel(entry)}</div>
+            <div className="row" style={{ gap: 6 }}>
+              {entry.defunct && <div className="pill pillBad">DEFUNCT</div>}
+              <div className="pill pillInfo">{folderLabel(entry)}</div>
+            </div>
           </div>
           <div className="muted" style={{ marginTop: 6 }}>
             {entry.id}
@@ -350,6 +362,8 @@ export function ScenariosPage() {
           </div>
         </div>
       ) : null}
+
+      <BundleFailuresBanner failures={failures} />
 
       <div className="swarmViewGrid" style={{ marginTop: 12 }}>
         <div className="swarmViewCards">
@@ -445,6 +459,25 @@ export function ScenariosPage() {
                   <div className="v">{folderLabel(selected)}</div>
                 </div>
               </div>
+
+              {selected.defunct && (
+                <div
+                  className="card"
+                  style={{
+                    borderColor: 'rgba(255, 95, 95, 0.35)',
+                    background: 'rgba(255, 95, 95, 0.08)',
+                    marginTop: 12,
+                  }}
+                >
+                  <div className="row" style={{ gap: 8, marginBottom: 8 }}>
+                    <span className="pill pillBad">DEFUNCT</span>
+                    <span className="h2" style={{ fontSize: 13 }}>This bundle cannot be used to create a swarm</span>
+                  </div>
+                  <div className="muted">
+                    {selected.defunctReason ?? 'Reason unknown — check server logs or reload.'}
+                  </div>
+                </div>
+              )}
 
               <div className="formGrid" style={{ marginTop: 14 }}>
                 <label className="field">

--- a/ui-v2/src/pages/hive/CreateSwarmModal.tsx
+++ b/ui-v2/src/pages/hive/CreateSwarmModal.tsx
@@ -13,6 +13,8 @@ type ScenarioTemplate = {
   description: string | null
   controllerImage: string | null
   bees: BeeSummary[]
+  defunct: boolean
+  defunctReason: string | null
 }
 
 type VariablesProfile = {
@@ -92,7 +94,12 @@ function normalizeTemplates(data: unknown): ScenarioTemplate[] {
             })
             .filter((bee): bee is BeeSummary => bee !== null)
         : []
-      return { id, name, folderPath, description, controllerImage, bees }
+      const defunct = value.defunct === true
+      const defunctReason =
+        typeof value.defunctReason === 'string' && value.defunctReason.trim().length > 0
+          ? value.defunctReason.trim()
+          : null
+      return { id, name, folderPath, description, controllerImage, bees, defunct, defunctReason }
     })
     .filter((template): template is ScenarioTemplate => template !== null)
 }
@@ -401,14 +408,26 @@ export function CreateSwarmModal({
       key={template.id}
       type="button"
       className={template.id === templateId ? 'swarmTemplateItem swarmTemplateItemSelected' : 'swarmTemplateItem'}
-      onClick={() => setTemplateId(template.id)}
+      onClick={() => {
+        if (template.defunct) return
+        setTemplateId(template.id)
+      }}
       aria-label={template.name}
+      title={template.defunct ? (template.defunctReason ?? 'This template is unavailable') : undefined}
+      style={template.defunct ? { opacity: 0.45, cursor: 'not-allowed' } : undefined}
     >
-      <div className="swarmTemplateTitle">{template.name}</div>
+      <div className="row between">
+        <div className="swarmTemplateTitle">{template.name}</div>
+        {template.defunct && <span className="pill pillBad" style={{ fontSize: 10 }}>DEFUNCT</span>}
+      </div>
       <div className="swarmTemplateId">
         {template.folderPath ? `${template.folderPath}/${template.id}` : template.id}
       </div>
-      <div className="swarmTemplateDesc">{template.description ?? 'No description'}</div>
+      <div className="swarmTemplateDesc">
+        {template.defunct
+          ? (template.defunctReason ?? 'This template is unavailable')
+          : (template.description ?? 'No description')}
+      </div>
     </button>
   )
 
@@ -442,6 +461,12 @@ export function CreateSwarmModal({
 
       if (!trimmedSwarmId || !trimmedTemplateId) {
         setError('Swarm ID and template are required.')
+        return
+      }
+
+      const selectedTpl = templates.find((t) => t.id === trimmedTemplateId)
+      if (selectedTpl?.defunct) {
+        setError(`Template '${trimmedTemplateId}' is unavailable: ${selectedTpl.defunctReason ?? 'unknown reason'}`)
         return
       }
 
@@ -628,6 +653,11 @@ export function CreateSwarmModal({
                   <div className="muted">No templates found.</div>
                 ) : (
                   <>
+                    {templates.some((t) => t.defunct) && (
+                      <div className="muted" style={{ fontSize: 11, padding: '4px 0' }}>
+                        {templates.filter((t) => t.defunct).length} template(s) unavailable — hover for details
+                      </div>
+                    )}
                     {hasAnyFolder ? (
                       <div>
                         {tree.folders.map((folder) => renderFolderNode(folder))}

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -61,7 +61,8 @@ server {
   }
 
   location ^~ /prometheus/ {
-    proxy_pass http://prometheus:9090/prometheus/;
+    set $prometheus prometheus;
+    proxy_pass http://$prometheus:9090/prometheus/;
 
     proxy_http_version 1.1;
     proxy_set_header Host              $host;
@@ -76,7 +77,8 @@ server {
   }
 
   location /grafana {
-    proxy_pass http://grafana:3000/grafana;
+    set $grafana grafana;
+    proxy_pass http://$grafana:3000/grafana;
     proxy_set_header   Host $host;
   }
 
@@ -86,12 +88,14 @@ server {
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;
     proxy_set_header Host $host;
-    proxy_pass http://grafana:3000/grafana;
+    set $grafana grafana;
+    proxy_pass http://$grafana:3000/grafana;
   }
 
   # Proxy the management UI
   location ^~ /rabbitmq/ {
-    proxy_pass http://rabbitmq:15672$request_uri;
+    set $rabbitmq rabbitmq;
+    proxy_pass http://$rabbitmq:15672$request_uri;
 
     proxy_http_version 1.1;
     proxy_set_header Upgrade    $http_upgrade;
@@ -114,7 +118,8 @@ server {
 
   # Proxy Redis Commander UI
   location ^~ /redis/ {
-    proxy_pass http://redis-commander:8081/;
+    set $redis_commander redis-commander;
+    proxy_pass http://$redis_commander:8081/;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP         $remote_addr;

--- a/ui/nginx.conf
+++ b/ui/nginx.conf
@@ -61,8 +61,7 @@ server {
   }
 
   location ^~ /prometheus/ {
-    set $prometheus prometheus;
-    proxy_pass http://$prometheus:9090/prometheus/;
+    proxy_pass http://prometheus:9090/prometheus/;
 
     proxy_http_version 1.1;
     proxy_set_header Host              $host;
@@ -77,8 +76,7 @@ server {
   }
 
   location /grafana {
-    set $grafana grafana;
-    proxy_pass http://$grafana:3000/grafana;
+    proxy_pass http://grafana:3000/grafana;
     proxy_set_header   Host $host;
   }
 
@@ -88,14 +86,12 @@ server {
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;
     proxy_set_header Host $host;
-    set $grafana grafana;
-    proxy_pass http://$grafana:3000/grafana;
+    proxy_pass http://grafana:3000/grafana;
   }
 
   # Proxy the management UI
   location ^~ /rabbitmq/ {
-    set $rabbitmq rabbitmq;
-    proxy_pass http://$rabbitmq:15672$request_uri;
+    proxy_pass http://rabbitmq:15672$request_uri;
 
     proxy_http_version 1.1;
     proxy_set_header Upgrade    $http_upgrade;
@@ -118,8 +114,7 @@ server {
 
   # Proxy Redis Commander UI
   location ^~ /redis/ {
-    set $redis_commander redis-commander;
-    proxy_pass http://$redis_commander:8081/;
+    proxy_pass http://redis-commander:8081/;
     proxy_http_version 1.1;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP         $remote_addr;

--- a/ui/src/pages/hive/SwarmCreateModal.tsx
+++ b/ui/src/pages/hive/SwarmCreateModal.tsx
@@ -664,6 +664,7 @@ function normalizeTemplates(data: unknown): ScenarioTemplate[] {
 function normalizeTemplate(entry: unknown): ScenarioTemplate | null {
   if (!entry || typeof entry !== 'object') return null
   const value = entry as Record<string, unknown>
+  if (value.defunct === true) return null
   const id = typeof value.id === 'string' ? value.id : null
   const name = typeof value.name === 'string' ? value.name : null
   if (!id || !name) return null


### PR DESCRIPTION
### Summary

Scenario bundles that fail to load or cannot be used to create a swarm previously disappeared
silently with no explanation. This PR surfaces all failure reasons directly in the UI so
operators can diagnose and fix problems without needing access to server logs.

### Problem

Six distinct failure modes could cause a bundle to silently disappear from the scenario list
and Create Swarm modal:

1. Malformed YAML/JSON in the scenario file
2. Missing `id` field
3. No swarm template defined
4. A bee or controller has no image defined
5. Image tag has no matching capability manifest
6. Two bundles share the same scenario id

Previously, a single bad bundle could also abort the entire reload, hiding all other bundles.

### Changes

**Scenario Manager (backend)**
- Reload is now fault-isolated — a bad bundle is recorded as a load failure and skipped;
  other bundles continue loading
- `ScenarioSummary` gains `defunct` and `defunctReason` fields with plain-English reasons
- New `GET /scenarios/failures` endpoint returns bundles that could not be parsed at all
- `GET /api/templates` now includes defunct scenarios with reasons so the UI can show them
  as unavailable
- Human-readable reasons for all 6 failure categories

**UI v2 (frontend)**
- Scenarios page shows a collapsible warning banner listing all load failures with reasons
- Defunct bundles show a red `DEFUNCT` badge in the scenario list
- Selecting a defunct bundle shows the failure reason in the details panel
- Create Swarm modal shows defunct templates greyed out and non-selectable with the reason
  on hover
- Attempting to submit a defunct template is blocked with a clear error message

**UI v1 (one-line fix)**
- `SwarmCreateModal` filters defunct entries from the template list to preserve existing
  behaviour

**Tests**
- 8 new unit tests in `ScenarioServiceTest` covering all failure categories and reload
  isolation
- 5 new integration tests in `ScenarioControllerTest` covering the new endpoint and response
  fields
- 2 updated tests in `CapabilityCatalogueControllerTest` covering the updated templates
  endpoint

**Docs**
- `SCENARIO_MANAGER_BUNDLE_REST.md` updated with new endpoint and response shapes
- `scenario-manager-service/README.md` updated with bundle diagnostics guide

### Backwards compatibility

All API changes are additive. Existing consumers that do not read `defunct` or `defunctReason`
are unaffected. The `GET /api/templates` behaviour change (now includes defunct entries) is
handled by the ui-v1 fix and documented in the API contract.


## Checklist
- [ x] Tests added or updated
- [x ] Architecture and policy respected
- [x ] Documentation updated
- [x ] Conventional Commit message
