### PR TITLE
Fix MCP array schema items

### DIFF
--- a/tools/pockethive-mcp/package.json
+++ b/tools/pockethive-mcp/package.json
@@ -24,7 +24,7 @@
     "acceptance:wizard": "node wizard-acceptance.mjs",
     "start": "node server.mjs",
     "start:http": "cross-env PH_MCP_HTTP_PORT=3100 node server.mjs",
-    "test": "node --test config-update.test.mjs target-input.test.mjs"
+    "test": "node --test config-update.test.mjs target-input.test.mjs tools-list-schema.test.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.1",

--- a/tools/pockethive-mcp/server.mjs
+++ b/tools/pockethive-mcp/server.mjs
@@ -1427,7 +1427,7 @@ reg("wizard.start", "Start a novice bundle creation session. Collects intent and
   authSecretEnvVar: z.string().optional(),
   sutNftUrl: z.string().optional(),
   sutDouble: z.enum(WIZARD_SUT_DOUBLES).optional(),
-  mockEndpoints: z.array(z.any()).optional(),
+  mockEndpoints: z.array(z.unknown()).optional(),
   resultRules: z.union([z.boolean(), z.enum(["yes", "no"])]).optional(),
   resultCodePattern: z.string().optional(),
   successCodes: z.union([z.string(), z.array(z.string())]).optional(),

--- a/tools/pockethive-mcp/tools-list-schema.test.mjs
+++ b/tools/pockethive-mcp/tools-list-schema.test.mjs
@@ -1,0 +1,67 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { dirname, resolve } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SERVER = resolve(__dirname, "server.mjs");
+const UNUSED_BASE_URL = "http://127.0.0.1:9";
+const BUNDLES_ROOT = tmpdir();
+
+async function withClient(fn) {
+  const transport = new StdioClientTransport({
+    command: "node",
+    args: [SERVER],
+    env: {
+      ...process.env,
+      POCKETHIVE_BASE_URL: UNUSED_BASE_URL,
+      ORCHESTRATOR_BASE_URL: `${UNUSED_BASE_URL}/orchestrator`,
+      SCENARIO_MANAGER_BASE_URL: `${UNUSED_BASE_URL}/scenario-manager`,
+      RABBITMQ_MANAGEMENT_BASE_URL: `${UNUSED_BASE_URL}/rabbitmq/api`,
+      POCKETHIVE_AUTH_TOKEN: "",
+      POCKETHIVE_AUTH_USERNAME: "",
+      BUNDLES_ROOT,
+      PH_BUNDLES_ROOTS: JSON.stringify([BUNDLES_ROOT]),
+    },
+  });
+  const client = new Client({ name: "tools-list-schema-test", version: "1.0.0" }, { capabilities: {} });
+  await client.connect(transport);
+  try {
+    await fn(client);
+  } finally {
+    await client.close();
+  }
+}
+
+function findArraySchemasMissingItems(node, path = "inputSchema", found = []) {
+  if (!node || typeof node !== "object") return found;
+  if (node.type === "array" && !Object.prototype.hasOwnProperty.call(node, "items")) {
+    found.push(path);
+  }
+  for (const [key, value] of Object.entries(node)) {
+    findArraySchemasMissingItems(value, `${path}.${key}`, found);
+  }
+  return found;
+}
+
+test("tools/list never emits array schemas without items", async () => {
+  await withClient(async (client) => {
+    const { tools } = await client.listTools();
+    const missing = [];
+    for (const tool of tools) {
+      for (const path of findArraySchemasMissingItems(tool.inputSchema)) {
+        missing.push(`${tool.name}:${path}`);
+      }
+    }
+
+    assert.deepEqual(missing, []);
+
+    const wizardStart = tools.find((tool) => tool.name === "wizard.start");
+    assert.ok(wizardStart, "wizard.start tool must be listed");
+    assert.deepEqual(wizardStart.inputSchema.properties.mockEndpoints.items, {});
+  });
+});


### PR DESCRIPTION
Fixes #487.

I am an AI coding agent/operator. The issue body references the old `mcp-plugin` / `tools/mcp-server` path, but the current repo config points at `tools/pockethive-mcp/start.cjs`. On current `main`, the active `tools/pockethive-mcp` server still emitted one array schema without `items`:

- `wizard.start.inputSchema.properties.mockEndpoints` from `z.array(z.any()).optional()`

Some strict MCP clients reject array schemas that omit `items`, which matches the failure class reported in #487.

Changes:

- replace `z.array(z.any())` with `z.array(z.unknown())`, which keeps arbitrary endpoint objects accepted but emits `items: {}` in JSON Schema
- add a black-box MCP `tools/list` regression test that starts the server through stdio and fails if any listed tool contains an array schema without `items`
- include the new regression in `npm test`

Verification:

- `npm install --cache /tmp/pockethive-npm-cache`
- `npm test` — 8 tests passed
- manual stdio `tools/list` check — 63 tools listed, `missing: []`, `wizard.start.mockEndpoints` now `{ "type": "array", "items": {} }`
- `git diff --check`

I intentionally kept this narrow: it does not change whether `mockEndpoints` is optional and it does not constrain endpoint object shape beyond requiring the array schema to describe its items for strict MCP host validation.